### PR TITLE
chore: prepare v0.1.0 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,44 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  build:
+    name: Build distributions
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Build sdist and wheel
+        run: |
+          python -m pip install --upgrade pip build
+          python -m build
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish-pypi:
+    name: Publish to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish (trusted publishing)
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/README.md
+++ b/README.md
@@ -27,6 +27,37 @@ translations, find orphaned assets, run builds, and search Ren'Py's docs.
 - **Web dashboard** — Starlette + WebSocket UI with a live story map, activity
   log, autopilot coverage, lint view, and game-state controls.
 
+## Quick start
+
+Requires Python 3.11+. With [uv](https://docs.astral.sh/uv/) installed, no
+setup is needed:
+
+```bash
+# Start the web dashboard on your project
+uvx --from "renforge[ui]" renforge ui --project /path/to/your/game
+
+# Or add the MCP server to Claude Code
+claude mcp add renforge -- uvx --from "renforge[fastmcp]" renforge serve --project /path/to/your/game
+```
+
+For Claude Desktop (or any MCP client using JSON config):
+
+```json
+{
+  "mcpServers": {
+    "renforge": {
+      "command": "uvx",
+      "args": [
+        "--from", "renforge[fastmcp]", "renforge",
+        "serve", "--project", "/path/to/your/game"
+      ]
+    }
+  }
+}
+```
+
+Prefer pip? `pip install "renforge[fastmcp,ui]"` gives you the `renforge` CLI.
+
 ## Install (dev)
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,14 +5,29 @@ build-backend = "hatchling.build"
 [project]
 name = "renforge"
 version = "0.1.0"
-description = "RenForge MCP foundation for Ren'Py project workflows"
+description = "MCP server, CLI, and web dashboard for Ren'Py visual-novel development"
 readme = "README.md"
 requires-python = ">=3.11"
 license = { text = "MIT" }
 authors = [{ name = "RenForge contributors" }]
+keywords = ["renpy", "mcp", "model-context-protocol", "visual-novel", "game-dev"]
+classifiers = [
+  "Development Status :: 3 - Alpha",
+  "Intended Audience :: Developers",
+  "License :: OSI Approved :: MIT License",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Topic :: Games/Entertainment",
+  "Topic :: Software Development :: Libraries",
+]
 dependencies = [
   "mcp>=1.0.0"
 ]
+
+[project.urls]
+Homepage = "https://github.com/alex-jordan547/renforge-mcp"
+Repository = "https://github.com/alex-jordan547/renforge-mcp"
+Issues = "https://github.com/alex-jordan547/renforge-mcp/issues"
 
 [project.optional-dependencies]
 fastmcp = ["fastmcp>=2.0.0"]


### PR DESCRIPTION
## Summary
Prepares the first public release (v0.1.0):

- **pyproject**: PyPI-facing description, keywords, classifiers, and project URLs
- **README**: Quick start section — `uvx` one-liners, `claude mcp add` command, Claude Desktop JSON config
- **CI**: `release.yml` workflow that builds sdist+wheel and publishes to PyPI via trusted publishing on `v*` tags

## Verification
- `python -m build` succeeds; wheel embeds the dashboard SPA (`ui/static/index.html` + assets) and `bridge.rpy`
- Fresh-venv install: `renforge --version` OK, `renforge ui` serves the SPA (HTTP 200), `renforge serve` answers the MCP initialize handshake
- Test suite: 70 passed, 5 skipped