### PR TITLE
chore: bump version to 0.1.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "renforge"
-version = "0.1.0"
+version = "0.1.1"
 description = "MCP server, CLI, and web dashboard for Ren'Py visual-novel development"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
Patch release: ships the dashboard token fix (#3) to PyPI.

The published 0.1.0 never prints the session-token URL — if the browser
doesn't auto-open (headless, some WSL/SSH setups), `renforge ui` is unusable
("invalid token" with no recovery). 0.1.1 always prints the tokenized URL at
startup and maps wildcard bind hosts to loopback in that URL.