### PR TITLE
docs: add complete MCP reference

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,8 +32,10 @@ examples/demo_game/game/gui/**/*.png
 !examples/demo_game/game/gui/bubble.png
 !examples/demo_game/game/gui/thoughtbubble.png
 
-# Internal working docs (reviews, competitive analysis, plans) — keep private
-docs/
+# Internal working docs (reviews, competitive analysis, plans) — keep private.
+# The public MCP reference is versioned alongside the code.
+docs/*
+!docs/MCP.md
 
 # Ren'Py / RenForge runtime artifacts
 *.rpyc

--- a/README.md
+++ b/README.md
@@ -75,6 +75,11 @@ On managed systems (Debian/Ubuntu), plain `pip install` is blocked by
 
 ## Use with your AI agent
 
+The complete operational reference is available in
+[docs/MCP.md](docs/MCP.md). This README keeps the installation examples below;
+the guide documents the full tool catalogue, safety guards, visual interaction,
+and troubleshooting.
+
 The MCP server command is the same everywhere:
 
 ```bash

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -1,0 +1,220 @@
+# RenForge MCP
+
+RenForge est un serveur [Model Context Protocol](https://modelcontextprotocol.io/)
+pour les projets Ren'Py. Un agent peut lire le projet, lancer le jeu, observer
+un écran, cliquer un contrôle et vérifier l'état runtime, sans avoir à deviner
+la structure ou les coordonnées du jeu.
+
+## Installation
+
+Le serveur MCP utilise `stdio` et se lance avec :
+
+```bash
+uvx renforge serve
+```
+
+Avec une installation locale :
+
+```bash
+pipx install renforge
+renforge serve
+```
+
+Pour développer RenForge :
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -e ".[ui,test]"
+renforge serve
+```
+
+Le dashboard est un processus séparé :
+
+```bash
+renforge ui --project /chemin/vers/le-jeu
+```
+
+Quand le dashboard est actif, un `renforge_launch` demandé par un client MCP
+est délégué au dashboard. C'est particulièrement utile sous WSLg ou lorsqu'un
+client MCP n'a pas directement accès à l'affichage graphique.
+
+## Configuration d'un client
+
+La commande est la même dans tous les clients. Exemple de configuration JSON :
+
+```json
+{
+  "mcpServers": {
+    "renforge": {
+      "command": "uvx",
+      "args": ["renforge", "serve"]
+    }
+  }
+}
+```
+
+Pour Codex CLI :
+
+```bash
+codex mcp add renforge -- uvx renforge serve
+```
+
+Ou dans `~/.codex/config.toml` :
+
+```toml
+[mcp_servers.renforge]
+command = "uvx"
+args = ["renforge", "serve"]
+```
+
+Pour Claude Code :
+
+```bash
+claude mcp add renforge -- uvx renforge serve
+```
+
+Tous les outils liés au projet prennent `project_path`. Il est préférable
+d'appeler `renforge_info` au début : il donne `active_project`, c'est-à-dire le
+projet sélectionné dans le dashboard, plutôt que de laisser l'agent deviner un
+chemin.
+
+## Workflow recommandé
+
+```text
+renforge_info
+  -> active_project
+renforge_launch(project_path)
+  -> jeu et bridge disponibles
+renforge_game_state_compact(project_path)
+  -> label et état courant
+renforge_list_ui_elements(project_path)
+  -> contrôles visibles + frame_id
+renforge_click_element(..., expected_frame_id=frame_id)
+  -> interaction sûre
+```
+
+Pour une action par image :
+
+```text
+renforge_find_image_on_screen(project_path, template_path)
+  -> bounds, center, coordinate_space="screenshot", frame_id
+renforge_click_at(
+  project_path,
+  x=center.x,
+  y=center.y,
+  coordinate_space="screenshot",
+  expected_frame_id=frame_id,
+)
+```
+
+`frame_id` protège contre un clic sur un écran devenu obsolète. Si le jeu a
+changé entre l'observation et le clic, RenForge renvoie une erreur de garde et
+l'agent doit relire l'écran avant de réessayer.
+
+Les bornes de `renforge_list_ui_elements` sont en coordonnées Ren'Py logiques.
+Les bornes trouvées par `renforge_find_image_on_screen` sont en coordonnées du
+PNG capturé ; il faut donc reprendre son `coordinate_space: "screenshot"` pour
+`renforge_click_at`. RenForge convertit alors vers les coordonnées logiques,
+y compris lorsque WSLg redimensionne la capture.
+
+## Catalogue des outils
+
+### Découverte et analyse statique
+
+| Outil | Usage |
+| --- | --- |
+| `renforge_info` | Version, dashboard et projet actif. À appeler en premier. |
+| `renforge_context` | Dashboard actif et projet Ren'Py sélectionné. |
+| `renforge_inspect_project` | Résumé léger d'un projet Ren'Py. |
+| `renforge_scan_project` | Scan des scripts, labels, liens et métadonnées. Utiliser les filtres et la pagination pour les gros projets. |
+| `renforge_find_references` | Définitions et usages Ren'Py exacts, y compris interpolations texte. |
+| `renforge_parse_lint` | Parse une sortie `renpy lint`. |
+| `renforge_inspect_image` | Inspecte un fichier image, avec crop et zoom facultatifs. |
+
+### Cycle de vie du jeu
+
+| Outil | Usage |
+| --- | --- |
+| `renforge_launch` | Lance ou réutilise le jeu et injecte le bridge temporaire. `warp` accepte `fichier:ligne`. |
+| `renforge_jump` | Redémarre le jeu sur un label ou un `fichier:ligne` via le warp Ren'Py. |
+| `renforge_new_game` | Nouvelle partie depuis le label `start`. |
+| `renforge_stop` | Arrête le jeu et retire le bridge injecté. |
+| `renforge_game_state` | État complet, incluant les variables. |
+| `renforge_game_state_compact` | État borné ; sélectionner les variables par nom ou préfixe. |
+| `renforge_advance` | Avance le dialogue courant. |
+| `renforge_screenshot` | Capture le jeu ; largeur, hauteur, crop et échelle sont facultatifs. |
+
+### Choix et interface
+
+| Outil | Usage |
+| --- | --- |
+| `renforge_list_choices` | Choix narratifs visibles. |
+| `renforge_select_choice` | Choisit par texte, de préférence, ou index. |
+| `renforge_list_ui_elements` | Contrôles focusables visibles : ID, texte, rôle, écran, bornes, centre, état et `frame_id`. |
+| `renforge_click_element` | Clique un contrôle par ID ou texte. Accepte `exact`, `screen` et `expected_frame_id`. |
+| `renforge_click_at` | Clique des coordonnées `logical` ou `screenshot`, avec gardes `expected_frame_id` et `expected_state`. |
+| `renforge_find_image_on_screen` | Cherche un PNG local dans la capture courante et renvoie confiance, bornes, centre et garde de frame. |
+
+### État et exécution contrôlée
+
+| Outil | Usage |
+| --- | --- |
+| `renforge_eval` | Évalue une expression Python dans `store`. À réserver au diagnostic et au développement. |
+| `renforge_get_var` | Lit une variable du store. |
+| `renforge_set_var` | Écrit une variable du store. |
+| `renforge_poll_events` | Lit les événements de labels, dialogues et exceptions depuis un curseur. |
+| `renforge_autopilot` | Explore des branches et rapporte couverture des labels et crashs. |
+
+### Projet, traductions, builds et documentation Ren'Py
+
+| Outil | Usage |
+| --- | --- |
+| `renforge_assets` | Images et audios orphelins ou manquants. |
+| `renforge_languages` | Langues présentes sous `game/tl/`. |
+| `renforge_translation_stats` | Avancement et manques d'une langue. |
+| `renforge_generate_translations` | Génère ou met à jour `game/tl/<langue>/`. Écrit dans le projet. |
+| `renforge_export_dialogue` | Exporte les dialogues en texte. |
+| `renforge_web_build` | Build navigateur ; requiert le DLC web du SDK. |
+| `renforge_distribute` | Distribution desktop (`pc`, `mac`, `linux`, etc.). |
+| `renforge_search_docs` | Recherche dans la documentation Ren'Py hors ligne. |
+| `renforge_get_doc` | Lit une page de documentation Ren'Py. |
+| `renforge_list_docs` | Liste les pages de documentation disponibles. |
+
+## Écritures et précautions
+
+Ces outils modifient l'état du jeu ou le projet : `renforge_launch`,
+`renforge_jump`, `renforge_new_game`, `renforge_stop`, `renforge_click_*`,
+`renforge_set_var`, `renforge_generate_translations`, `renforge_web_build` et
+`renforge_distribute`.
+
+Pratiques recommandées :
+
+- préférer `renforge_game_state_compact` à l'état complet ;
+- borner `renforge_scan_project` avec `file_glob`, `symbol`, `offset` et
+  `limit` ;
+- utiliser une copie ou une branche pour les traductions et builds ;
+- lister l'UI avant de cliquer et toujours transmettre le `frame_id` ;
+- après une erreur de garde, refaire une capture ou une liste plutôt que
+  rejouer le même clic.
+
+## Dépannage
+
+| Symptôme | Cause probable et correction |
+| --- | --- |
+| `no running game` | Appeler `renforge_launch` ou démarrer le dashboard avec `renforge ui`. |
+| Aucun `active_project` | Sélectionner le projet dans le dashboard ou fournir explicitement `project_path`. |
+| Échec `expected_frame_id guard failed` | L'écran a changé ; relancer `renforge_list_ui_elements` ou `renforge_find_image_on_screen`. |
+| Clic au mauvais endroit sous WSLg | Réutiliser `coordinate_space` renvoyé par la recherche visuelle. |
+| Pas d'affichage depuis le client MCP | Démarrer `renforge ui --project …` : le lancement sera délégué au processus qui possède l'affichage. |
+| Outil MCP absent | Mettre à jour RenForge puis redémarrer la session MCP afin de recharger le catalogue. |
+
+## Vérification rapide
+
+Après la configuration, demander à l'agent :
+
+> Appelle `renforge_info`, inspecte mon projet Ren'Py, puis liste les contrôles
+> visibles du jeu.
+
+Une réponse correcte indique le projet actif, le résumé du projet et les
+contrôles accompagnés de leurs bornes et d'un `frame_id`.

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -1,26 +1,26 @@
 # RenForge MCP
 
-RenForge est un serveur [Model Context Protocol](https://modelcontextprotocol.io/)
-pour les projets Ren'Py. Un agent peut lire le projet, lancer le jeu, observer
-un écran, cliquer un contrôle et vérifier l'état runtime, sans avoir à deviner
-la structure ou les coordonnées du jeu.
+RenForge is a [Model Context Protocol](https://modelcontextprotocol.io/) server
+for Ren'Py projects. An agent can inspect a project, start a game, observe a
+frame, click a control, and verify runtime state without guessing the project's
+structure or screen coordinates.
 
 ## Installation
 
-Le serveur MCP utilise `stdio` et se lance avec :
+The MCP server uses `stdio` and starts with:
 
 ```bash
 uvx renforge serve
 ```
 
-Avec une installation locale :
+With a local installation:
 
 ```bash
 pipx install renforge
 renforge serve
 ```
 
-Pour développer RenForge :
+To develop RenForge:
 
 ```bash
 python -m venv .venv
@@ -29,19 +29,19 @@ pip install -e ".[ui,test]"
 renforge serve
 ```
 
-Le dashboard est un processus séparé :
+The dashboard is a separate process:
 
 ```bash
-renforge ui --project /chemin/vers/le-jeu
+renforge ui --project /path/to/game
 ```
 
-Quand le dashboard est actif, un `renforge_launch` demandé par un client MCP
-est délégué au dashboard. C'est particulièrement utile sous WSLg ou lorsqu'un
-client MCP n'a pas directement accès à l'affichage graphique.
+When the dashboard is running, an `renforge_launch` request from an MCP client
+is delegated to it. This is particularly useful with WSLg or when the MCP
+client does not have direct access to a graphical display.
 
-## Configuration d'un client
+## Client configuration
 
-La commande est la même dans tous les clients. Exemple de configuration JSON :
+The command is the same for every client. Example JSON configuration:
 
 ```json
 {
@@ -54,13 +54,13 @@ La commande est la même dans tous les clients. Exemple de configuration JSON :
 }
 ```
 
-Pour Codex CLI :
+For Codex CLI:
 
 ```bash
 codex mcp add renforge -- uvx renforge serve
 ```
 
-Ou dans `~/.codex/config.toml` :
+Or add this to `~/.codex/config.toml`:
 
 ```toml
 [mcp_servers.renforge]
@@ -68,33 +68,32 @@ command = "uvx"
 args = ["renforge", "serve"]
 ```
 
-Pour Claude Code :
+For Claude Code:
 
 ```bash
 claude mcp add renforge -- uvx renforge serve
 ```
 
-Tous les outils liés au projet prennent `project_path`. Il est préférable
-d'appeler `renforge_info` au début : il donne `active_project`, c'est-à-dire le
-projet sélectionné dans le dashboard, plutôt que de laisser l'agent deviner un
-chemin.
+Every project-related tool takes `project_path`. Call `renforge_info` first
+when possible: it returns `active_project`, the project selected in the
+dashboard, so an agent does not have to guess a path.
 
-## Workflow recommandé
+## Recommended workflow
 
 ```text
 renforge_info
   -> active_project
 renforge_launch(project_path)
-  -> jeu et bridge disponibles
+  -> game and bridge are available
 renforge_game_state_compact(project_path)
-  -> label et état courant
+  -> current label and bounded state
 renforge_list_ui_elements(project_path)
-  -> contrôles visibles + frame_id
+  -> visible controls and frame_id
 renforge_click_element(..., expected_frame_id=frame_id)
-  -> interaction sûre
+  -> safe interaction
 ```
 
-Pour une action par image :
+For image-driven interaction:
 
 ```text
 renforge_find_image_on_screen(project_path, template_path)
@@ -108,113 +107,112 @@ renforge_click_at(
 )
 ```
 
-`frame_id` protège contre un clic sur un écran devenu obsolète. Si le jeu a
-changé entre l'observation et le clic, RenForge renvoie une erreur de garde et
-l'agent doit relire l'écran avant de réessayer.
+`frame_id` protects against clicking a stale frame. If the game changes between
+observation and click, RenForge returns a guard error and the agent must inspect
+the current frame before trying again.
 
-Les bornes de `renforge_list_ui_elements` sont en coordonnées Ren'Py logiques.
-Les bornes trouvées par `renforge_find_image_on_screen` sont en coordonnées du
-PNG capturé ; il faut donc reprendre son `coordinate_space: "screenshot"` pour
-`renforge_click_at`. RenForge convertit alors vers les coordonnées logiques,
-y compris lorsque WSLg redimensionne la capture.
+`renforge_list_ui_elements` returns Ren'Py logical coordinates. Bounds returned
+by `renforge_find_image_on_screen` use the captured PNG's coordinates, so pass
+its `coordinate_space: "screenshot"` to `renforge_click_at`. RenForge converts
+them to logical coordinates, including when WSLg scales the capture.
 
-## Catalogue des outils
+## Tool catalogue
 
-### Découverte et analyse statique
+### Discovery and static analysis
 
-| Outil | Usage |
+| Tool | Purpose |
 | --- | --- |
-| `renforge_info` | Version, dashboard et projet actif. À appeler en premier. |
-| `renforge_context` | Dashboard actif et projet Ren'Py sélectionné. |
-| `renforge_inspect_project` | Résumé léger d'un projet Ren'Py. |
-| `renforge_scan_project` | Scan des scripts, labels, liens et métadonnées. Utiliser les filtres et la pagination pour les gros projets. |
-| `renforge_find_references` | Définitions et usages Ren'Py exacts, y compris interpolations texte. |
-| `renforge_parse_lint` | Parse une sortie `renpy lint`. |
-| `renforge_inspect_image` | Inspecte un fichier image, avec crop et zoom facultatifs. |
+| `renforge_info` | Version, dashboard status, and active project. Call this first. |
+| `renforge_context` | Active dashboard and selected Ren'Py project. |
+| `renforge_inspect_project` | Lightweight Ren'Py project summary. |
+| `renforge_scan_project` | Scan scripts, labels, links, and metadata. Use filters and pagination for large projects. |
+| `renforge_find_references` | Exact Ren'Py definitions and usages, including text interpolations. |
+| `renforge_parse_lint` | Parse `renpy lint` output. |
+| `renforge_inspect_image` | Inspect a local image, with optional crop and zoom. |
 
-### Cycle de vie du jeu
+### Game lifecycle
 
-| Outil | Usage |
+| Tool | Purpose |
 | --- | --- |
-| `renforge_launch` | Lance ou réutilise le jeu et injecte le bridge temporaire. `warp` accepte `fichier:ligne`. |
-| `renforge_jump` | Redémarre le jeu sur un label ou un `fichier:ligne` via le warp Ren'Py. |
-| `renforge_new_game` | Nouvelle partie depuis le label `start`. |
-| `renforge_stop` | Arrête le jeu et retire le bridge injecté. |
-| `renforge_game_state` | État complet, incluant les variables. |
-| `renforge_game_state_compact` | État borné ; sélectionner les variables par nom ou préfixe. |
-| `renforge_advance` | Avance le dialogue courant. |
-| `renforge_screenshot` | Capture le jeu ; largeur, hauteur, crop et échelle sont facultatifs. |
+| `renforge_launch` | Start or reuse a game and inject the temporary bridge. `warp` accepts `file:line`. |
+| `renforge_jump` | Restart a game at a label or `file:line` using Ren'Py warp. |
+| `renforge_new_game` | Start a fresh process at the `start` label. |
+| `renforge_stop` | Stop the running game and remove the injected bridge. |
+| `renforge_game_state` | Complete state, including variables. |
+| `renforge_game_state_compact` | Bounded state; select variables by name or prefix. |
+| `renforge_advance` | Advance the current dialogue. |
+| `renforge_screenshot` | Capture a frame; width, height, crop, and scale are optional. |
 
-### Choix et interface
+### Choices and user interface
 
-| Outil | Usage |
+| Tool | Purpose |
 | --- | --- |
-| `renforge_list_choices` | Choix narratifs visibles. |
-| `renforge_select_choice` | Choisit par texte, de préférence, ou index. |
-| `renforge_list_ui_elements` | Contrôles focusables visibles : ID, texte, rôle, écran, bornes, centre, état et `frame_id`. |
-| `renforge_click_element` | Clique un contrôle par ID ou texte. Accepte `exact`, `screen` et `expected_frame_id`. |
-| `renforge_click_at` | Clique des coordonnées `logical` ou `screenshot`, avec gardes `expected_frame_id` et `expected_state`. |
-| `renforge_find_image_on_screen` | Cherche un PNG local dans la capture courante et renvoie confiance, bornes, centre et garde de frame. |
+| `renforge_list_choices` | Visible narrative choices. |
+| `renforge_select_choice` | Select a choice by text, preferably, or index. |
+| `renforge_list_ui_elements` | Visible focusable controls: ID, text, role, screen, bounds, center, state, and `frame_id`. |
+| `renforge_click_element` | Click a control by ID or text. Supports `exact`, `screen`, and `expected_frame_id`. |
+| `renforge_click_at` | Click `logical` or `screenshot` coordinates, with `expected_frame_id` and `expected_state` guards. |
+| `renforge_find_image_on_screen` | Locate a local PNG template in the current frame and return confidence, bounds, center, and frame guard. |
 
-### État et exécution contrôlée
+### State and controlled execution
 
-| Outil | Usage |
+| Tool | Purpose |
 | --- | --- |
-| `renforge_eval` | Évalue une expression Python dans `store`. À réserver au diagnostic et au développement. |
-| `renforge_get_var` | Lit une variable du store. |
-| `renforge_set_var` | Écrit une variable du store. |
-| `renforge_poll_events` | Lit les événements de labels, dialogues et exceptions depuis un curseur. |
-| `renforge_autopilot` | Explore des branches et rapporte couverture des labels et crashs. |
+| `renforge_eval` | Evaluate a Python expression in `store`. Use for diagnosis and development only. |
+| `renforge_get_var` | Read a store variable. |
+| `renforge_set_var` | Write a store variable. |
+| `renforge_poll_events` | Read label, dialogue, and exception events from a cursor. |
+| `renforge_autopilot` | Explore branches and report label coverage and crashes. |
 
-### Projet, traductions, builds et documentation Ren'Py
+### Project, translation, builds, and Ren'Py documentation
 
-| Outil | Usage |
+| Tool | Purpose |
 | --- | --- |
-| `renforge_assets` | Images et audios orphelins ou manquants. |
-| `renforge_languages` | Langues présentes sous `game/tl/`. |
-| `renforge_translation_stats` | Avancement et manques d'une langue. |
-| `renforge_generate_translations` | Génère ou met à jour `game/tl/<langue>/`. Écrit dans le projet. |
-| `renforge_export_dialogue` | Exporte les dialogues en texte. |
-| `renforge_web_build` | Build navigateur ; requiert le DLC web du SDK. |
-| `renforge_distribute` | Distribution desktop (`pc`, `mac`, `linux`, etc.). |
-| `renforge_search_docs` | Recherche dans la documentation Ren'Py hors ligne. |
-| `renforge_get_doc` | Lit une page de documentation Ren'Py. |
-| `renforge_list_docs` | Liste les pages de documentation disponibles. |
+| `renforge_assets` | Find orphaned or missing image and audio assets. |
+| `renforge_languages` | List languages under `game/tl/`. |
+| `renforge_translation_stats` | Report translation progress and missing strings for one language. |
+| `renforge_generate_translations` | Generate or update `game/tl/<language>/`. Writes to the project. |
+| `renforge_export_dialogue` | Export dialogue as plain text. |
+| `renforge_web_build` | Create a browser build; requires the SDK web DLC. |
+| `renforge_distribute` | Build desktop distributions (`pc`, `mac`, `linux`, and more). |
+| `renforge_search_docs` | Search the offline Ren'Py documentation. |
+| `renforge_get_doc` | Read an offline Ren'Py documentation page. |
+| `renforge_list_docs` | List available offline documentation pages. |
 
-## Écritures et précautions
+## Writes and safety
 
-Ces outils modifient l'état du jeu ou le projet : `renforge_launch`,
-`renforge_jump`, `renforge_new_game`, `renforge_stop`, `renforge_click_*`,
-`renforge_set_var`, `renforge_generate_translations`, `renforge_web_build` et
+These tools change game or project state: `renforge_launch`, `renforge_jump`,
+`renforge_new_game`, `renforge_stop`, `renforge_click_*`, `renforge_set_var`,
+`renforge_generate_translations`, `renforge_web_build`, and
 `renforge_distribute`.
 
-Pratiques recommandées :
+Recommended practices:
 
-- préférer `renforge_game_state_compact` à l'état complet ;
-- borner `renforge_scan_project` avec `file_glob`, `symbol`, `offset` et
-  `limit` ;
-- utiliser une copie ou une branche pour les traductions et builds ;
-- lister l'UI avant de cliquer et toujours transmettre le `frame_id` ;
-- après une erreur de garde, refaire une capture ou une liste plutôt que
-  rejouer le même clic.
+- prefer `renforge_game_state_compact` to the full state;
+- bound `renforge_scan_project` with `file_glob`, `symbol`, `offset`, and
+  `limit`;
+- use a copy or branch before generating translations or distributions;
+- list the UI before clicking and always pass `frame_id`;
+- after a guard error, capture or list the current screen instead of replaying
+  the same click.
 
-## Dépannage
+## Troubleshooting
 
-| Symptôme | Cause probable et correction |
+| Symptom | Likely cause and resolution |
 | --- | --- |
-| `no running game` | Appeler `renforge_launch` ou démarrer le dashboard avec `renforge ui`. |
-| Aucun `active_project` | Sélectionner le projet dans le dashboard ou fournir explicitement `project_path`. |
-| Échec `expected_frame_id guard failed` | L'écran a changé ; relancer `renforge_list_ui_elements` ou `renforge_find_image_on_screen`. |
-| Clic au mauvais endroit sous WSLg | Réutiliser `coordinate_space` renvoyé par la recherche visuelle. |
-| Pas d'affichage depuis le client MCP | Démarrer `renforge ui --project …` : le lancement sera délégué au processus qui possède l'affichage. |
-| Outil MCP absent | Mettre à jour RenForge puis redémarrer la session MCP afin de recharger le catalogue. |
+| `no running game` | Call `renforge_launch` or start the dashboard with `renforge ui`. |
+| No `active_project` | Select a project in the dashboard or provide `project_path` explicitly. |
+| `expected_frame_id guard failed` | The screen changed; call `renforge_list_ui_elements` or `renforge_find_image_on_screen` again. |
+| A click lands at the wrong place under WSLg | Reuse the `coordinate_space` returned by visual search. |
+| The MCP client cannot open a display | Start `renforge ui --project …`; launch requests are delegated to the display-owning process. |
+| An MCP tool is missing | Update RenForge, then restart the MCP session to reload its catalogue. |
 
-## Vérification rapide
+## Quick verification
 
-Après la configuration, demander à l'agent :
+After configuration, ask the agent:
 
-> Appelle `renforge_info`, inspecte mon projet Ren'Py, puis liste les contrôles
-> visibles du jeu.
+> Call `renforge_info`, inspect my Ren'Py project, then list the visible game
+> controls.
 
-Une réponse correcte indique le projet actif, le résumé du projet et les
-contrôles accompagnés de leurs bornes et d'un `frame_id`.
+A successful response contains the active project, a project summary, and
+controls with bounds and a `frame_id`.


### PR DESCRIPTION
## Summary

- replace the ignored planning notes with a public, versioned MCP reference
- document installation, client configuration, all 36 tools, guarded visual interaction, safety, and troubleshooting
- link the guide from the README

## Verification

- `git diff --check`
- catalog check against `create_app().list_tools()` (`documented_tools=36`)