### PR TITLE
ci(release): auto-create GitHub Release from CHANGELOG on tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,8 @@ jobs:
         run: |
           version="${GITHUB_REF_NAME#v}"
           awk -v ver="$version" '
-            $0 ~ "^## \\[" ver "\\]" { found = 1; next }
+            BEGIN { escaped = ver; gsub(/\./, "\\.", escaped) }
+            $0 ~ "^## \\[" escaped "\\]" { found = 1; next }
             found && /^## \[/ { exit }
             found { print }
           ' CHANGELOG.md > release-notes.md
@@ -71,8 +72,9 @@ jobs:
       - name: Create release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GENERATED: ${{ steps.notes.outputs.generated }}
         run: |
-          if [ "${{ steps.notes.outputs.generated }}" = "true" ]; then
+          if [ "$GENERATED" = "true" ]; then
             gh release create "$GITHUB_REF_NAME" --title "$GITHUB_REF_NAME" --generate-notes
           else
             gh release create "$GITHUB_REF_NAME" --title "$GITHUB_REF_NAME" --notes-file release-notes.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,3 +42,38 @@ jobs:
 
       - name: Publish (trusted publishing)
         uses: pypa/gh-action-pypi-publish@release/v1
+
+  github-release:
+    name: Create GitHub Release
+    needs: publish-pypi
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Extract release notes from CHANGELOG
+        id: notes
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          awk -v ver="$version" '
+            $0 ~ "^## \\[" ver "\\]" { found = 1; next }
+            found && /^## \[/ { exit }
+            found { print }
+          ' CHANGELOG.md > release-notes.md
+          if [ -s release-notes.md ]; then
+            echo "generated=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "No CHANGELOG entry for $version; falling back to generated notes."
+            echo "generated=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ "${{ steps.notes.outputs.generated }}" = "true" ]; then
+            gh release create "$GITHUB_REF_NAME" --title "$GITHUB_REF_NAME" --generate-notes
+          else
+            gh release create "$GITHUB_REF_NAME" --title "$GITHUB_REF_NAME" --notes-file release-notes.md
+          fi


### PR DESCRIPTION
## Summary

The release workflow only published to PyPI on `v*` tags — GitHub Releases were created by hand and drifted (v0.2.0 and v0.3.0 shipped to PyPI without a Release).

This adds a `github-release` job that runs after a successful PyPI publish:
- extracts the tagged version's section from `CHANGELOG.md` (`## [X.Y.Z]` up to the next entry)
- creates the GitHub Release with those notes
- falls back to GitHub's generated notes when the version has no CHANGELOG entry

## Notes

- `awk` extraction verified locally against the current CHANGELOG for 0.4.0, 0.3.0, and a non-existent version (empty → fallback path).
- No `--latest` flag: GitHub marks the highest semver as latest automatically, which is correct for forward releases.
- Takes effect on the next `v*` tag (this release cycle's v0.4.0 Release already exists).