### PR TITLE
fix(mcp): project discovery fallback and single-dimension screenshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,23 @@
 All notable RenForge releases are recorded here. Versions follow semantic
 versioning; the 0.4.0 additions are backwards-compatible with 0.3.0.
 
+## [Unreleased]
+
+### Added
+
+- `renforge_info`/`renforge_context` now resolve `active_project` without the
+  dashboard: they fall back to the `serve --project` default, then to a Ren'Py
+  project auto-detected from the current directory, and report the winning
+  source in a new `project_source` field. When nothing matches, the payload
+  carries an explicit `hint` so agents pass `project_path` directly instead of
+  stalling.
+
+### Changed
+
+- `renforge_screenshot` accepts a single `width` or `height` and derives the
+  other dimension from the game's aspect ratio (previously both were required
+  together).
+
 ## [0.4.0] - 2026-07-12
 
 ### Added

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -82,8 +82,12 @@ claude mcp add renforge -- uvx renforge@latest serve
 ```
 
 Every project-related tool takes `project_path`. Call `renforge_info` first
-when possible: it returns `active_project`, the project selected in the
-dashboard, so an agent does not have to guess a path.
+when possible: it returns `active_project` with a `project_source` explaining
+how it was resolved — the dashboard selection, the `serve --project` default,
+or a Ren'Py project auto-detected from the current directory. A null
+`active_project` only means auto-discovery found nothing: every tool still
+accepts `project_path` directly (no dashboard required), so ask the user for
+the game's path and continue.
 
 ## Recommended workflow
 
@@ -231,7 +235,7 @@ Notes:
 | `renforge_control` | Run one action: `advance`, `rollback`, `toggle_skip`, `toggle_auto`, `toggle_afm`, `game_menu`, `hide_windows`, `quick_save`, `quick_load`, `reload_script`, `restart_interaction`, or `quit`. |
 | `renforge_send_input` | Send exactly one `text`, named `key`, or logical-coordinate `scroll` operation. Text posts character-by-character events to a focused Ren'Py `Input`; `submit=true` presses Enter. Supported keys include `enter`, `esc`, arrows, `pageup`, `pagedown`, `backspace`, `delete`, `home`, `end`, `space`, `tab`, and `f1`-`f12`. Scroll uses `{"x": ..., "y": ..., "direction": "up"|"down", "amount": 1}`. |
 | `renforge_saves` | Run `save`, `load`, or `list` for named slots. Save/load require `slot`; save accepts optional `extra_info`; list accepts optional `regexp` and returns `name`, `extra_info`, and `mtime` without screenshots. |
-| `renforge_screenshot` | Capture a frame; width, height, crop, scale, and `grid`/`rulers`/`crosshair` overlays are optional. |
+| `renforge_screenshot` | Capture a frame; width, height, crop, scale, and `grid`/`rulers`/`crosshair` overlays are optional. Passing only one of `width`/`height` keeps the game's aspect ratio. |
 
 ### Choices and user interface
 
@@ -319,7 +323,7 @@ Recommended practices:
 | Symptom | Likely cause and resolution |
 | --- | --- |
 | `no running game` | Call `renforge_launch` or start the dashboard with `renforge ui`. |
-| No `active_project` | Select a project in the dashboard or provide `project_path` explicitly. |
+| No `active_project` | Provide `project_path` explicitly (every tool accepts it), run the server from the game's directory, or select a project in the dashboard. |
 | `expected_frame_id guard failed` | The screen changed; call `renforge_list_ui_elements` or `renforge_find_image_on_screen` again. |
 | A click lands at the wrong place under WSLg | Reuse the `coordinate_space` returned by visual search. |
 | The MCP client cannot open a display | Start `renforge ui --project …`; launch requests are delegated to the display-owning process. |

--- a/src/renforge/bridge/bridge.rpy
+++ b/src/renforge/bridge/bridge.rpy
@@ -397,6 +397,7 @@ init python:
         width = int(payload.get("width", 0) or 0)
         height = int(payload.get("height", 0) or 0)
         # A single dimension keeps the game's aspect ratio.
+        note = None
         logical_width = getattr(renpy.config, "screen_width", None)
         logical_height = getattr(renpy.config, "screen_height", None)
         if logical_width and logical_height:
@@ -404,9 +405,14 @@ init python:
                 height = max(1, int(round(width * logical_height / float(logical_width))))
             elif height and not width:
                 width = max(1, int(round(height * logical_width / float(logical_height))))
+        elif (width and not height) or (height and not width):
+            # Never silently ignore the requested size: without the logical
+            # ratio the frame comes back at native resolution, so say so.
+            width = height = 0
+            note = "aspect ratio unavailable; captured at native resolution"
         size = (width, height) if (width and height) else None
         data = renpy.screenshot_to_bytes(size)  # PNG bytes
-        return {
+        reply = {
             "format": "png",
             "base64": base64.b64encode(data).decode("ascii"),
             # The digest lets an external client use the exact frame it
@@ -414,6 +420,9 @@ init python:
             # data in the bridge process.
             "sha256": hashlib.sha256(data).hexdigest(),
         }
+        if note:
+            reply["note"] = note
+        return reply
 
     def _renforge_h_advance(payload):
         # Post a "dismiss" event (the keymap action that advances dialogue).

--- a/src/renforge/bridge/bridge.rpy
+++ b/src/renforge/bridge/bridge.rpy
@@ -396,6 +396,14 @@ init python:
         payload = payload or {}
         width = int(payload.get("width", 0) or 0)
         height = int(payload.get("height", 0) or 0)
+        # A single dimension keeps the game's aspect ratio.
+        logical_width = getattr(renpy.config, "screen_width", None)
+        logical_height = getattr(renpy.config, "screen_height", None)
+        if logical_width and logical_height:
+            if width and not height:
+                height = max(1, int(round(width * logical_height / float(logical_width))))
+            elif height and not width:
+                width = max(1, int(round(height * logical_width / float(logical_height))))
         size = (width, height) if (width and height) else None
         data = renpy.screenshot_to_bytes(size)  # PNG bytes
         return {

--- a/src/renforge/project.py
+++ b/src/renforge/project.py
@@ -13,17 +13,41 @@ RENFORGE_CACHE_DIR: Final = ".renforge"
 # A real project's game/ dir holds scripts or archives; requiring one avoids
 # misdetecting an unrelated directory that merely contains a "game" folder.
 _PROJECT_CONTENT_GLOBS: Final = ("*.rpy", "*.rpyc", "*.rpa")
+_PROJECT_CONTENT_SUFFIXES: Final = (".rpy", ".rpyc", ".rpa")
+
+
+def _has_renpy_content(game_dir: Path) -> bool:
+    # Fast path: virtually every project keeps a script or archive at the top
+    # level of game/. Fall back to one recursive walk for projects that nest
+    # everything in subfolders (e.g. game/chapters/script.rpy).
+    for pattern in _PROJECT_CONTENT_GLOBS:
+        if next(game_dir.glob(pattern), None) is not None:
+            return True
+    return (
+        next(
+            (p for p in game_dir.rglob("*") if p.suffix in _PROJECT_CONTENT_SUFFIXES),
+            None,
+        )
+        is not None
+    )
 
 
 def discover_project_from(start: Path | None = None) -> Path | None:
     """Walk up from *start* (default: cwd) to the nearest Ren'Py project root."""
-    current = (start or Path.cwd()).resolve()
+    # This runs inside the first tool an agent calls (renforge_info), so a
+    # deleted cwd or an unreadable directory must degrade to "not found"
+    # rather than crash the call.
+    try:
+        current = (start or Path.cwd()).resolve()
+    except OSError:
+        return None
     for candidate in (current, *current.parents):
         game_dir = candidate / RENPY_GAME_DIR
-        if game_dir.is_dir() and any(
-            next(game_dir.glob(pattern), None) for pattern in _PROJECT_CONTENT_GLOBS
-        ):
-            return candidate
+        try:
+            if game_dir.is_dir() and _has_renpy_content(game_dir):
+                return candidate
+        except OSError:
+            continue
     return None
 
 

--- a/src/renforge/project.py
+++ b/src/renforge/project.py
@@ -10,6 +10,22 @@ from .sdk import RenpySdk
 RENPY_GAME_DIR: Final = "game"
 RENFORGE_CACHE_DIR: Final = ".renforge"
 
+# A real project's game/ dir holds scripts or archives; requiring one avoids
+# misdetecting an unrelated directory that merely contains a "game" folder.
+_PROJECT_CONTENT_GLOBS: Final = ("*.rpy", "*.rpyc", "*.rpa")
+
+
+def discover_project_from(start: Path | None = None) -> Path | None:
+    """Walk up from *start* (default: cwd) to the nearest Ren'Py project root."""
+    current = (start or Path.cwd()).resolve()
+    for candidate in (current, *current.parents):
+        game_dir = candidate / RENPY_GAME_DIR
+        if game_dir.is_dir() and any(
+            next(game_dir.glob(pattern), None) for pattern in _PROJECT_CONTENT_GLOBS
+        ):
+            return candidate
+    return None
+
 
 @dataclass(frozen=True)
 class RenpyProject:

--- a/src/renforge/server.py
+++ b/src/renforge/server.py
@@ -11,6 +11,7 @@ from time import perf_counter
 from typing import Any, Callable, Optional
 
 from . import __version__, session_registry
+from .project import discover_project_from
 
 
 @dataclass
@@ -113,23 +114,45 @@ def _register_tools(app: Any) -> None:
         dashboard = session_registry.active_dashboard()
         default_project = getattr(app, "project_root", None)
         active_project = dashboard.get("project") if dashboard else None
+        project_source = "dashboard" if active_project else None
         if active_project is None and default_project is not None:
             active_project = str(Path(default_project).expanduser().resolve())
-        return {
+            project_source = "serve_default"
+        if active_project is None:
+            detected = discover_project_from()
+            if detected is not None:
+                active_project = str(detected)
+                project_source = "cwd"
+        payload: dict[str, Any] = {
             "ok": True,
             "version": __version__,
             "active_project": active_project,
+            "project_source": project_source,
             "dashboard": dashboard,
         }
+        if active_project is None:
+            payload["hint"] = (
+                "No dashboard, serve default, or Ren'Py project near the "
+                "current directory. Every tool accepts project_path directly: "
+                "ask the user for the game's path."
+            )
+        return payload
 
     @tool_decorator()
     def renforge_info() -> dict:
-        """Call first: report RenForge version and the project selected in the dashboard."""
+        """Call first: report RenForge version and the active project.
+
+        active_project falls back from the dashboard selection to the serve
+        default, then to a Ren'Py project detected from the current directory
+        (project_source says which one matched). A null active_project only
+        means auto-discovery found nothing — every tool accepts project_path
+        directly, so ask the user for the game's path and keep going.
+        """
         return _context_payload()
 
     @tool_decorator()
     def renforge_context() -> dict:
-        """Discover the active dashboard and its currently selected Ren'Py project."""
+        """Discover the active Ren'Py project (dashboard, serve default, or cwd)."""
         return _context_payload()
 
     @tool_decorator()
@@ -959,12 +982,11 @@ def _register_tools(app: Any) -> None:
         every N pixels, ``rulers`` labels those steps along the edges, and
         ``crosshair_x``/``crosshair_y`` mark a point. Capture at the game's
         logical resolution (``width``/``height``) so the labels read as logical
-        coordinates.
+        coordinates. Passing only one of ``width``/``height`` keeps the game's
+        aspect ratio.
         """
         def _tool() -> Any:
             try:
-                if (width == 0) != (height == 0):
-                    raise ValueError("width and height must be provided together")
                 if (crosshair_x < 0) != (crosshair_y < 0):
                     raise ValueError("crosshair_x and crosshair_y must be provided together")
                 if width or height:
@@ -1091,10 +1113,12 @@ def create_app() -> Any:
         return _FallbackServer()
 
     instructions = (
-        "Call renforge_info first. It reports the project selected in the RenForge "
-        "dashboard; use active_project for project_path instead of guessing. "
-        "When that dashboard is active, renforge_launch delegates display-bound startup "
-        "to its process automatically. Prefer bounded scan queries and "
+        "Call renforge_info first: its active_project (see project_source — "
+        "dashboard, serve_default, or cwd) is the project_path to pass to the "
+        "other tools. If active_project is null, ask the user for the game's "
+        "path; every tool accepts project_path directly and no dashboard is "
+        "required. When the dashboard is active, renforge_launch delegates "
+        "display-bound startup to its process automatically. Prefer bounded scan queries and "
         "renforge_game_state_compact for large results. For UI interaction, call "
         "renforge_list_ui_elements first, then pass its frame_id to "
         "renforge_click_element or renforge_click_at; use "

--- a/src/renforge/server.py
+++ b/src/renforge/server.py
@@ -987,6 +987,8 @@ def _register_tools(app: Any) -> None:
         """
         def _tool() -> Any:
             try:
+                if width < 0 or height < 0:
+                    raise ValueError("width and height must be non-negative")
                 if (crosshair_x < 0) != (crosshair_y < 0):
                     raise ValueError("crosshair_x and crosshair_y must be provided together")
                 if width or height:

--- a/tests/test_bridge_runtime.py
+++ b/tests/test_bridge_runtime.py
@@ -387,6 +387,26 @@ def test_screenshot_derives_the_missing_dimension_from_the_aspect_ratio(running_
     assert sizes == [(320, 180), (480, 270), None]
 
 
+def test_screenshot_reports_when_the_aspect_ratio_is_unavailable(running_bridge):
+    sizes = []
+
+    def record(size):
+        sizes.append(size)
+        return b"\x89PNG\r\n_fake_frame_"
+
+    running_bridge.renpy.screenshot_to_bytes = record
+    running_bridge.renpy.config.screen_width = 0
+
+    reply = running_bridge.client.request(
+        "screenshot", {"width": 320, "height": 0}
+    )
+
+    # The frame comes back at native resolution, and the reply says so
+    # instead of silently ignoring the requested size.
+    assert sizes == [None]
+    assert reply["note"] == "aspect ratio unavailable; captured at native resolution"
+
+
 def test_bad_token_is_rejected(running_bridge):
     port = running_bridge.client._config.port
     wrong = BridgeClient(BridgeConfig(port=port, token="WRONG"))

--- a/tests/test_bridge_runtime.py
+++ b/tests/test_bridge_runtime.py
@@ -370,6 +370,23 @@ def test_screenshot_returns_decoded_png_bytes(running_bridge):
     assert data.startswith(b"\x89PNG")
 
 
+def test_screenshot_derives_the_missing_dimension_from_the_aspect_ratio(running_bridge):
+    sizes = []
+
+    def record(size):
+        sizes.append(size)
+        return b"\x89PNG\r\n_fake_frame_"
+
+    running_bridge.renpy.screenshot_to_bytes = record
+
+    # Logical screen is 1920x1080 (16:9) in the fake renpy module.
+    running_bridge.client.screenshot(width=320)
+    running_bridge.client.screenshot(height=270)
+    running_bridge.client.screenshot()
+
+    assert sizes == [(320, 180), (480, 270), None]
+
+
 def test_bad_token_is_rejected(running_bridge):
     port = running_bridge.client._config.port
     wrong = BridgeClient(BridgeConfig(port=port, token="WRONG"))

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -46,3 +46,20 @@ def test_discover_project_ignores_a_game_dir_without_scripts(tmp_path: Path) -> 
 
 def test_discover_project_returns_none_outside_any_project(tmp_path: Path) -> None:
     assert discover_project_from(tmp_path) is None
+
+
+def test_discover_project_finds_scripts_nested_in_subfolders(tmp_path: Path) -> None:
+    project_root = tmp_path / "nested-game"
+    chapters = project_root / "game" / "chapters"
+    chapters.mkdir(parents=True)
+    (chapters / "script.rpy").write_text("label start:\n    return\n")
+
+    assert discover_project_from(project_root) == project_root.resolve()
+
+
+def test_discover_project_survives_a_deleted_start_directory(tmp_path: Path) -> None:
+    doomed = tmp_path / "doomed"
+    doomed.mkdir()
+    doomed.rmdir()
+
+    assert discover_project_from(doomed) is None

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import pytest
 
-from renforge.project import RenpyProject
+from renforge.project import RenpyProject, discover_project_from
 
 
 def test_renpy_project_with_game_dir(tmp_path: Path) -> None:
@@ -24,3 +24,25 @@ def test_renpy_project_without_game_dir_raises(tmp_path: Path) -> None:
 
     with pytest.raises(FileNotFoundError, match="missing 'game/'"):
         RenpyProject(project_root)
+
+
+def test_discover_project_walks_up_from_a_nested_directory(tmp_path: Path) -> None:
+    project_root = tmp_path / "my-game"
+    game_dir = project_root / "game"
+    game_dir.mkdir(parents=True)
+    (game_dir / "script.rpy").write_text("label start:\n    return\n")
+    nested = game_dir / "images" / "sprites"
+    nested.mkdir(parents=True)
+
+    assert discover_project_from(nested) == project_root.resolve()
+
+
+def test_discover_project_ignores_a_game_dir_without_scripts(tmp_path: Path) -> None:
+    # A bare "game" folder (e.g. an assets directory) is not a project.
+    (tmp_path / "game").mkdir()
+
+    assert discover_project_from(tmp_path) is None
+
+
+def test_discover_project_returns_none_outside_any_project(tmp_path: Path) -> None:
+    assert discover_project_from(tmp_path) is None

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -126,7 +126,47 @@ def test_info_falls_back_to_the_server_default_project(tmp_path, monkeypatch) ->
     result = asyncio.run(_call())
     payload = json.loads(next(block.text for block in result.content if block.type == "text"))
     assert payload["active_project"] == str(tmp_path.resolve())
+    assert payload["project_source"] == "serve_default"
     assert payload["dashboard"] is None
+
+
+def test_info_detects_a_project_from_the_current_directory(tmp_path, monkeypatch) -> None:
+    pytest.importorskip("fastmcp", reason="fastmcp not installed")
+    from fastmcp import Client
+
+    monkeypatch.setenv("RENFORGE_RUNTIME_DIR", str(tmp_path / "empty-runtime"))
+    project = tmp_path / "my-game"
+    game = project / "game"
+    game.mkdir(parents=True)
+    (game / "script.rpy").write_text("label start:\n    return\n")
+    monkeypatch.chdir(project)
+
+    async def _call():
+        async with Client(create_app()) as client:
+            return await client.call_tool("renforge_info", {})
+
+    result = asyncio.run(_call())
+    payload = json.loads(next(block.text for block in result.content if block.type == "text"))
+    assert payload["active_project"] == str(project.resolve())
+    assert payload["project_source"] == "cwd"
+
+
+def test_info_explains_the_fallback_when_nothing_matches(tmp_path, monkeypatch) -> None:
+    pytest.importorskip("fastmcp", reason="fastmcp not installed")
+    from fastmcp import Client
+
+    monkeypatch.setenv("RENFORGE_RUNTIME_DIR", str(tmp_path / "empty-runtime"))
+    monkeypatch.chdir(tmp_path)
+
+    async def _call():
+        async with Client(create_app()) as client:
+            return await client.call_tool("renforge_info", {})
+
+    result = asyncio.run(_call())
+    payload = json.loads(next(block.text for block in result.content if block.type == "text"))
+    assert payload["active_project"] is None
+    assert payload["project_source"] is None
+    assert "project_path" in payload["hint"]
 
 
 def test_scan_tool_accepts_bounded_queries(tmp_path) -> None:
@@ -861,6 +901,33 @@ def test_screenshot_can_crop_and_zoom_the_live_frame(tmp_path, monkeypatch) -> N
     cropped = image_module.open(io.BytesIO(base64.b64decode(block.data)))
     assert cropped.size == (100, 120)
     assert calls == {"path": str(tmp_path), "width": 100, "height": 60}
+
+
+def test_screenshot_accepts_a_single_dimension(tmp_path, monkeypatch) -> None:
+    pytest.importorskip("fastmcp", reason="fastmcp not installed")
+    from fastmcp import Client
+
+    from renforge.tools import live
+
+    calls = {}
+
+    def fake_screenshot(path: str, width: int = 0, height: int = 0) -> bytes:
+        calls.update(width=width, height=height)
+        return b"fake-png-bytes"
+
+    monkeypatch.setattr(live, "screenshot_png", fake_screenshot)
+
+    async def _call():
+        async with Client(create_app()) as client:
+            return await client.call_tool(
+                "renforge_screenshot",
+                {"project_path": str(tmp_path), "width": 1280},
+            )
+
+    result = asyncio.run(_call())
+    # The bridge derives the missing height from the game's aspect ratio.
+    assert any(block.type == "image" for block in result.content)
+    assert calls == {"width": 1280, "height": 0}
 
 
 def test_find_references_tool_reports_unused_definitions(tmp_path) -> None:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -930,6 +930,27 @@ def test_screenshot_accepts_a_single_dimension(tmp_path, monkeypatch) -> None:
     assert calls == {"width": 1280, "height": 0}
 
 
+def test_screenshot_rejects_negative_dimensions(tmp_path, monkeypatch) -> None:
+    pytest.importorskip("fastmcp", reason="fastmcp not installed")
+    from fastmcp import Client
+
+    from renforge.tools import live
+
+    monkeypatch.setattr(live, "screenshot_png", lambda *a, **k: b"fake-png-bytes")
+
+    async def _call():
+        async with Client(create_app()) as client:
+            return await client.call_tool(
+                "renforge_screenshot",
+                {"project_path": str(tmp_path), "width": -1},
+            )
+
+    result = asyncio.run(_call())
+    payload = json.loads(next(block.text for block in result.content if block.type == "text"))
+    assert payload["ok"] is False
+    assert "non-negative" in payload["error"]
+
+
 def test_find_references_tool_reports_unused_definitions(tmp_path) -> None:
     pytest.importorskip("fastmcp", reason="fastmcp not installed")
     from fastmcp import Client


### PR DESCRIPTION
## Problème

Observé en conditions réelles : sans dashboard actif, `renforge_info` renvoie `active_project: null` sans aucune indication de repli, et l'agent MCP conclut qu'il est bloqué — alors que tous les outils acceptent `project_path` directement. Les instructions serveur (« use active_project instead of guessing ») aggravaient le comportement.

Par ailleurs, `renforge_screenshot(width=1280)` échouait avec « width and height must be provided together ».

## Changements

### Découverte de projet
- `discover_project_from()` (`project.py`) : remonte depuis le cwd jusqu'au premier dossier contenant `game/` avec au moins un `.rpy`/`.rpyc`/`.rpa` (un dossier `game` vide n'est pas détecté).
- `renforge_info`/`renforge_context` : résolution en cascade **dashboard → défaut `serve --project` → cwd**, nouveau champ `project_source`, et `hint` explicite quand rien ne matche.
- Instructions serveur et docstrings réécrites : `active_project` null n'est pas un blocage, tous les outils acceptent `project_path`, le dashboard n'est jamais requis.

### Screenshot
- Une seule dimension suffit : le bridge dérive l'autre du ratio logique du jeu (`config.screen_width/height`).

## Tests
- 212 tests passent, dont 7 nouveaux (découverte cwd, payload info, dérivation de ratio côté bridge, dimension unique côté serveur).
- Vérifié en live : jeu réel lancé via le MCP sous WSLg.

Docs synchronisées (`docs/MCP.md`, `CHANGELOG.md` section Unreleased).