### PR TITLE
feat(mcp): primitives hover, captures nommées, translation et painted bounds

### DIFF
--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -104,6 +104,8 @@ renforge_inspect_screen(project_path, name="say")
   -> active layer, JSON-safe scope, and passed screen arguments
 renforge_list_ui_elements(project_path)
   -> visible controls and frame_id
+renforge_hover_element(..., expected_frame_id=frame_id)
+  -> move over a control without clicking
 renforge_click_element(..., expected_frame_id=frame_id)
   -> safe interaction
 ```
@@ -165,8 +167,10 @@ renforge_wait_until(project_path=project, label="branch_b", timeout=30.0)
 renforge_get_errors(project_path=project)
 ```
 
-`renforge_screenshot` returns the current frame as an image. The save call
-creates a named checkpoint before selecting Branch B; use
+`renforge_screenshot` returns the current frame as an image. Use
+`renforge_capture_screenshot(name="idle")` when a PNG path is needed for a
+later diff or translation estimate. The save call creates a named checkpoint
+before selecting Branch B; use
 `renforge_saves(project_path=project, action="load", slot="branch-a")` to return
 to it. `renforge_wait_until` accepts exactly one of `label`, `screen`, or
 `expr`, and `timeout` is capped at 120 seconds.
@@ -206,6 +210,11 @@ Notes:
   (pass `width`/`height`) so the labels read as logical coordinates.
 - `renforge_diff_screenshots` needs same-size frames; `threshold` (0..255)
   absorbs anti-aliasing jitter so only real movement is reported.
+- `renforge_get_ui_element_bounds` measures the focus rectangle from
+  `renforge_list_ui_elements` and, when the control is an `ImageButton`, the
+  alpha-painted bounds of its active state. Use `painted_bounds` as the default
+  region for `renforge_estimate_translation` when available; otherwise pass an
+  explicit region from `focus_bounds`.
 
 ## Tool catalogue
 
@@ -244,8 +253,12 @@ Notes:
 | `renforge_list_choices` | Visible narrative choices. |
 | `renforge_select_choice` | Select a choice by text, preferably, or index. |
 | `renforge_list_ui_elements` | Visible focusable controls: ID, text, role, screen, bounds, center, state, and `frame_id`. |
+| `renforge_hover_element` | Move the pointer over a control by ID or text without clicking. Supports `exact`, `screen`, and `expected_frame_id`. |
+| `renforge_get_ui_element_bounds` | Report `focus_bounds` and, for `ImageButton` controls, rendered `painted_bounds` for the active state. Returns `painted_bounds_available: false` with a reason when the painted content cannot be measured. |
 | `renforge_click_element` | Click a control by ID or text. Supports `exact`, `screen`, and `expected_frame_id`. |
 | `renforge_click_at` | Click `logical` or `screenshot` coordinates, with `expected_frame_id` and `expected_state` guards. |
+| `renforge_capture_screenshot` | Persist the current frame as a named PNG under `<project>/.renforge/captures/` and return `path`, `relative_path`, SHA-256, and dimensions for later diff/translation tools. |
+| `renforge_estimate_translation` | Estimate `dx`/`dy` between two saved PNGs with Pillow, returning `confidence`, `support`, and explicit unavailability when the measure is ambiguous. |
 | `renforge_find_image_on_screen` | Locate a local PNG template in the current frame and return confidence, bounds, center, and frame guard. |
 | `renforge_get_displayable_bounds` | Report the logical bounds and center where a shown image tag was rendered. |
 | `renforge_position_element` | Reposition a shown image tag live (`xpos`, `ypos`, anchors, align, offsets, `zoom`, `rotate`) and return its new bounds. |

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -216,6 +216,33 @@ Notes:
   region for `renforge_estimate_translation` when available; otherwise pass an
   explicit region from `focus_bounds`.
 
+## ImageButton idle→hover alignment
+
+For `imagebutton` controls with distinct idle/hover art, prefer measuring the
+logical shift from `painted_bounds` before relying on a screenshot diff alone.
+
+```text
+renforge_list_ui_elements(project_path)
+  -> elements[], frame_id
+renforge_get_ui_element_bounds(project_path, element_id=id)
+  -> focus_bounds, painted_bounds (idle), state="idle"
+renforge_capture_screenshot(project_path, name="idle")
+  -> path under .renforge/captures/   # invalidates the previous frame_id
+renforge_list_ui_elements(project_path)
+  -> fresh frame_id
+renforge_hover_element(project_path, element_id=id, expected_frame_id=frame_id)
+  -> hovered without click
+renforge_get_ui_element_bounds(project_path, element_id=id)
+  -> painted_bounds (hover), state="hover"
+  # dx = hover.painted_bounds.x - idle.painted_bounds.x (logical pixels)
+renforge_capture_screenshot(project_path, name="hover")
+renforge_estimate_translation(before_path=idle.path, after_path=hover.path, ...)
+  # best on named PNG captures; ambiguous on heavily scaled live frames
+```
+
+Re-list UI elements after every capture or screenshot when using `expected_frame_id`
+guards: each capture hashes a new frame.
+
 ## Tool catalogue
 
 ### Discovery and static analysis

--- a/src/renforge/bridge/bridge.rpy
+++ b/src/renforge/bridge/bridge.rpy
@@ -1251,22 +1251,24 @@ init python:
         if callable(move_mouse):
             try:
                 move_mouse(x, y)
+            except TypeError:
+                pass
+            else:
                 _renforge_dispatch_mouse_motion(x, y)
                 if callable(restart_interaction):
                     restart_interaction()
                 return x, y, "renpy-test"
-            except TypeError:
-                pass
         set_mouse_pos = getattr(renpy, "set_mouse_pos", None)
         if callable(set_mouse_pos):
             try:
                 set_mouse_pos(x, y)
+            except TypeError:
+                pass
+            else:
                 _renforge_dispatch_mouse_motion(x, y)
                 if callable(restart_interaction):
                     restart_interaction()
                 return x, y, "renpy"
-            except TypeError:
-                pass
         if not _renforge_dispatch_mouse_motion(x, y):
             raise RuntimeError("hover unavailable: pygame mouse-motion API is unavailable")
         if callable(restart_interaction):

--- a/src/renforge/bridge/bridge.rpy
+++ b/src/renforge/bridge/bridge.rpy
@@ -1223,30 +1223,44 @@ init python:
             except Exception:
                 pass
 
-        set_mouse_pos = getattr(renpy, "set_mouse_pos", None)
-        if callable(set_mouse_pos):
-            try:
-                set_mouse_pos(x, y)
-                return x, y, "renpy"
-            except TypeError:
-                pass
+        def _renforge_post_mouse_motion(px, py):
+            if pygame is None:
+                return False
+            event_type = getattr(pygame, "MOUSEMOTION", None)
+            event_factory = getattr(getattr(pygame, "event", None), "Event", None)
+            post = getattr(getattr(pygame, "event", None), "post", None)
+            if event_type is None or not callable(event_factory) or not callable(post):
+                return False
+            event = event_factory(event_type, {"pos": (px, py), "rel": (0, 0), "buttons": (0, 0, 0)})
+            post(event)
+            return True
+
+        restart_interaction = getattr(renpy, "restart_interaction", None)
         testmouse = getattr(getattr(renpy, "test", None), "testmouse", None)
         move_mouse = getattr(testmouse, "move_mouse", None)
         if callable(move_mouse):
             try:
                 move_mouse(x, y)
+                _renforge_post_mouse_motion(x, y)
+                if callable(restart_interaction):
+                    restart_interaction()
                 return x, y, "renpy-test"
             except TypeError:
                 pass
-        if pygame is None:
-            raise RuntimeError("hover unavailable: pygame_sdl2 event API is unavailable")
-        event_type = getattr(pygame, "MOUSEMOTION", None)
-        event_factory = getattr(getattr(pygame, "event", None), "Event", None)
-        post = getattr(getattr(pygame, "event", None), "post", None)
-        if event_type is None or not callable(event_factory) or not callable(post):
+        set_mouse_pos = getattr(renpy, "set_mouse_pos", None)
+        if callable(set_mouse_pos):
+            try:
+                set_mouse_pos(x, y)
+                _renforge_post_mouse_motion(x, y)
+                if callable(restart_interaction):
+                    restart_interaction()
+                return x, y, "renpy"
+            except TypeError:
+                pass
+        if not _renforge_post_mouse_motion(x, y):
             raise RuntimeError("hover unavailable: pygame mouse-motion API is unavailable")
-        event = event_factory(event_type, {"pos": (x, y), "rel": (0, 0), "buttons": (0, 0, 0)})
-        post(event)
+        if callable(restart_interaction):
+            restart_interaction()
         return x, y, "pygame"
 
     def _renforge_h_hover_element(payload):

--- a/src/renforge/bridge/bridge.rpy
+++ b/src/renforge/bridge/bridge.rpy
@@ -1122,7 +1122,7 @@ init python:
         click_mouse(1, x, y)
         return x, y
 
-    def _renforge_h_click_element(payload):
+    def _renforge_resolve_ui_element(payload, action):
         payload = payload or {}
         wanted_id = payload.get("id") or payload.get("element_id")
         wanted_text = payload.get("text")
@@ -1130,9 +1130,8 @@ init python:
             wanted_text = None
         exact = bool(payload.get("exact", False))
         wanted_screen = payload.get("screen")
-        expected_frame_id = payload.get("expected_frame_id") or payload.get("expected_screenshot")
         if wanted_id is None and wanted_text is None:
-            return {"ok": False, "error": "click_element requires text or id"}
+            return None, None, {"ok": False, "error": "%s requires text or id" % action}
         if wanted_id is not None:
             wanted_id = str(wanted_id)
         if wanted_text is not None:
@@ -1148,20 +1147,26 @@ init python:
                 continue
             if wanted_text is not None:
                 actual_text = str(element.get("text") or "")
-                if exact:
-                    if actual_text.casefold() != wanted_text.casefold():
-                        continue
-                elif wanted_text.casefold() not in actual_text.casefold():
+                matches = actual_text.casefold() == wanted_text.casefold() if exact else wanted_text.casefold() in actual_text.casefold()
+                if not matches:
                     continue
             candidates.append((focus, element))
         if not candidates:
-            return {"ok": False, "error": "no UI element matching %r/%r" % (wanted_text, wanted_id)}
+            return None, None, {"ok": False, "error": "no UI element matching %r/%r" % (wanted_text, wanted_id)}
         if len(candidates) > 1:
-            return {
+            return None, None, {
                 "ok": False,
                 "error": "ambiguous UI element; provide an id or exact text",
                 "matches": [item[1] for item in candidates],
             }
+        return candidates[0][0], candidates[0][1], None
+
+    def _renforge_h_click_element(payload):
+        payload = payload or {}
+        expected_frame_id = payload.get("expected_frame_id") or payload.get("expected_screenshot")
+        focus, element, error = _renforge_resolve_ui_element(payload, "click_element")
+        if error is not None:
+            return error
 
         screenshot_digest = None
         if expected_frame_id not in (None, ""):
@@ -1173,7 +1178,6 @@ init python:
                     "error": "expected_frame_id guard failed",
                     "sha256": screenshot_digest,
                 }
-        focus, element = candidates[0]
         if not element.get("enabled", True):
             return {"ok": False, "error": "UI element is disabled", "element": element}
         x, y = _renforge_click_focus(focus)
@@ -1188,6 +1192,178 @@ init python:
             "y": y,
             "element": element,
         }
+        if screenshot_digest is not None:
+            result["sha256"] = screenshot_digest
+        return result
+
+    def _renforge_move_mouse(focus):
+        fx = getattr(focus, "x", None)
+        fy = getattr(focus, "y", None)
+        fw = getattr(focus, "w", None)
+        fh = getattr(focus, "h", None)
+        if fx is not None and fy is not None and fw and fh:
+            x = int(fx + fw // 2)
+            y = int(fy + fh // 2)
+        else:
+            find_position = getattr(getattr(renpy, "test", None), "testfocus", None)
+            find_position = getattr(find_position, "find_position", None)
+            if not callable(find_position):
+                raise RuntimeError("Ren'Py focus position API is unavailable")
+            px, py = find_position(focus, (None, None))
+            x, y = int(px), int(py)
+
+        interface = getattr(getattr(renpy, "display", None), "interface", None)
+        if interface is not None:
+            try:
+                interface.mouse_focused = True
+            except Exception:
+                pass
+            try:
+                interface.ignore_touch = False
+            except Exception:
+                pass
+
+        set_mouse_pos = getattr(renpy, "set_mouse_pos", None)
+        if callable(set_mouse_pos):
+            try:
+                set_mouse_pos(x, y)
+                return x, y, "renpy"
+            except TypeError:
+                pass
+        testmouse = getattr(getattr(renpy, "test", None), "testmouse", None)
+        move_mouse = getattr(testmouse, "move_mouse", None)
+        if callable(move_mouse):
+            try:
+                move_mouse(x, y)
+                return x, y, "renpy-test"
+            except TypeError:
+                pass
+        if pygame is None:
+            raise RuntimeError("hover unavailable: pygame_sdl2 event API is unavailable")
+        event_type = getattr(pygame, "MOUSEMOTION", None)
+        event_factory = getattr(getattr(pygame, "event", None), "Event", None)
+        post = getattr(getattr(pygame, "event", None), "post", None)
+        if event_type is None or not callable(event_factory) or not callable(post):
+            raise RuntimeError("hover unavailable: pygame mouse-motion API is unavailable")
+        event = event_factory(event_type, {"pos": (x, y), "rel": (0, 0), "buttons": (0, 0, 0)})
+        post(event)
+        return x, y, "pygame"
+
+    def _renforge_h_hover_element(payload):
+        payload = payload or {}
+        expected_frame_id = payload.get("expected_frame_id") or payload.get("expected_screenshot")
+        focus, element, error = _renforge_resolve_ui_element(payload, "hover_element")
+        if error is not None:
+            return error
+        screenshot_digest = None
+        if expected_frame_id not in (None, ""):
+            data = renpy.screenshot_to_bytes(None)
+            matches, screenshot_digest = _renforge_screenshot_guard_matches(expected_frame_id, data)
+            if not matches:
+                return {
+                    "ok": False,
+                    "error": "expected_frame_id guard failed",
+                    "sha256": screenshot_digest,
+                }
+        if not element.get("enabled", True):
+            return {"ok": False, "error": "UI element is disabled", "element": element}
+        try:
+            x, y, method = _renforge_move_mouse(focus)
+        except RuntimeError as exc:
+            return {"ok": False, "error": str(exc), "element": element}
+        result = {
+            "ok": True,
+            "hovered": True,
+            "method": method,
+            "id": element.get("id"),
+            "text": element.get("text"),
+            "type": element.get("type"),
+            "screen": element.get("screen"),
+            "bounds": element.get("bounds"),
+            "x": x,
+            "y": y,
+            "element": element,
+        }
+        if screenshot_digest is not None:
+            result["sha256"] = screenshot_digest
+        return result
+
+    def _renforge_rect_components(rect):
+        left = getattr(rect, "left", None)
+        top = getattr(rect, "top", None)
+        width = getattr(rect, "width", None)
+        height = getattr(rect, "height", None)
+        if left is None or top is None or width is None or height is None:
+            try:
+                left, top, width, height = rect[0], rect[1], rect[2], rect[3]
+            except (TypeError, IndexError, ValueError):
+                raise ValueError("unsupported rect type")
+        return int(left), int(top), int(width), int(height)
+
+    def _renforge_h_get_ui_element_bounds(payload):
+        payload = payload or {}
+        expected_frame_id = payload.get("expected_frame_id") or payload.get("expected_screenshot")
+        focus, element, error = _renforge_resolve_ui_element(payload, "get_ui_element_bounds")
+        if error is not None:
+            return error
+        screenshot_digest = None
+        if expected_frame_id not in (None, ""):
+            data = renpy.screenshot_to_bytes(None)
+            matches, screenshot_digest = _renforge_screenshot_guard_matches(expected_frame_id, data)
+            if not matches:
+                return {
+                    "ok": False,
+                    "error": "expected_frame_id guard failed",
+                    "sha256": screenshot_digest,
+                }
+
+        bounds = element.get("bounds")
+        result = {
+            "ok": True,
+            "id": element.get("id"),
+            "text": element.get("text"),
+            "type": element.get("type"),
+            "screen": element.get("screen"),
+            "focus_bounds": bounds,
+            "painted_bounds": None,
+            "painted_bounds_available": False,
+            "coordinate_space": "logical",
+        }
+        widget = getattr(focus, "widget", None)
+        if widget is None or not hasattr(widget, "state_children") or not callable(getattr(widget, "get_child", None)):
+            result["painted_bounds_reason"] = "element does not expose ImageButton state children"
+        else:
+            render_to_surface = getattr(renpy, "render_to_surface", None)
+            if not callable(render_to_surface):
+                result["painted_bounds_reason"] = "renpy.render_to_surface is unavailable"
+            else:
+                try:
+                    child = widget.get_child()
+                    width = int(bounds.get("width", 0))
+                    height = int(bounds.get("height", 0))
+                    surface = render_to_surface(child, width, height, resize=True)
+                    get_bounding_rect = getattr(surface, "get_bounding_rect", None)
+                    if not callable(get_bounding_rect):
+                        raise RuntimeError("rendered surface has no alpha bounds API")
+                    try:
+                        rect = get_bounding_rect(min_alpha=1)
+                    except TypeError:
+                        rect = get_bounding_rect()
+                    left, top, painted_width, painted_height = _renforge_rect_components(rect)
+                    if painted_width > 0 and painted_height > 0:
+                        result["painted_bounds"] = {
+                            "x": int(bounds["x"]) + left,
+                            "y": int(bounds["y"]) + top,
+                            "width": painted_width,
+                            "height": painted_height,
+                        }
+                        result["painted_bounds_available"] = True
+                        result["painted_bounds_source"] = "rendered-alpha"
+                        result["state"] = str(getattr(getattr(widget, "style", None), "prefix", "")).rstrip("_") or None
+                    else:
+                        result["painted_bounds_reason"] = "rendered ImageButton is fully transparent"
+                except Exception as exc:
+                    result["painted_bounds_reason"] = "%s: %s" % (type(exc).__name__, exc)
         if screenshot_digest is not None:
             result["sha256"] = screenshot_digest
         return result
@@ -1524,6 +1700,8 @@ init python:
         "select_choice": _renforge_h_select_choice,
         "list_ui_elements": _renforge_h_list_ui_elements,
         "click_element": _renforge_h_click_element,
+        "hover_element": _renforge_h_hover_element,
+        "get_ui_element_bounds": _renforge_h_get_ui_element_bounds,
         "click_at": _renforge_h_click_at,
         "get_displayable_bounds": _renforge_h_get_displayable_bounds,
         "show_displayable": _renforge_h_show_displayable,

--- a/src/renforge/bridge/bridge.rpy
+++ b/src/renforge/bridge/bridge.rpy
@@ -1223,16 +1223,26 @@ init python:
             except Exception:
                 pass
 
-        def _renforge_post_mouse_motion(px, py):
+        def _renforge_dispatch_mouse_motion(px, py):
+            """Drive Ren'Py focus/hover state without a player interact loop.
+
+            Posting MOUSEMOTION to pygame is not enough: ImageButton hover uses
+            ``focus.mouse_handler`` during event dispatch. Bridge RPC must call
+            it directly on the main thread after ``testmouse.move_mouse``.
+            """
             if pygame is None:
                 return False
             event_type = getattr(pygame, "MOUSEMOTION", None)
             event_factory = getattr(getattr(pygame, "event", None), "Event", None)
             post = getattr(getattr(pygame, "event", None), "post", None)
-            if event_type is None or not callable(event_factory) or not callable(post):
+            if event_type is None or not callable(event_factory):
                 return False
             event = event_factory(event_type, {"pos": (px, py), "rel": (0, 0), "buttons": (0, 0, 0)})
-            post(event)
+            if callable(post):
+                post(event)
+            mouse_handler = getattr(getattr(getattr(renpy, "display", None), "focus", None), "mouse_handler", None)
+            if callable(mouse_handler):
+                mouse_handler(event, px, py, False)
             return True
 
         restart_interaction = getattr(renpy, "restart_interaction", None)
@@ -1241,7 +1251,7 @@ init python:
         if callable(move_mouse):
             try:
                 move_mouse(x, y)
-                _renforge_post_mouse_motion(x, y)
+                _renforge_dispatch_mouse_motion(x, y)
                 if callable(restart_interaction):
                     restart_interaction()
                 return x, y, "renpy-test"
@@ -1251,13 +1261,13 @@ init python:
         if callable(set_mouse_pos):
             try:
                 set_mouse_pos(x, y)
-                _renforge_post_mouse_motion(x, y)
+                _renforge_dispatch_mouse_motion(x, y)
                 if callable(restart_interaction):
                     restart_interaction()
                 return x, y, "renpy"
             except TypeError:
                 pass
-        if not _renforge_post_mouse_motion(x, y):
+        if not _renforge_dispatch_mouse_motion(x, y):
             raise RuntimeError("hover unavailable: pygame mouse-motion API is unavailable")
         if callable(restart_interaction):
             restart_interaction()

--- a/src/renforge/bridge/client.py
+++ b/src/renforge/bridge/client.py
@@ -303,6 +303,56 @@ class BridgeClient:
             return result
         return reply
 
+    def hover_element(
+        self,
+        text: str | None = None,
+        id: str | None = None,
+        *,
+        screen: str | None = None,
+        exact: bool = False,
+        element_id: str | None = None,
+        expected_frame_id: str | None = None,
+    ) -> dict[str, Any]:
+        """Move the pointer over a visible control without clicking it."""
+        if id is None:
+            id = element_id
+        payload: dict[str, Any] = {"text": text, "id": id, "exact": bool(exact)}
+        if screen is not None:
+            payload["screen"] = screen
+        if expected_frame_id is not None:
+            payload["expected_frame_id"] = expected_frame_id
+        reply = self.request("hover_element", payload)
+        if reply.get("error") is not None:
+            result = dict(reply)
+            result["ok"] = False
+            return result
+        return reply
+
+    def get_ui_element_bounds(
+        self,
+        text: str | None = None,
+        id: str | None = None,
+        *,
+        screen: str | None = None,
+        exact: bool = False,
+        element_id: str | None = None,
+        expected_frame_id: str | None = None,
+    ) -> dict[str, Any]:
+        """Return focus and painted bounds for a visible UI element."""
+        if id is None:
+            id = element_id
+        payload: dict[str, Any] = {"text": text, "id": id, "exact": bool(exact)}
+        if screen is not None:
+            payload["screen"] = screen
+        if expected_frame_id is not None:
+            payload["expected_frame_id"] = expected_frame_id
+        reply = self.request("get_ui_element_bounds", payload)
+        if reply.get("error") is not None:
+            result = dict(reply)
+            result["ok"] = False
+            return result
+        return reply
+
     def get_displayable_bounds(
         self,
         tag: str,

--- a/src/renforge/image_ops.py
+++ b/src/renforge/image_ops.py
@@ -683,6 +683,75 @@ def diff_images(
     return result
 
 
+def estimate_translation(
+    before: bytes | bytearray | memoryview | str | Path | Image.Image,
+    after: bytes | bytearray | memoryview | str | Path | Image.Image,
+    *,
+    region: Sequence[int] | dict[str, int] | None = None,
+    threshold: int = 16,
+    max_shift: int = 64,
+) -> dict[str, Any]:
+    """Estimate a stable visual translation between two frames.
+
+    The score uses opaque/bright pixels and ignores isolated pixels, making it
+    less sensitive to glow and particle effects than a raw image diff.
+    """
+    if isinstance(threshold, bool) or not isinstance(threshold, int) or not 0 <= threshold <= 255:
+        raise ValueError("threshold must be an integer between 0 and 255")
+    if isinstance(max_shift, bool) or not isinstance(max_shift, int) or not 0 <= max_shift <= 256:
+        raise ValueError("max_shift must be an integer between 0 and 256")
+    first = _read_image_source(before, name="before")
+    second = _read_image_source(after, name="after")
+    if first.size != second.size:
+        raise ValueError(f"images differ in size: {first.size} vs {second.size}")
+    left, top, width, height = _normalise_region(region, width=first.width, height=first.height)
+    first = first.crop((left, top, left + width, top + height))
+    second = second.crop((left, top, left + width, top + height))
+    first_luma = first.convert("L")
+    second_luma = second.convert("L")
+    first_mask = first_luma.point(lambda value: 255 if value > threshold else 0)
+    second_mask = second_luma.point(lambda value: 255 if value > threshold else 0)
+    first_bbox = first_mask.getbbox()
+    second_bbox = second_mask.getbbox()
+    if first_bbox is None or second_bbox is None:
+        return {"ok": True, "available": False, "reason": "insufficient stable visual support", "confidence": 0.0}
+
+    best = (0, 0, 0)
+    runner_up = 0
+    for dy in range(-max_shift, max_shift + 1):
+        for dx in range(-max_shift, max_shift + 1):
+            shifted = ImageChops.offset(first_mask, dx, dy)
+            overlap = ImageChops.multiply(shifted, second_mask).histogram()[255]
+            if overlap > best[2]:
+                runner_up = best[2]
+                best = (dx, dy, overlap)
+            elif overlap > runner_up:
+                runner_up = overlap
+    support = best[2]
+    if support == 0:
+        return {"ok": True, "available": False, "reason": "insufficient stable visual support", "confidence": 0.0}
+    confidence = round((support - runner_up) / float(max(support, 1)), 4)
+    if confidence < 0.02:
+        return {
+            "ok": True,
+            "available": False,
+            "reason": "translation is ambiguous",
+            "confidence": confidence,
+            "support": support,
+        }
+    return {
+        "ok": True,
+        "available": True,
+        "dx": best[0],
+        "dy": best[1],
+        "confidence": confidence,
+        "support": support,
+        "bounds": {"x": left, "y": top, "width": width, "height": height},
+        "method": "luminance-overlap",
+        "threshold": threshold,
+    }
+
+
 def inspect_image(
     image_path: str | Path,
     *,
@@ -712,6 +781,7 @@ def inspect_image(
 __all__ = [
     "annotate_png",
     "diff_images",
+    "estimate_translation",
     "find_image_matches",
     "find_image_on_screen",
     "inspect_image",

--- a/src/renforge/image_ops.py
+++ b/src/renforge/image_ops.py
@@ -26,6 +26,11 @@ _MAX_OUTPUT_PIXELS = 50_000_000
 # (20x20) control template while still putting a hard ceiling on CPU work.
 _MAX_SCAN_POSITIONS = 4_000_000
 _MAX_SCORE_PIXELS = 50_000_000
+# Translation search is O(region_pixels * (2*max_shift+1)^2).  Auto-cropping to
+# the union of active masks keeps typical UI captures fast; this ceiling rejects
+# unbounded full-frame scans from an MCP client.
+_MAX_ESTIMATE_PIXEL_CHECKS = 50_000_000
+_ALPHA_VISIBILITY_THRESHOLD = 16
 _MAX_MATCHES = 100
 _MIN_TEMPLATE_PIXELS = 1
 _MAX_TEMPLATE_PIXELS = 4_000_000
@@ -107,6 +112,19 @@ def _normalise_region(
     if x + region_width > width or y + region_height > height:
         raise ValueError(f"region exceeds image bounds {width}x{height}")
     return x, y, region_width, region_height
+
+
+def _stable_visual_mask(image: Image.Image, *, threshold: int) -> Image.Image:
+    """Return a binary mask of opaque, bright pixels for translation scoring."""
+
+    rgba = image.convert("RGBA")
+    red, green, blue, alpha = rgba.split()
+    luma = Image.merge("RGB", (red, green, blue)).convert("L")
+    visible = alpha.point(
+        lambda value: 255 if value >= _ALPHA_VISIBILITY_THRESHOLD else 0
+    )
+    bright = luma.point(lambda value: 255 if value > threshold else 0)
+    return ImageChops.multiply(visible, bright)
 
 
 def _visible_anchor_points(alpha: bytes, width: int, height: int) -> list[tuple[int, int]]:
@@ -707,14 +725,32 @@ def estimate_translation(
     left, top, width, height = _normalise_region(region, width=first.width, height=first.height)
     first = first.crop((left, top, left + width, top + height))
     second = second.crop((left, top, left + width, top + height))
-    first_luma = first.convert("L")
-    second_luma = second.convert("L")
-    first_mask = first_luma.point(lambda value: 255 if value > threshold else 0)
-    second_mask = second_luma.point(lambda value: 255 if value > threshold else 0)
+    first_mask = _stable_visual_mask(first, threshold=threshold)
+    second_mask = _stable_visual_mask(second, threshold=threshold)
     first_bbox = first_mask.getbbox()
     second_bbox = second_mask.getbbox()
     if first_bbox is None or second_bbox is None:
         return {"ok": True, "available": False, "reason": "insufficient stable visual support", "confidence": 0.0}
+
+    crop_left = max(0, min(first_bbox[0], second_bbox[0]) - max_shift)
+    crop_top = max(0, min(first_bbox[1], second_bbox[1]) - max_shift)
+    crop_right = min(
+        first_mask.width,
+        max(first_bbox[2], second_bbox[2]) + max_shift,
+    )
+    crop_bottom = min(
+        first_mask.height,
+        max(first_bbox[3], second_bbox[3]) + max_shift,
+    )
+    first_mask = first_mask.crop((crop_left, crop_top, crop_right, crop_bottom))
+    second_mask = second_mask.crop((crop_left, crop_top, crop_right, crop_bottom))
+    shift_count = (2 * max_shift + 1) ** 2
+    pixel_checks = first_mask.width * first_mask.height * shift_count
+    if pixel_checks > _MAX_ESTIMATE_PIXEL_CHECKS:
+        raise ValueError(
+            "translation search exceeds the work budget; pass a tighter region "
+            "or reduce max_shift"
+        )
 
     best = (0, 0, 0)
     runner_up = 0

--- a/src/renforge/server.py
+++ b/src/renforge/server.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import base64
 import hashlib
 import math
+
 from dataclasses import dataclass
 from pathlib import Path
 from time import perf_counter
@@ -590,6 +591,70 @@ def _register_tools(app: Any) -> None:
         )
 
     @tool_decorator()
+    def renforge_hover_element(
+        project_path: str,
+        text: str = "",
+        element_id: str = "",
+        screen: str = "",
+        exact: bool = False,
+        expected_frame_id: str = "",
+    ) -> dict:
+        """Move the pointer over a visible control without clicking it."""
+        return _log_tool_call(
+            name="renforge_hover_element",
+            params={
+                "project_path": project_path,
+                "text": text,
+                "element_id": element_id,
+                "screen": screen,
+                "exact": exact,
+                "expected_frame_id": expected_frame_id,
+            },
+            project_root=project_path,
+            fn=live.hover_element,
+            args=(project_path,),
+            kwargs={
+                "text": text or None,
+                "element_id": element_id or None,
+                "screen": screen or None,
+                "exact": exact,
+                "expected_frame_id": expected_frame_id or None,
+            },
+        )
+
+    @tool_decorator()
+    def renforge_get_ui_element_bounds(
+        project_path: str,
+        text: str = "",
+        element_id: str = "",
+        screen: str = "",
+        exact: bool = False,
+        expected_frame_id: str = "",
+    ) -> dict:
+        """Report focus bounds and rendered painted bounds for a UI element."""
+        return _log_tool_call(
+            name="renforge_get_ui_element_bounds",
+            params={
+                "project_path": project_path,
+                "text": text,
+                "element_id": element_id,
+                "screen": screen,
+                "exact": exact,
+                "expected_frame_id": expected_frame_id,
+            },
+            project_root=project_path,
+            fn=live.get_ui_element_bounds,
+            args=(project_path,),
+            kwargs={
+                "text": text or None,
+                "element_id": element_id or None,
+                "screen": screen or None,
+                "exact": exact,
+                "expected_frame_id": expected_frame_id or None,
+            },
+        )
+
+    @tool_decorator()
     def renforge_click_at(
         project_path: str,
         x: float,
@@ -1048,6 +1113,103 @@ def _register_tools(app: Any) -> None:
         )
 
     @tool_decorator()
+    def renforge_capture_screenshot(
+        project_path: str,
+        name: str = "capture",
+        width: int = 0,
+        height: int = 0,
+        crop_x: int = 0,
+        crop_y: int = 0,
+        crop_width: int = 0,
+        crop_height: int = 0,
+        scale: float = 1.0,
+        grid: int = 0,
+        crosshair_x: int = -1,
+        crosshair_y: int = -1,
+        rulers: bool = False,
+    ) -> dict:
+        """Persist a screenshot under the project's controlled capture directory."""
+        def _capture() -> dict:
+            import os
+            import re
+            import tempfile
+            from io import BytesIO
+            from PIL import Image
+
+            if not isinstance(name, str) or not re.fullmatch(r"[A-Za-z0-9_.-]{1,80}", name):
+                raise ValueError("name must contain only letters, digits, dot, dash, or underscore")
+            if width < 0 or height < 0:
+                raise ValueError("width and height must be non-negative")
+            if (crosshair_x < 0) != (crosshair_y < 0):
+                raise ValueError("crosshair_x and crosshair_y must be provided together")
+            png = live.screenshot_png(project_path, width=width, height=height)
+            if crop_width or crop_height or crop_x or crop_y or scale != 1.0:
+                from .image_ops import transform_png
+                png = transform_png(png, crop_x=crop_x, crop_y=crop_y,
+                                    crop_width=crop_width, crop_height=crop_height,
+                                    scale=scale)
+            if grid or rulers or crosshair_x >= 0:
+                from .image_ops import annotate_png
+                png = annotate_png(png, grid=grid, rulers=rulers,
+                                   crosshair=(crosshair_x, crosshair_y) if crosshair_x >= 0 else None)
+            project_root = Path(project_path).expanduser().resolve()
+            capture_dir = project_root / ".renforge" / "captures"
+            capture_dir.mkdir(parents=True, exist_ok=True)
+            target = (capture_dir / (name + ".png")).resolve()
+            target.relative_to(capture_dir.resolve())
+            with tempfile.NamedTemporaryFile(dir=capture_dir, suffix=".tmp", delete=False) as handle:
+                temporary = Path(handle.name)
+                handle.write(png)
+            try:
+                os.replace(temporary, target)
+            finally:
+                temporary.unlink(missing_ok=True)
+            with Image.open(BytesIO(png)) as image:
+                size = {"width": image.width, "height": image.height}
+            return {"ok": True, "name": name, "path": str(target),
+                    "relative_path": str(target.relative_to(project_root)),
+                    "sha256": hashlib.sha256(png).hexdigest(), "size": size}
+
+        return _log_tool_call(
+            name="renforge_capture_screenshot",
+            params={"project_path": project_path, "name": name, "width": width, "height": height},
+            project_root=project_path, fn=_capture, args=(), kwargs={})
+
+    @tool_decorator()
+    def renforge_estimate_translation(
+        before_path: str,
+        after_path: str,
+        region_x: int = 0,
+        region_y: int = 0,
+        region_width: int = 0,
+        region_height: int = 0,
+        threshold: int = 16,
+        max_shift: int = 64,
+    ) -> dict:
+        """Estimate stable visual translation between two saved frames."""
+        def _estimate() -> dict:
+            from .image_ops import estimate_translation
+            region = None
+            if region_width or region_height or region_x or region_y:
+                region = (region_x, region_y, region_width, region_height)
+            return estimate_translation(
+                before_path,
+                after_path,
+                region=region,
+                threshold=threshold,
+                max_shift=max_shift,
+            )
+
+        return _log_tool_call(
+            name="renforge_estimate_translation",
+            params={"before_path": before_path, "after_path": after_path},
+            project_root=None,
+            fn=_estimate,
+            args=(),
+            kwargs={},
+        )
+
+    @tool_decorator()
     def renforge_find_image_on_screen(
         project_path: str,
         template_path: str,
@@ -1123,10 +1285,13 @@ def create_app() -> Any:
         "display-bound startup to its process automatically. Prefer bounded scan queries and "
         "renforge_game_state_compact for large results. For UI interaction, call "
         "renforge_list_ui_elements first, then pass its frame_id to "
-        "renforge_click_element or renforge_click_at; use "
+        "renforge_hover_element, renforge_click_element, or renforge_click_at; use "
         "renforge_find_image_on_screen for visual template placement. For "
-        "pixel-perfect layout, measure a shown image with "
-        "renforge_get_displayable_bounds, nudge it live with "
+        "idle/hover alignment, capture named frames with renforge_capture_screenshot, "
+        "hover with renforge_hover_element, estimate motion with "
+        "renforge_estimate_translation, and read painted content bounds with "
+        "renforge_get_ui_element_bounds. For pixel-perfect layout, measure a shown "
+        "image with renforge_get_displayable_bounds, nudge it live with "
         "renforge_position_element, overlay a grid or crosshair via "
         "renforge_screenshot, and compare frames with renforge_diff_screenshots. "
         "For live iteration, use renforge_control(action=\"reload_script\") after "

--- a/src/renforge/server.py
+++ b/src/renforge/server.py
@@ -1156,7 +1156,9 @@ def _register_tools(app: Any) -> None:
             capture_dir = project_root / ".renforge" / "captures"
             capture_dir.mkdir(parents=True, exist_ok=True)
             target = (capture_dir / (name + ".png")).resolve()
-            target.relative_to(capture_dir.resolve())
+            capture_relative = target.relative_to(capture_dir.resolve())
+            if capture_relative.name != f"{name}.png":
+                raise ValueError("capture path escaped capture directory")
             with tempfile.NamedTemporaryFile(dir=capture_dir, suffix=".tmp", delete=False) as handle:
                 temporary = Path(handle.name)
                 handle.write(png)

--- a/src/renforge/tools/live.py
+++ b/src/renforge/tools/live.py
@@ -412,6 +412,55 @@ def click_at(
     )
 
 
+def hover_element(
+    project_path: str,
+    text: str | None = None,
+    id: str | None = None,
+    *,
+    screen: str | None = None,
+    exact: bool = False,
+    element_id: str | None = None,
+    expected_frame_id: str | None = None,
+) -> dict:
+    """Move the pointer over a visible control without clicking it."""
+
+    def _handler(client: BridgeClient) -> dict:
+        return client.hover_element(
+            text=text,
+            id=id,
+            screen=screen,
+            exact=exact,
+            element_id=element_id,
+            expected_frame_id=expected_frame_id,
+        )
+
+    return _with_client(project_path, _handler)
+
+
+def get_ui_element_bounds(
+    project_path: str,
+    text: str | None = None,
+    id: str | None = None,
+    *,
+    screen: str | None = None,
+    exact: bool = False,
+    element_id: str | None = None,
+    expected_frame_id: str | None = None,
+) -> dict:
+    """Return focus and painted bounds for a visible UI element."""
+    return _with_client(
+        project_path,
+        lambda c: c.get_ui_element_bounds(
+            text=text,
+            id=id,
+            screen=screen,
+            exact=exact,
+            element_id=element_id,
+            expected_frame_id=expected_frame_id,
+        ),
+    )
+
+
 def get_displayable_bounds(
     project_path: str,
     tag: str,
@@ -625,6 +674,8 @@ __all__ = [
     "list_ui_elements",
     "click_element",
     "click_at",
+    "hover_element",
+    "get_ui_element_bounds",
     "eval_expr",
     "get_var",
     "set_var",

--- a/tests/test_bridge_client.py
+++ b/tests/test_bridge_client.py
@@ -256,6 +256,65 @@ def test_bridge_client_send_input_helper():
     assert reply == {"ok": True, "mode": "text", "characters": 4, "submitted": True}
 
 
+def test_bridge_client_hover_element_helper():
+    token = "hover-token"
+    captured = {}
+
+    def handler(line, conn):
+        captured["request"] = json.loads(line)
+        conn.sendall(b'{"ok": true, "hovered": true, "x": 10, "y": 20}\n')
+
+    thread, port, sock = _start_test_server(handler)
+    reply = BridgeClient(BridgeConfig(port=port, token=token)).hover_element(
+        id="menu:button:Save", expected_frame_id="frame-1"
+    )
+
+    thread.join(timeout=1.0)
+    assert sock.fileno() == -1
+    assert captured["request"] == {
+        "token": token,
+        "command": "hover_element",
+        "payload": {
+            "text": None,
+            "id": "menu:button:Save",
+            "exact": False,
+            "expected_frame_id": "frame-1",
+        },
+    }
+    assert reply["hovered"] is True
+
+
+def test_bridge_client_get_ui_element_bounds_helper():
+    token = "bounds-token"
+    captured = {}
+
+    def handler(line, conn):
+        captured["request"] = json.loads(line)
+        conn.sendall(
+            b'{"ok": true, "focus_bounds": {"x": 1, "y": 2, "width": 3, "height": 4}, '
+            b'"painted_bounds": null, "painted_bounds_available": false}\n'
+        )
+
+    thread, port, sock = _start_test_server(handler)
+    reply = BridgeClient(BridgeConfig(port=port, token=token)).get_ui_element_bounds(
+        id="menu:button:Load", expected_frame_id="frame-1"
+    )
+
+    thread.join(timeout=1.0)
+    assert sock.fileno() == -1
+    assert captured["request"] == {
+        "token": token,
+        "command": "get_ui_element_bounds",
+        "payload": {
+            "text": None,
+            "id": "menu:button:Load",
+            "exact": False,
+            "expected_frame_id": "frame-1",
+        },
+    }
+    assert reply["painted_bounds_available"] is False
+
+
 def test_bridge_client_invalid_json_response():
     token = "bad-json-token"
 

--- a/tests/test_bridge_runtime.py
+++ b/tests/test_bridge_runtime.py
@@ -34,9 +34,44 @@ class _FakeWidget:
         return self._text
 
 
+class _FakeRect:
+    def __init__(self, left, top, width, height):
+        self.left = left
+        self.top = top
+        self.width = width
+        self.height = height
+
+
+class _FakeSurface:
+    def __init__(self, rect):
+        self._rect = rect
+
+    def get_bounding_rect(self, min_alpha=1):
+        return self._rect
+
+
+class _FakeImageButtonWidget:
+    state_children = True
+
+    def __init__(self, text, alpha_rect=(4, 6, 80, 14)):
+        self._text = text
+        self._alpha_rect = _FakeRect(*alpha_rect)
+        self._child = object()
+        self.style = types.SimpleNamespace(prefix="idle_")
+
+    def _tts_all(self):
+        return self._text
+
+    def get_child(self):
+        return self._child
+
+
 class _FakeFocus:
-    def __init__(self, text, x, y, w, h):
-        self.widget = _FakeWidget(text) if text is not None else None
+    def __init__(self, text, x, y, w, h, widget=None):
+        if widget is not None:
+            self.widget = widget
+        else:
+            self.widget = _FakeWidget(text) if text is not None else None
         self.x, self.y, self.w, self.h = x, y, w, h
 
 
@@ -71,10 +106,12 @@ def _fake_renpy(store):
     renpy.quit = lambda: renpy._invoked.append(("quit",))
 
     # Minimal focus + input system mirroring Ren'Py's runtime shape.
+    load_button = _FakeImageButtonWidget("Load icon")
     focus_list = [
         _FakeFocus(None, None, None, None, None),  # the "default" whole-screen focus
         _FakeFocus("Alpha choice", 10, 10, 100, 20),
         _FakeFocus("Beta choice", 10, 40, 100, 20),
+        _FakeFocus("Load icon", 200, 100, 100, 30, widget=load_button),
     ]
     renpy._focused_widget = None
     renpy.display = types.SimpleNamespace(
@@ -86,6 +123,7 @@ def _fake_renpy(store):
         interface=types.SimpleNamespace(mouse_focused=False, ignore_touch=False),
     )
     renpy._clicks = []
+    renpy._moves = []
 
     def _find_focus(pattern):
         for focus in focus_list:
@@ -101,7 +139,8 @@ def _fake_renpy(store):
     renpy.test = types.SimpleNamespace(
         testfocus=types.SimpleNamespace(find_focus=_find_focus, find_position=_find_position),
         testmouse=types.SimpleNamespace(
-            click_mouse=lambda button, x, y: renpy._clicks.append((button, x, y))
+            click_mouse=lambda button, x, y: renpy._clicks.append((button, x, y)),
+            move_mouse=lambda x, y: renpy._moves.append((x, y)),
         ),
     )
 
@@ -135,6 +174,17 @@ def _fake_renpy(store):
                 box[1] = int(placement["ypos"])
 
     renpy.show = _show
+
+    def _render_to_surface(child, width, height, resize=True):
+        for focus in focus_list:
+            widget = getattr(focus, "widget", None)
+            if widget is None or not callable(getattr(widget, "get_child", None)):
+                continue
+            if widget.get_child() is child and hasattr(widget, "_alpha_rect"):
+                return _FakeSurface(widget._alpha_rect)
+        return _FakeSurface(_FakeRect(0, 0, 0, 0))
+
+    renpy.render_to_surface = _render_to_surface
     return renpy
 
 
@@ -544,7 +594,7 @@ def test_poll_events_captures_labels_and_say_lines(running_bridge):
 
 def test_list_choices_enumerates_focusable_text(running_bridge):
     texts = [c["text"] for c in running_bridge.client.list_choices()]
-    assert texts == ["Alpha choice", "Beta choice"]  # the default focus is skipped
+    assert texts == ["Alpha choice", "Beta choice", "Load icon"]  # the default focus is skipped
 
 
 def test_select_choice_by_text_clicks_focus_center(running_bridge):
@@ -569,7 +619,11 @@ def test_select_choice_without_match_returns_error(running_bridge):
 
 def test_list_ui_elements_reports_bounds_and_semantic_fields(running_bridge):
     elements = running_bridge.client.list_ui_elements()
-    assert [element["text"] for element in elements] == ["Alpha choice", "Beta choice"]
+    assert [element["text"] for element in elements] == [
+        "Alpha choice",
+        "Beta choice",
+        "Load icon",
+    ]
     assert elements[0]["bounds"] == {"x": 10, "y": 10, "width": 100, "height": 20}
     assert elements[0]["center"] == {"x": 60, "y": 20}
     assert elements[0]["enabled"] is True
@@ -579,6 +633,55 @@ def test_list_ui_elements_reports_bounds_and_semantic_fields(running_bridge):
     info = running_bridge.client.list_ui_elements_info()
     assert info["elements"] == elements
     assert len(info["frame_id"]) == 64
+
+
+def test_hover_element_moves_without_clicking(running_bridge):
+    element = running_bridge.client.list_ui_elements()[1]
+    hovered = running_bridge.client.hover_element(id=element["id"])
+    assert hovered["ok"] is True
+    assert hovered["hovered"] is True
+    assert hovered["x"] == 60 and hovered["y"] == 50
+    assert running_bridge.renpy._moves == [(60, 50)]
+    assert running_bridge.renpy._clicks == []
+
+
+def test_hover_element_frame_guard_blocks_motion(running_bridge):
+    element = running_bridge.client.list_ui_elements()[1]
+    mismatch = running_bridge.client.hover_element(id=element["id"], expected_frame_id="0" * 64)
+    assert mismatch["ok"] is False
+    assert "expected_frame_id" in mismatch["error"]
+    assert running_bridge.renpy._moves == []
+
+
+def test_get_ui_element_bounds_non_imagebutton_reports_unavailable(running_bridge):
+    element = running_bridge.client.list_ui_elements()[0]
+    reply = running_bridge.client.get_ui_element_bounds(id=element["id"])
+    assert reply["ok"] is True
+    assert reply["focus_bounds"] == element["bounds"]
+    assert reply["painted_bounds"] is None
+    assert reply["painted_bounds_available"] is False
+    assert "ImageButton" in reply["painted_bounds_reason"]
+
+
+def test_get_ui_element_bounds_imagebutton_reports_painted_bounds(running_bridge):
+    element = running_bridge.client.list_ui_elements()[-1]
+    reply = running_bridge.client.get_ui_element_bounds(id=element["id"])
+    assert reply["ok"] is True
+    assert reply["focus_bounds"] == {"x": 200, "y": 100, "width": 100, "height": 30}
+    assert reply["painted_bounds"] == {"x": 204, "y": 106, "width": 80, "height": 14}
+    assert reply["painted_bounds_available"] is True
+    assert reply["painted_bounds_source"] == "rendered-alpha"
+    assert reply["state"] == "idle"
+
+
+def test_get_ui_element_bounds_frame_guard_blocks_lookup(running_bridge):
+    element = running_bridge.client.list_ui_elements()[-1]
+    mismatch = running_bridge.client.get_ui_element_bounds(
+        id=element["id"],
+        expected_frame_id="0" * 64,
+    )
+    assert mismatch["ok"] is False
+    assert "expected_frame_id" in mismatch["error"]
 
 
 def test_click_element_by_id_and_click_at_guards(running_bridge):

--- a/tests/test_image_ops.py
+++ b/tests/test_image_ops.py
@@ -201,6 +201,59 @@ def test_estimate_translation_finds_shifted_sprite() -> None:
     assert result["support"] == 100
 
 
+def test_estimate_translation_ignores_bright_transparent_padding() -> None:
+    image_module = pytest.importorskip("PIL.Image", reason="Pillow not installed")
+    from renforge.image_ops import estimate_translation
+
+    before = image_module.new("RGBA", (80, 60), (255, 255, 255, 0))
+    after = image_module.new("RGBA", (80, 60), (255, 255, 255, 0))
+    for x in range(10, 20):
+        for y in range(8, 18):
+            before.putpixel((x, y), (220, 40, 40, 255))
+    for x in range(13, 23):
+        for y in range(10, 20):
+            after.putpixel((x, y), (220, 40, 40, 255))
+
+    result = estimate_translation(before, after, max_shift=5)
+
+    assert result["available"] is True
+    assert (result["dx"], result["dy"]) == (3, 2)
+
+
+def test_estimate_translation_crops_to_active_bbox_on_large_canvas() -> None:
+    image_module = pytest.importorskip("PIL.Image", reason="Pillow not installed")
+    from renforge.image_ops import estimate_translation
+
+    before = image_module.new("L", (400, 300), 0)
+    after = image_module.new("L", (400, 300), 0)
+    before.paste(255, (40, 30, 52, 42))
+    after.paste(255, (45, 34, 57, 46))
+
+    result = estimate_translation(before, after, max_shift=8)
+
+    assert result["available"] is True
+    assert (result["dx"], result["dy"]) == (5, 4)
+
+
+def test_estimate_translation_rejects_excessive_work_budget() -> None:
+    image_module = pytest.importorskip("PIL.Image", reason="Pillow not installed")
+    from renforge import image_ops
+    from renforge.image_ops import estimate_translation
+
+    before = image_module.new("L", (500, 500), 0)
+    after = image_module.new("L", (500, 500), 0)
+    before.paste(255, (10, 10, 30, 30))
+    after.paste(255, (20, 20, 40, 40))
+
+    original_budget = image_ops._MAX_ESTIMATE_PIXEL_CHECKS
+    image_ops._MAX_ESTIMATE_PIXEL_CHECKS = 1_000
+    try:
+        with pytest.raises(ValueError, match="work budget"):
+            estimate_translation(before, after, max_shift=64)
+    finally:
+        image_ops._MAX_ESTIMATE_PIXEL_CHECKS = original_budget
+
+
 def test_diff_images_locates_the_changed_region() -> None:
     image_module = pytest.importorskip("PIL.Image", reason="Pillow not installed")
     from renforge.image_ops import diff_images

--- a/tests/test_image_ops.py
+++ b/tests/test_image_ops.py
@@ -185,6 +185,22 @@ def test_annotate_png_rejects_tiny_grid_spacing() -> None:
         annotate_png(_png(20, 10), grid=2)
 
 
+def test_estimate_translation_finds_shifted_sprite() -> None:
+    image_module = pytest.importorskip("PIL.Image", reason="Pillow not installed")
+    from renforge.image_ops import estimate_translation
+
+    before = image_module.new("L", (60, 40), 0)
+    after = image_module.new("L", (60, 40), 0)
+    before.paste(255, (10, 8, 20, 18))
+    after.paste(255, (13, 10, 23, 20))
+
+    result = estimate_translation(before, after, max_shift=5)
+
+    assert result["available"] is True
+    assert (result["dx"], result["dy"]) == (3, 2)
+    assert result["support"] == 100
+
+
 def test_diff_images_locates_the_changed_region() -> None:
     image_module = pytest.importorskip("PIL.Image", reason="Pillow not installed")
     from renforge.image_ops import diff_images

--- a/tests/test_integration_sdk.py
+++ b/tests/test_integration_sdk.py
@@ -51,11 +51,11 @@ def _add_hover_fixtures(demo_copy: Path) -> None:
 
     idle = image_module.new("RGBA", (100, 100), (0, 0, 0, 0))
     hover = image_module.new("RGBA", (100, 100), (0, 0, 0, 0))
-    for x in range(10, 60):
-        for y in range(10, 60):
+    for x in range(12, 36):
+        for y in range(12, 36):
             idle.putpixel((x, y), (220, 40, 40, 255))
-    for x in range(15, 65):
-        for y in range(13, 63):
+    for x in range(40, 64):
+        for y in range(34, 58):
             hover.putpixel((x, y), (220, 40, 40, 255))
     idle.save(images_dir / "renforge_sdk_idle.png")
     hover.save(images_dir / "renforge_sdk_hover.png")
@@ -509,11 +509,27 @@ def test_live_displayable_bounds_and_repositioning(sdk, demo_copy: Path) -> None
 
 
 @pytest.mark.skipif(not os.environ.get("DISPLAY"), reason="live bridge needs a display (set DISPLAY, or run under xvfb)")
-def test_live_imagebutton_hover_bounds_capture_and_translation(sdk, demo_copy: Path) -> None:
-    """Prove hover without click, painted bounds, named captures, and translation."""
+def test_live_imagebutton_hover_bounds_and_capture(sdk, demo_copy: Path) -> None:
+    """Exercise hover, painted bounds, and named captures on a real Ren'Py runtime.
+
+    Scope note (important): this SDK subprocess is driven by the bridge drain loop,
+    not a player-facing ``interact()`` loop. We can therefore prove:
+
+    - ``hover_element`` resolves the control and moves synthetic input without firing
+      the ImageButton action (no click).
+    - ``get_ui_element_bounds`` reaches ``renpy.render_to_surface`` and returns
+      alpha-painted bounds smaller than the focus rectangle.
+    - bridge screenshots can be persisted under ``.renforge/captures/``.
+
+    A full idle→hover *visual repaint* plus translation estimate on live frames is
+    intentionally out of scope here: ImageButton hover prefix is decided during
+    render, while screenshots are scaled by the host display (logical 1280×720 vs
+    physical PNG). That pipeline is covered by unit tests (``test_image_ops``,
+    ``test_bridge_runtime``) and by manual MCP runs against a long-lived game process.
+    """
     from renforge.bridge.launcher import launch_with_bridge
-    from renforge.image_ops import diff_images, estimate_translation
     from renforge.project import RenpyProject
+    from renforge.tools import live
 
     _add_hover_fixtures(demo_copy)
 
@@ -530,61 +546,29 @@ def test_live_imagebutton_hover_bounds_capture_and_translation(sdk, demo_copy: P
             time.sleep(0.25)
         assert ui_info is not None and ui_info.get("elements"), ui_info
 
-        button = next(
-            (
-                element
-                for element in ui_info["elements"]
-                if "imagebutton" in str(element.get("type", "")).casefold()
-                or "imagebutton" in str(element.get("role", "")).casefold()
-            ),
-            ui_info["elements"][0],
-        )
-        frame_id = ui_info["frame_id"]
+        button = ui_info["elements"][0]
         clicks_before = client.get_var("renforge_sdk_button_clicks")
 
-        idle_path = _save_capture(demo_copy, "sdk-idle", client.screenshot())
+        bounds = client.get_ui_element_bounds(id=button["id"])
+        assert bounds["ok"] is True, bounds
+        assert bounds["painted_bounds_available"] is True, bounds
+        assert bounds["painted_bounds_source"] == "rendered-alpha"
+        assert bounds["state"] == "idle"
+        focus = bounds["focus_bounds"]
+        painted = bounds["painted_bounds"]
+        assert painted["width"] <= focus["width"]
+        assert painted["height"] <= focus["height"]
 
-        hovered = client.hover_element(id=button["id"], expected_frame_id=frame_id)
+        capture_path = _save_capture(demo_copy, "sdk-idle", client.screenshot())
+        assert capture_path.is_file()
+        assert capture_path.parent == demo_copy / ".renforge" / "captures"
+
+        hovered = client.hover_element(id=button["id"])
         assert hovered["ok"] is True, hovered
         assert hovered.get("hovered") is True, hovered
+        assert hovered["method"] in {"renpy", "renpy-test", "pygame"}
         assert client.get_var("renforge_sdk_button_clicks") == clicks_before
 
-        client.eval_expr("renpy.restart_interaction()")
-        time.sleep(0.5)
-
-        bounds_idle = client.get_ui_element_bounds(id=button["id"], expected_frame_id=frame_id)
-        assert bounds_idle["ok"] is True, bounds_idle
-        assert bounds_idle["focus_bounds"]["width"] > 0
-        if bounds_idle.get("painted_bounds_available"):
-            painted = bounds_idle["painted_bounds"]
-            focus = bounds_idle["focus_bounds"]
-            assert painted["width"] <= focus["width"]
-            assert painted["height"] <= focus["height"]
-
-        hover_path = _save_capture(demo_copy, "sdk-hover", client.screenshot())
-        assert idle_path.is_file() and hover_path.is_file()
-
-        diff = diff_images(idle_path, hover_path, threshold=16)
-        assert diff["changed"] is True, diff
-
-        region = bounds_idle.get("painted_bounds") or bounds_idle["focus_bounds"]
-        estimate = estimate_translation(
-            idle_path,
-            hover_path,
-            region=(
-                region["x"],
-                region["y"],
-                region["width"],
-                region["height"],
-            ),
-            threshold=16,
-            max_shift=16,
-        )
-        assert estimate["ok"] is True, estimate
-        if estimate.get("available"):
-            assert abs(estimate["dx"]) <= 16
-            assert abs(estimate["dy"]) <= 16
-
-        errors = client.get_errors()
+        errors = live.get_errors(str(demo_copy))
         assert errors.get("ok") is True, errors
-        assert not errors.get("errors"), errors
+        assert not errors.get("events"), errors

--- a/tests/test_integration_sdk.py
+++ b/tests/test_integration_sdk.py
@@ -42,6 +42,70 @@ def demo_copy(tmp_path: Path) -> Path:
     return destination
 
 
+def _add_hover_fixtures(demo_copy: Path) -> None:
+    """Add an ImageButton screen and offset idle/hover sprites for SDK E2E."""
+    image_module = pytest.importorskip("PIL.Image", reason="Pillow not installed")
+
+    images_dir = demo_copy / "game" / "images"
+    images_dir.mkdir(parents=True, exist_ok=True)
+
+    idle = image_module.new("RGBA", (100, 100), (0, 0, 0, 0))
+    hover = image_module.new("RGBA", (100, 100), (0, 0, 0, 0))
+    for x in range(10, 60):
+        for y in range(10, 60):
+            idle.putpixel((x, y), (220, 40, 40, 255))
+    for x in range(15, 65):
+        for y in range(13, 63):
+            hover.putpixel((x, y), (220, 40, 40, 255))
+    idle.save(images_dir / "renforge_sdk_idle.png")
+    hover.save(images_dir / "renforge_sdk_hover.png")
+
+    fixture = demo_copy / "game" / "renforge_sdk_fixtures.rpy"
+    existing = fixture.read_text(encoding="utf-8") if fixture.exists() else ""
+    if "renforge_sdk_imagebutton_fixture" not in existing:
+        fixture.write_text(
+            existing
+            + '''
+
+default renforge_sdk_button_clicks = 0
+
+screen renforge_sdk_imagebutton_fixture():
+    modal True
+    zorder 200
+    key "dismiss" action NullAction()
+    frame:
+        xalign 0.5
+        yalign 0.5
+        background None
+        imagebutton:
+            idle "renforge_sdk_idle"
+            hover "renforge_sdk_hover"
+            action SetVariable("renforge_sdk_button_clicks", renforge_sdk_button_clicks + 1)
+''',
+            encoding="utf-8",
+        )
+
+
+def _save_capture(project_root: Path, name: str, png: bytes) -> Path:
+    import hashlib
+    import os
+    import tempfile
+
+    capture_dir = project_root / ".renforge" / "captures"
+    capture_dir.mkdir(parents=True, exist_ok=True)
+    target = (capture_dir / f"{name}.png").resolve()
+    target.relative_to(capture_dir.resolve())
+    with tempfile.NamedTemporaryFile(dir=capture_dir, suffix=".tmp", delete=False) as handle:
+        temporary = Path(handle.name)
+        handle.write(png)
+    try:
+        os.replace(temporary, target)
+    finally:
+        temporary.unlink(missing_ok=True)
+    assert hashlib.sha256(png).hexdigest()
+    return target
+
+
 def _add_sdk_fixtures(demo_copy: Path) -> dict[str, str]:
     """Add opt-in-only runtime fixtures without changing the public demo.
 
@@ -442,3 +506,85 @@ def test_live_displayable_bounds_and_repositioning(sdk, demo_copy: Path) -> None
         diff = diff_images(before_png, after_png, threshold=16)
         assert diff["changed"] is True, diff
         assert diff["bounds"] is not None, diff
+
+
+@pytest.mark.skipif(not os.environ.get("DISPLAY"), reason="live bridge needs a display (set DISPLAY, or run under xvfb)")
+def test_live_imagebutton_hover_bounds_capture_and_translation(sdk, demo_copy: Path) -> None:
+    """Prove hover without click, painted bounds, named captures, and translation."""
+    from renforge.bridge.launcher import launch_with_bridge
+    from renforge.image_ops import diff_images, estimate_translation
+    from renforge.project import RenpyProject
+
+    _add_hover_fixtures(demo_copy)
+
+    with launch_with_bridge(sdk, RenpyProject(demo_copy), startup_timeout=90) as session:
+        client = session.client
+        client.eval_expr('renpy.show_screen("renforge_sdk_imagebutton_fixture")')
+        client.eval_expr("renpy.restart_interaction()")
+
+        ui_info = None
+        for _ in range(40):
+            ui_info = client.list_ui_elements_info()
+            if ui_info.get("elements"):
+                break
+            time.sleep(0.25)
+        assert ui_info is not None and ui_info.get("elements"), ui_info
+
+        button = next(
+            (
+                element
+                for element in ui_info["elements"]
+                if "imagebutton" in str(element.get("type", "")).casefold()
+                or "imagebutton" in str(element.get("role", "")).casefold()
+            ),
+            ui_info["elements"][0],
+        )
+        frame_id = ui_info["frame_id"]
+        clicks_before = client.get_var("renforge_sdk_button_clicks")
+
+        idle_path = _save_capture(demo_copy, "sdk-idle", client.screenshot())
+
+        hovered = client.hover_element(id=button["id"], expected_frame_id=frame_id)
+        assert hovered["ok"] is True, hovered
+        assert hovered.get("hovered") is True, hovered
+        assert client.get_var("renforge_sdk_button_clicks") == clicks_before
+
+        client.eval_expr("renpy.restart_interaction()")
+        time.sleep(0.5)
+
+        bounds_idle = client.get_ui_element_bounds(id=button["id"], expected_frame_id=frame_id)
+        assert bounds_idle["ok"] is True, bounds_idle
+        assert bounds_idle["focus_bounds"]["width"] > 0
+        if bounds_idle.get("painted_bounds_available"):
+            painted = bounds_idle["painted_bounds"]
+            focus = bounds_idle["focus_bounds"]
+            assert painted["width"] <= focus["width"]
+            assert painted["height"] <= focus["height"]
+
+        hover_path = _save_capture(demo_copy, "sdk-hover", client.screenshot())
+        assert idle_path.is_file() and hover_path.is_file()
+
+        diff = diff_images(idle_path, hover_path, threshold=16)
+        assert diff["changed"] is True, diff
+
+        region = bounds_idle.get("painted_bounds") or bounds_idle["focus_bounds"]
+        estimate = estimate_translation(
+            idle_path,
+            hover_path,
+            region=(
+                region["x"],
+                region["y"],
+                region["width"],
+                region["height"],
+            ),
+            threshold=16,
+            max_shift=16,
+        )
+        assert estimate["ok"] is True, estimate
+        if estimate.get("available"):
+            assert abs(estimate["dx"]) <= 16
+            assert abs(estimate["dy"]) <= 16
+
+        errors = client.get_errors()
+        assert errors.get("ok") is True, errors
+        assert not errors.get("errors"), errors

--- a/tests/test_integration_sdk.py
+++ b/tests/test_integration_sdk.py
@@ -521,11 +521,8 @@ def test_live_imagebutton_hover_bounds_and_capture(sdk, demo_copy: Path) -> None
       alpha-painted bounds smaller than the focus rectangle.
     - bridge screenshots can be persisted under ``.renforge/captures/``.
 
-    A full idle→hover *visual repaint* plus translation estimate on live frames is
-    intentionally out of scope here: ImageButton hover prefix is decided during
-    render, while screenshots are scaled by the host display (logical 1280×720 vs
-    physical PNG). That pipeline is covered by unit tests (``test_image_ops``,
-    ``test_bridge_runtime``) and by manual MCP runs against a long-lived game process.
+    The idle→hover repaint and painted-bounds translation on real frames are covered
+    by :func:`test_live_imagebutton_idle_hover_pipeline`.
     """
     from renforge.bridge.launcher import launch_with_bridge
     from renforge.project import RenpyProject
@@ -568,6 +565,88 @@ def test_live_imagebutton_hover_bounds_and_capture(sdk, demo_copy: Path) -> None
         assert hovered.get("hovered") is True, hovered
         assert hovered["method"] in {"renpy", "renpy-test", "pygame"}
         assert client.get_var("renforge_sdk_button_clicks") == clicks_before
+
+        errors = live.get_errors(str(demo_copy))
+        assert errors.get("ok") is True, errors
+        assert not errors.get("events"), errors
+
+
+@pytest.mark.skipif(not os.environ.get("DISPLAY"), reason="live bridge needs a display (set DISPLAY, or run under xvfb)")
+def test_live_imagebutton_idle_hover_pipeline(sdk, demo_copy: Path) -> None:
+    """Run the MCP idle→hover workflow on a real Ren'Py ImageButton.
+
+    Mirrors the agent recipe documented in ``docs/MCP.md``:
+
+    1. list UI + read ``painted_bounds`` while idle
+    2. persist an idle capture
+    3. ``hover_element`` without clicking
+    4. read ``painted_bounds`` again (hover state) and derive the logical shift
+    5. persist a hover capture and diff the frames
+    6. run ``estimate_translation`` on the fixture art (file-based MCP tool path)
+
+    Ren'Py scales screenshots (logical UI vs physical PNG), so the overlap
+    estimator can be ambiguous on live captures even when the bridge reports an
+    exact shift through ``painted_bounds``. Agents should prefer the bounds delta
+    for UI alignment and reserve ``estimate_translation`` for named PNG captures.
+    """
+    from renforge.bridge.launcher import launch_with_bridge
+    from renforge.image_ops import diff_images, estimate_translation
+    from renforge.project import RenpyProject
+    from renforge.tools import live
+
+    _add_hover_fixtures(demo_copy)
+    images_dir = demo_copy / "game" / "images"
+
+    with launch_with_bridge(sdk, RenpyProject(demo_copy), startup_timeout=90) as session:
+        client = session.client
+        client.eval_expr('renpy.show_screen("renforge_sdk_imagebutton_fixture")')
+        client.eval_expr("renpy.restart_interaction()")
+
+        ui_info = None
+        for _ in range(40):
+            ui_info = client.list_ui_elements_info()
+            if ui_info.get("elements"):
+                break
+            time.sleep(0.25)
+        assert ui_info is not None and ui_info.get("elements"), ui_info
+
+        button = ui_info["elements"][0]
+        clicks_before = client.get_var("renforge_sdk_button_clicks")
+
+        bounds_idle = client.get_ui_element_bounds(id=button["id"])
+        assert bounds_idle["ok"] is True, bounds_idle
+        assert bounds_idle["state"] == "idle"
+
+        idle_path = _save_capture(demo_copy, "pipeline-idle", client.screenshot())
+
+        hovered = client.hover_element(id=button["id"])
+        assert hovered["ok"] is True, hovered
+        assert client.get_var("renforge_sdk_button_clicks") == clicks_before
+
+        bounds_hover = client.get_ui_element_bounds(id=button["id"])
+        assert bounds_hover["ok"] is True, bounds_hover
+        assert bounds_hover["state"] == "hover"
+
+        painted_idle = bounds_idle["painted_bounds"]
+        painted_hover = bounds_hover["painted_bounds"]
+        assert painted_idle is not None and painted_hover is not None
+        assert (painted_hover["x"] - painted_idle["x"], painted_hover["y"] - painted_idle["y"]) == (28, 22)
+
+        hover_path = _save_capture(demo_copy, "pipeline-hover", client.screenshot())
+        diff = diff_images(idle_path, hover_path, threshold=16)
+        assert diff["changed"] is True, diff
+        assert diff.get("changed_pixels", 0) > 100
+
+        estimate = estimate_translation(
+            images_dir / "renforge_sdk_idle.png",
+            images_dir / "renforge_sdk_hover.png",
+            region=(0, 0, 100, 100),
+            threshold=16,
+            max_shift=40,
+        )
+        assert estimate["ok"] is True, estimate
+        assert estimate.get("available") is True, estimate
+        assert (estimate["dx"], estimate["dy"]) == (28, 22)
 
         errors = live.get_errors(str(demo_copy))
         assert errors.get("ok") is True, errors

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -32,7 +32,11 @@ EXPECTED_TOOLS = {
     "renforge_select_choice",
     "renforge_list_ui_elements",
     "renforge_click_element",
+    "renforge_hover_element",
+    "renforge_get_ui_element_bounds",
     "renforge_click_at",
+    "renforge_capture_screenshot",
+    "renforge_estimate_translation",
     "renforge_eval",
     "renforge_get_var",
     "renforge_set_var",
@@ -747,11 +751,26 @@ def test_ui_tools_expose_semantic_elements_and_coordinate_guards(tmp_path, monke
         calls["element"] = (path, kwargs)
         return {"ok": True, "id": kwargs["element_id"], "x": 60, "y": 50}
 
+    def fake_hover_element(path, **kwargs):
+        calls["hover"] = (path, kwargs)
+        return {"ok": True, "hovered": True, "id": kwargs["element_id"], "x": 60, "y": 50}
+
+    def fake_get_ui_element_bounds(path, **kwargs):
+        calls["bounds"] = (path, kwargs)
+        return {
+            "ok": True,
+            "focus_bounds": {"x": 20, "y": 30, "width": 80, "height": 40},
+            "painted_bounds": {"x": 24, "y": 34, "width": 72, "height": 32},
+            "painted_bounds_available": True,
+        }
+
     def fake_click_at(path, x, y, **kwargs):
         calls["at"] = (path, x, y, kwargs)
         return {"ok": True, "x": x, "y": y}
 
     monkeypatch.setattr(live, "click_element", fake_click_element)
+    monkeypatch.setattr(live, "hover_element", fake_hover_element)
+    monkeypatch.setattr(live, "get_ui_element_bounds", fake_get_ui_element_bounds)
     monkeypatch.setattr(live, "click_at", fake_click_at)
 
     async def _call():
@@ -761,6 +780,14 @@ def test_ui_tools_expose_semantic_elements_and_coordinate_guards(tmp_path, monke
             )
             clicked = await client.call_tool(
                 "renforge_click_element",
+                {
+                    "project_path": str(tmp_path),
+                    "element_id": "save-1",
+                    "expected_frame_id": "frame-1",
+                },
+            )
+            bounds = await client.call_tool(
+                "renforge_get_ui_element_bounds",
                 {
                     "project_path": str(tmp_path),
                     "element_id": "save-1",
@@ -778,16 +805,20 @@ def test_ui_tools_expose_semantic_elements_and_coordinate_guards(tmp_path, monke
                     "coordinate_space": "screenshot",
                 },
             )
-            return listed, clicked, by_coord
+            return listed, clicked, bounds, by_coord
 
-    listed, clicked, by_coord = asyncio.run(_call())
+    listed, clicked, bounds, by_coord = asyncio.run(_call())
     listed_payload = json.loads(next(block.text for block in listed.content if block.type == "text"))
     clicked_payload = json.loads(next(block.text for block in clicked.content if block.type == "text"))
+    bounds_payload = json.loads(next(block.text for block in bounds.content if block.type == "text"))
     coord_payload = json.loads(next(block.text for block in by_coord.content if block.type == "text"))
     assert listed_payload["elements"][0]["bounds"]["width"] == 80
     assert clicked_payload == {"ok": True, "id": "save-1", "x": 60, "y": 50}
+    assert bounds_payload["painted_bounds_available"] is True
+    assert bounds_payload["painted_bounds"]["width"] == 72
     assert coord_payload == {"ok": True, "x": 60, "y": 50}
     assert calls["element"][1]["expected_frame_id"] == "frame-1"
+    assert calls["bounds"][1]["expected_frame_id"] == "frame-1"
     assert calls["at"][3]["expected_state"] == {"menu": True}
     assert calls["at"][3]["coordinate_space"] == "screenshot"
 


### PR DESCRIPTION
## Résumé

Cette PR ajoute les primitives MCP RenForge demandées pour accélérer le diagnostic d’alignement **idle → hover** sur les `imagebutton`, sans OpenCV. Le workflow agent peut désormais survoler sans cliquer, persister des captures réutilisables, mesurer le décalage visuel et lire les bounds réellement peints d’un contrôle UI.

## Nouveaux outils MCP

| Outil | Rôle |
|-------|------|
| `renforge_hover_element` | Déplace le pointeur sur un contrôle (texte ou `element_id`) **sans clic**, avec garde `expected_frame_id` |
| `renforge_capture_screenshot` | Persiste un PNG nommé sous `<project>/.renforge/captures/` (chemin exploitable par diff/translation) |
| `renforge_estimate_translation` | Estime `dx`/`dy` entre deux PNG via Pillow, avec `confidence` / `available` |
| `renforge_get_ui_element_bounds` | Retourne `focus_bounds` + `painted_bounds` (alpha rendu) pour les `ImageButton` |

`renforge_screenshot` conserve son contrat image MCP inchangé.

## Correctif bridge (hover réel)

Le hover ImageButton Ren’Py passe par `focus.mouse_handler` lors d’un `MOUSEMOTION`, pas seulement par la position pygame. Le bridge appelle maintenant :

1. `renpy.test.testmouse.move_mouse`
2. `renpy.display.focus.mouse_handler`
3. `renpy.restart_interaction`

Cela permet au prefix `hover_` de s’appliquer même sans boucle `interact()` joueur.

## Workflow agent documenté

`docs/MCP.md` décrit la séquence idle→hover :

```text
list_ui_elements → get_ui_element_bounds (idle) → capture idle
→ re-list (frame_id invalidé) → hover_element → get_ui_element_bounds (hover)
→ capture hover → estimate_translation (sur PNG nommés)
```

**Recommandation :** préférer le delta `painted_bounds` (pixels logiques exacts) pour l’alignement UI ; réserver `estimate_translation` aux captures PNG nommées.

## Tests

- **Unitaires / fake bridge :** hover sans clic, painted bounds, translation Pillow, wire client/server
- **SDK E2E** (`RENFORGE_SDK_TESTS=1`) :
  - `test_live_imagebutton_hover_bounds_and_capture`
  - `test_live_imagebutton_idle_hover_pipeline` (shift logique `(28, 22)`, diff visuel, estimate sur art fixture)

```bash
pytest -q                                    # 171 passed, 66 skipped
RENFORGE_SDK_TESTS=1 pytest -q -k imagebutton  # 2 passed
```

## Fichiers principaux

- `src/renforge/bridge/bridge.rpy` — hover, `get_ui_element_bounds`, helper `Rect`
- `src/renforge/server.py` / `tools/live.py` / `bridge/client.py` — exposition MCP
- `src/renforge/image_ops.py` — `estimate_translation`
- `docs/MCP.md` — catalogue + workflow idle/hover
- `tests/test_*` — couverture bridge, server, image_ops, integration SDK

## Hors scope

- Pas de commit des assets non trackés (`assets/`)
- Validation E2E sur le `quick_menu` du demo (textbuttons, pas imagebuttons) — fixture SDK dédiée à la place

## Checklist

- [x] Tests unitaires passent
- [x] Tests SDK imagebutton passent (DISPLAY requis)
- [x] `git diff --check` propre
- [x] Documentation MCP mise à jour
- [ ] Review humaine