### PR TITLE
fix(runtime): isolate SDK and bridge sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable RenForge releases are recorded here. Versions follow semantic
 versioning.
 
+## [0.6.6] - 2026-07-24
+
+### Fixed
+
+- Runtime discovery now prefers validated project-local Ren'Py SDKs and safely
+  falls back to compatible managed SDKs with locked, atomic cache repair.
+- Concurrent RenForge servers now isolate bridge ownership per project,
+  preserve dashboard-owned sessions, and retain locks through incomplete
+  teardown so one launch cannot overwrite another session's artifacts.
+
 ## [0.6.5] - 2026-07-21
 
 ### Fixed

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -51,11 +51,13 @@ fresh process at the project's `start` label through that same path.
 
 ## Ren'Py SDK resolution
 
-RenForge does not require a pre-installed Ren'Py. `sdk.py` discovers an
-existing SDK (`RENPY_SDK_HOME`, `~/.renpy`, `~/.cache/renpy`,
-`~/.local/share/renpy`, …) or downloads the pinned stable version into
-`~/.cache/renforge/sdks/` on first launch. Override with `RENPY_SDK_HOME` or
-`RENPY_SDK_STABLE_VERSION`.
+RenForge does not require a pre-installed Ren'Py. `sdk.py` first checks
+conventional SDK locations inside the detected project and uses one only when
+its launcher and version are compatible. It then checks the explicit
+`RENPY_SDK_HOME` override before falling back to the managed
+`~/.cache/renforge/sdks/` cache. Missing or invalid cached SDKs are installed
+under an inter-process lock and published atomically. Override the stable
+version with `RENPY_SDK_STABLE_VERSION`.
 
 ## Packaging
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "renforge"
-version = "0.6.5"
+version = "0.6.6"
 description = "MCP server, CLI, and web dashboard for Ren'Py visual-novel development"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/renforge/__init__.py
+++ b/src/renforge/__init__.py
@@ -1,4 +1,4 @@
 """RenForge package."""
 
-__version__ = "0.6.5"
+__version__ = "0.6.6"
 __all__ = ["__version__"]

--- a/src/renforge/bridge/launcher.py
+++ b/src/renforge/bridge/launcher.py
@@ -8,6 +8,8 @@ the game and removes the injected file.
 
 from __future__ import annotations
 
+import errno
+import json
 import os
 import secrets
 import shutil
@@ -35,13 +37,98 @@ _INJECTED_NAME: str = "renforge_bridge.rpy"
 _SESSION_INIT_NAME: str = "00renforge_session.rpy"
 
 
+class ProjectBridgeLock:
+    """A non-blocking, process-wide lock for one project's bridge artifacts."""
+
+    def __init__(self, path: Path):
+        self.path = path
+        self._file: Any | None = None
+        self.is_deferred = False
+
+    def acquire(self) -> None:
+        if self._file is not None:
+            return
+        try:
+            self.path.parent.mkdir(parents=True, exist_ok=True)
+            lock_file = self.path.open("a+b")
+        except OSError as exc:
+            raise LaunchError(
+                "BRIDGE_PROJECT_LOCK_FAILED",
+                f"Could not open the project bridge lock: {exc}",
+                phase="acquiring_project_lock",
+                suggested_fix="Check write permissions under .renforge/.",
+            ) from exc
+        try:
+            self._lock_file(lock_file)
+        except OSError as exc:
+            try:
+                lock_file.close()
+            except OSError:
+                pass
+            if exc.errno in {errno.EACCES, errno.EAGAIN}:
+                raise LaunchError(
+                    "BRIDGE_PROJECT_LOCKED",
+                    f"Another RenForge bridge session is active for {self.path.parent.parent}.",
+                    phase="acquiring_project_lock",
+                    suggested_fix="Stop the existing session before launching another for this project.",
+                ) from exc
+            raise LaunchError(
+                "BRIDGE_PROJECT_LOCK_FAILED",
+                f"Could not lock the project bridge: {exc}",
+                phase="acquiring_project_lock",
+                suggested_fix="Check write permissions under .renforge/.",
+            ) from exc
+        self._file = lock_file
+
+    def release(self) -> None:
+        if self._file is None:
+            return
+        lock_file, self._file = self._file, None
+        try:
+            self._unlock_file(lock_file)
+        finally:
+            lock_file.close()
+
+    @staticmethod
+    def _lock_file(lock_file: Any) -> None:
+        if os.name == "nt":
+            import msvcrt
+
+            lock_file.seek(0)
+            if not lock_file.read(1):
+                lock_file.write(b"\0")
+                lock_file.flush()
+            lock_file.seek(0)
+            msvcrt.locking(lock_file.fileno(), msvcrt.LK_NBLCK, 1)
+            return
+
+        import fcntl
+
+        fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+
+    @staticmethod
+    def _unlock_file(lock_file: Any) -> None:
+        if os.name == "nt":
+            import msvcrt
+
+            lock_file.seek(0)
+            msvcrt.locking(lock_file.fileno(), msvcrt.LK_UNLCK, 1)
+            return
+
+        import fcntl
+
+        fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+
+
+_DEFERRED_LOCKS: set[ProjectBridgeLock] = set()
+
+
 def remove_bridge_artifacts(project_root: Path) -> None:
     """Delete every file the bridge injects or leaves behind on ``project_root``.
 
-    Safe to call more than once and whether or not the game is running; missing
-    files are ignored. Shared by :meth:`BridgeSession.close` and the
-    cross-process stop path so a session torn down from another process cleans
-    up the same set of files.
+    The caller must hold the project's :class:`ProjectBridgeLock` unless this is
+    a legacy maintenance or test cleanup. Missing files are ignored, so cleanup
+    remains idempotent.
     """
     game_dir = project_root / "game"
     for path in (
@@ -107,6 +194,7 @@ class BridgeSession:
         environment: dict[str, Any] | None = None,
         startup_ms: int | None = None,
         phases: list[dict[str, Any]] | None = None,
+        project_lock: ProjectBridgeLock | None = None,
     ):
         self.process = process
         self.client = client
@@ -119,6 +207,10 @@ class BridgeSession:
         self.phases = phases or []
         self._project_root = project_root
         self._cleaned: dict[str, Any] = {}
+        self._project_lock = project_lock
+        self._close_lock = threading.Lock()
+        self._closed = False
+        self._close_result: dict[str, Any] | None = None
 
     def __enter__(self) -> "BridgeSession":
         return self
@@ -126,8 +218,27 @@ class BridgeSession:
     def __exit__(self, *_exc) -> None:
         self.close()
 
+    @property
+    def closed(self) -> bool:
+        """Whether teardown completed and project ownership was released."""
+        return self._closed
+
     def close(self, timeout: float = 10.0) -> dict[str, Any]:
         """Stop the game, Xvfb group if any, and temporary session files."""
+        with self._close_lock:
+            if self._closed:
+                return self._close_result or {"cleaned": self._cleaned, "failed": ["close"]}
+            self._close_result = self._close_resources(timeout)
+            ownership_failures = {"process_alive", "bridge_artifacts", "temporary_savedir"}
+            if ownership_failures.intersection(self._close_result.get("failed", [])):
+                return self._close_result
+            if self._project_lock is not None:
+                self._project_lock.release()
+                self._project_lock = None
+            self._closed = True
+            return self._close_result
+
+    def _close_resources(self, timeout: float) -> dict[str, Any]:
         cleaned: dict[str, Any] = {
             "renpy_process": False,
             "process_group": False,
@@ -144,23 +255,25 @@ class BridgeSession:
                 try:
                     os.killpg(os.getpgid(self.process.pid), signal.SIGKILL)
                     cleaned["process_group"] = True
-                    cleaned["renpy_process"] = True
                 except (ProcessLookupError, PermissionError):
                     try:
                         self.process.kill()
-                        cleaned["renpy_process"] = True
                     except Exception:
                         failed.append("renpy_process")
             else:
                 try:
                     self.process.kill()
-                    cleaned["renpy_process"] = True
                 except Exception:
                     failed.append("renpy_process")
             try:
                 self.process.wait(timeout=timeout)
             except Exception:
                 failed.append("renpy_wait")
+            if self.process.poll() is None:
+                failed.append("process_alive")
+                self._cleaned = cleaned
+                return {"cleaned": cleaned, "failed": failed}
+            cleaned["renpy_process"] = True
         else:
             # Already exited: reap it so it does not linger as a zombie.
             try:
@@ -200,10 +313,11 @@ def _raise_if_cancelled(cancel_event: threading.Event | None, *, phase: str) -> 
         )
 
 
-def launch_with_bridge(
+def _launch_after_project_lock(
     sdk: RenpySdk,
     project: RenpyProject,
     *,
+    project_lock: ProjectBridgeLock,
     token: str | None = None,
     port: int = 0,
     warp: str | None = None,
@@ -358,6 +472,10 @@ def launch_with_bridge(
                 )
             if info_path.exists():
                 try:
+                    manifest = json.loads(info_path.read_text(encoding="utf-8"))
+                    if not isinstance(manifest, dict) or manifest.get("token") != token:
+                        time.sleep(0.3)
+                        continue
                     client = BridgeClient.from_project(project.root)
                     reply = client.ping()
                     if not isinstance(reply, dict) or reply.get("pong") is not True:
@@ -386,27 +504,37 @@ def launch_with_bridge(
                         environment=capabilities.to_dict(),
                         startup_ms=startup_ms,
                         phases=phases,
+                        project_lock=project_lock,
                     )
                 except Exception:
                     pass  # bridge.json not fully written yet, retry
             time.sleep(0.3)
     except LaunchError:
-        _terminate(process, headless)
-        remove_bridge_artifacts(project.root)
-        if cleanup_savedir and temporary_savedir is not None:
-            shutil.rmtree(temporary_savedir, ignore_errors=True)
+        _teardown_failed_launch(
+            process,
+            headless,
+            project.root,
+            temporary_savedir if cleanup_savedir else None,
+            project_lock,
+        )
         raise
     except BaseException:
-        _terminate(process, headless)
-        remove_bridge_artifacts(project.root)
-        if cleanup_savedir and temporary_savedir is not None:
-            shutil.rmtree(temporary_savedir, ignore_errors=True)
+        _teardown_failed_launch(
+            process,
+            headless,
+            project.root,
+            temporary_savedir if cleanup_savedir else None,
+            project_lock,
+        )
         raise
 
-    _terminate(process, headless)
-    remove_bridge_artifacts(project.root)
-    if cleanup_savedir and temporary_savedir is not None:
-        shutil.rmtree(temporary_savedir, ignore_errors=True)
+    _teardown_failed_launch(
+        process,
+        headless,
+        project.root,
+        temporary_savedir if cleanup_savedir else None,
+        project_lock,
+    )
     raise LaunchError(
         "BRIDGE_CONNECTION_TIMEOUT",
         f"Bridge did not come up within {startup_timeout}s",
@@ -416,19 +544,147 @@ def launch_with_bridge(
     )
 
 
-def _terminate(process: subprocess.Popen, headless: bool) -> None:
-    """Terminate the launched process; in headless mode, its whole group.
+def launch_with_bridge(
+    sdk: RenpySdk,
+    project: RenpyProject,
+    *,
+    token: str | None = None,
+    port: int = 0,
+    warp: str | None = None,
+    startup_timeout: float = 90.0,
+    cancel_event: threading.Event | None = None,
+    extra_env: dict[str, str] | None = None,
+    display: str = "auto",
+    audio: str = "auto",
+    savedir: str | None = None,
+    persistent: str = "existing",
+    cleanup_on_stop: bool = True,
+    preferences: str = "existing",
+) -> BridgeSession:
+    """Launch a bridge while exclusively owning this project's artifacts."""
+    project_lock = ProjectBridgeLock(project.root / ".renforge" / "bridge.lock")
+    project_lock.acquire()
+    try:
+        remove_bridge_artifacts(project.root)
+        session = _launch_after_project_lock(
+            sdk,
+            project,
+            project_lock=project_lock,
+            token=token,
+            port=port,
+            warp=warp,
+            startup_timeout=startup_timeout,
+            cancel_event=cancel_event,
+            extra_env=extra_env,
+            display=display,
+            audio=audio,
+            savedir=savedir,
+            persistent=persistent,
+            cleanup_on_stop=cleanup_on_stop,
+            preferences=preferences,
+        )
+        return session
+    except BaseException:
+        if project_lock.is_deferred:
+            raise
+        try:
+            remove_bridge_artifacts(project.root)
+        finally:
+            project_lock.release()
+        raise
+
+
+def _terminate(process: subprocess.Popen, headless: bool, timeout: float = 1.0) -> bool:
+    """Stop a process with bounded TERM/KILL escalation and confirm its death.
 
     Under ``xvfb-run`` the tracked process is the wrapper — signalling it alone
     would orphan the game and the Xvfb server.
     """
+    if process.poll() is not None:
+        try:
+            process.wait(timeout=0)
+        except Exception:
+            pass
+        return process.poll() is not None
+
+    _signal_process(process, headless, force=False)
+    try:
+        process.wait(timeout=timeout)
+    except Exception:
+        pass
+    if process.poll() is not None:
+        return True
+
+    _signal_process(process, headless, force=True)
+    try:
+        process.wait(timeout=timeout)
+    except Exception:
+        pass
+    return process.poll() is not None
+
+
+def _signal_process(process: subprocess.Popen, headless: bool, *, force: bool) -> None:
     if headless:
         try:
-            os.killpg(os.getpgid(process.pid), signal.SIGTERM)
+            signal_number = signal.SIGKILL if force else signal.SIGTERM
+            os.killpg(os.getpgid(process.pid), signal_number)
             return
         except (ProcessLookupError, PermissionError):
             pass
-    process.terminate()
+    try:
+        process.kill() if force else process.terminate()
+    except Exception:
+        pass
 
 
-__all__ = ["BridgeSession", "launch_with_bridge", "remove_bridge_artifacts"]
+def _teardown_failed_launch(
+    process: subprocess.Popen,
+    headless: bool,
+    project_root: Path,
+    temporary_savedir: Path | None,
+    project_lock: ProjectBridgeLock,
+) -> None:
+    if _terminate(process, headless):
+        try:
+            remove_bridge_artifacts(project_root)
+            if temporary_savedir is not None:
+                shutil.rmtree(temporary_savedir, ignore_errors=False)
+            return
+        except FileNotFoundError:
+            return
+        except Exception:
+            pass
+
+    project_lock.is_deferred = True
+    _DEFERRED_LOCKS.add(project_lock)
+
+    def reap() -> None:
+        while process.poll() is None:
+            try:
+                process.wait(timeout=1.0)
+            except Exception:
+                time.sleep(0.1)
+        while True:
+            try:
+                remove_bridge_artifacts(project_root)
+                if temporary_savedir is not None:
+                    shutil.rmtree(temporary_savedir, ignore_errors=False)
+                project_lock.release()
+                _DEFERRED_LOCKS.discard(project_lock)
+                return
+            except FileNotFoundError:
+                project_lock.release()
+                _DEFERRED_LOCKS.discard(project_lock)
+                return
+            except Exception:
+                time.sleep(0.1)
+
+    threading.Thread(target=reap, name="renforge-bridge-reaper", daemon=True).start()
+
+
+__all__ = [
+    "BridgeSession",
+    "ProjectBridgeLock",
+    "launch_with_bridge",
+    "remove_bridge_artifacts",
+]

--- a/src/renforge/dashboard_client.py
+++ b/src/renforge/dashboard_client.py
@@ -12,14 +12,7 @@ from urllib.request import Request, urlopen
 from .session_registry import dashboard_connection
 
 
-def launch_game(
-    project_path: str,
-    *,
-    version: str = "stable",
-    warp: str | None = None,
-) -> dict[str, Any] | None:
-    """Launch through the active dashboard, or return ``None`` when unavailable."""
-
+def _post(project_path: str, route: str, body: dict[str, Any]) -> dict[str, Any] | None:
     connection = dashboard_connection()
     if not connection:
         return None
@@ -31,12 +24,11 @@ def launch_game(
     if Path(selected_project).expanduser().resolve() != Path(project_path).expanduser().resolve():
         return None
 
-    endpoint = urljoin(url.rstrip("/") + "/", "api/live/launch")
+    endpoint = urljoin(url.rstrip("/") + "/", route)
     endpoint = f"{endpoint}?{urlencode({'token': token})}"
-    body = json.dumps({"version": version, "warp": warp}).encode("utf-8")
     request = Request(
         endpoint,
-        data=body,
+        data=json.dumps(body).encode("utf-8"),
         headers={"Content-Type": "application/json"},
         method="POST",
     )
@@ -51,4 +43,23 @@ def launch_game(
     return payload
 
 
-__all__ = ["launch_game"]
+def launch_game(
+    project_path: str,
+    *,
+    version: str = "stable",
+    warp: str | None = None,
+) -> dict[str, Any] | None:
+    """Launch through the active dashboard, or return ``None`` when unavailable."""
+    return _post(
+        project_path,
+        "api/live/launch",
+        {"version": version, "warp": warp},
+    )
+
+
+def stop_game(project_path: str) -> dict[str, Any] | None:
+    """Stop through the active dashboard, or return ``None`` when unavailable."""
+    return _post(project_path, "api/live/stop", {})
+
+
+__all__ = ["launch_game", "stop_game"]

--- a/src/renforge/lint.py
+++ b/src/renforge/lint.py
@@ -168,7 +168,7 @@ def run_lint(project_root: str | Path, *, version: str = "stable", timeout: int 
         return {"ok": False, "error": f"{type(exc).__name__}: {exc}"}
 
     try:
-        sdk = get_or_install_sdk(version)
+        sdk = get_or_install_sdk(version, project_root=project.abs_root)
     except Exception as exc:
         return {"ok": False, "error": f"{type(exc).__name__}: {exc}"}
 

--- a/src/renforge/sdk.py
+++ b/src/renforge/sdk.py
@@ -1,16 +1,18 @@
 from __future__ import annotations
 
+from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Final, Iterable
 
-import errno
 import os
+import re
 import shutil
 import sys
 import tarfile
 import tempfile
 import urllib.request
+import uuid
 import zipfile
 from urllib.error import HTTPError, URLError
 
@@ -21,6 +23,9 @@ RENPY_SDK_STABLE_ENV: Final = "RENPY_SDK_STABLE_VERSION"
 RENPY_SDK_BASE_URL_ENV: Final = "RENPY_SDK_BASE_URL"
 RENPY_SDK_ARCHIVE_URL_ENV: Final = "RENPY_SDK_ARCHIVE_URL"
 RENPY_SDK_BASE_URL_DEFAULT: Final = "https://www.renpy.org/dl"
+_VERSION_IDENTIFIER_RE: Final = re.compile(
+    r"\d+\.\d+\.\d+(?:[._+-][A-Za-z0-9]+)*\Z"
+)
 
 # Ren'Py 8.5 keyed Script.namemap by Node (Node.__hash__/__eq__ use .name) but
 # left dump.py filtering with ``isinstance(name, str)``, which drops every
@@ -77,6 +82,17 @@ def _resolve_version(version: str) -> str:
     return version
 
 
+def _validate_version_identifier(version: str) -> str:
+    if (
+        not _VERSION_IDENTIFIER_RE.fullmatch(version)
+        or ".." in version
+        or "/" in version
+        or "\\" in version
+    ):
+        raise ValueError(f"Invalid Ren'Py version identifier: {version!r}")
+    return version
+
+
 def _cache_dir() -> Path:
     cache_root = Path(os.environ.get(RENPY_SDK_CACHE_ENV, Path.home() / ".cache" / "renforge" / "sdks"))
     return cache_root.expanduser()
@@ -86,51 +102,84 @@ def _cache_version_dir(version: str) -> Path:
     return _cache_dir() / version
 
 
+def _managed_cache_child(path: Path) -> Path:
+    cache_root = _cache_dir().resolve(strict=False)
+    candidate = path.expanduser().absolute()
+    try:
+        parent = candidate.parent.resolve(strict=False)
+    except (OSError, RuntimeError) as exc:
+        raise ValueError(f"Invalid managed cache path: {path}") from exc
+    if parent != cache_root or candidate.name in {"", ".", ".."}:
+        raise ValueError(f"Managed cache path is not a direct cache child: {path}")
+    return cache_root / candidate.name
+
+
 def _unique_paths(candidates: Iterable[Path]) -> list[Path]:
     seen: list[Path] = []
     for path in candidates:
-        normalized = path.expanduser().resolve()
+        try:
+            normalized = path.expanduser().resolve(strict=False)
+        except (OSError, RuntimeError):
+            continue
         if normalized not in seen:
             seen.append(normalized)
     return seen
 
 
-def _discover_candidate_roots(version: str) -> list[Path]:
-    env_root = os.environ.get(RENPY_SDK_ENV)
-    bases = [
-        Path(env_root) if env_root else None,
-        Path.home() / ".renpy",
-        Path.home() / ".cache" / "renpy",
-        Path.home() / ".local" / "share" / "renpy",
-        Path("/opt") / "renpy",
-        Path("/usr/local") / "renpy",
+def _versioned_candidates(base: Path, version: str) -> list[Path]:
+    return [
+        base,
+        base / version,
+        base / f"renpy-{version}",
+        base / f"renpy-{version}-sdk",
     ]
-    candidates: list[Path] = []
-    for base in bases:
-        if base is None:
-            continue
-        candidates.extend(
-            [
-                base,
-                base / version,
-                base / f"renpy-{version}",
-                base / "renpy" / version,
-                base / "renpy" / f"renpy-{version}",
-            ]
-        )
-    return _unique_paths(candidates)
+
+
+def _project_candidate_roots(project_root: Path, version: str) -> list[Path]:
+    project = project_root.expanduser().resolve()
+    bases = [
+        project,
+        project / "renpy",
+        project / "renpy-sdk",
+        project / ".renpy",
+        project / ".renforge" / "sdk",
+    ]
+    candidates = _unique_paths(
+        candidate
+        for base in bases
+        for candidate in _versioned_candidates(base, version)
+    )
+    return [
+        candidate
+        for candidate in candidates
+        if candidate.is_relative_to(project)
+    ]
+
+
+def _explicit_candidate_roots(version: str) -> list[Path]:
+    env_root = os.environ.get(RENPY_SDK_ENV)
+    if not env_root:
+        return []
+    root = Path(env_root)
+    return _unique_paths(
+        [
+            *_versioned_candidates(root, version),
+            *_versioned_candidates(root / "renpy", version),
+        ]
+    )
 
 
 def _find_entrypoint(path: Path) -> Path:
     # Prefer the platform launcher scripts: they bootstrap Ren'Py's *bundled*
     # Python (which ships every dependency). `renpy.py` run with an arbitrary
     # system Python fails on missing deps, so it is only a last resort.
-    # renpy.sh is not runnable on native Windows, so prefer renpy.exe there.
-    scripts = ("renpy.exe", "renpy.sh") if os.name == "nt" else ("renpy.sh", "renpy.exe")
+    # Native launchers are platform-specific; a PE file is not runnable on
+    # POSIX even when its executable permission bit is set.
+    scripts = ("renpy.exe",) if os.name == "nt" else ("renpy.sh",)
     options = [
         *(path / script for script in scripts),
         path / "renpy.py",
-        path / "renpy-sdk" / "renpy.sh",
+        *(path / "renpy-sdk" / script for script in scripts),
         path / "renpy-sdk" / "renpy.py",
         path / "lib" / "renpy" / "renpy.py",
     ]
@@ -148,14 +197,141 @@ def _is_sdk_root(path: Path) -> bool:
     return True
 
 
-def _iter_existing_sdk_roots(version: str) -> Iterable[Path]:
-    for candidate in [*_discover_candidate_roots(version), _cache_version_dir(version)]:
-        if candidate.exists():
+def _version_tuple(version: str) -> tuple[int, int, int] | None:
+    match = re.match(r"^\s*(\d+)\.(\d+)\.(\d+)", version)
+    if match is None:
+        return None
+    return tuple(int(component) for component in match.groups())
+
+
+def _sdk_internal_version(root: Path) -> str | None:
+    version_file = root / "renpy" / "vc_version.py"
+    try:
+        text = version_file.read_text(encoding="utf-8")
+    except (OSError, UnicodeError):
+        return None
+    match = re.search(
+        r"(?m)^\s*version\s*=\s*(['\"])(?P<version>\d+\.\d+\.\d+[^'\"]*)\1",
+        text,
+    )
+    return match.group("version") if match else None
+
+
+def _compatible_sdk_version(installed: str, required: str) -> bool:
+    installed_tuple = _version_tuple(installed)
+    required_tuple = _version_tuple(required)
+    if installed_tuple is None or required_tuple is None:
+        return False
+    return (
+        installed_tuple[0] == required_tuple[0]
+        and installed_tuple >= required_tuple
+    )
+
+
+def _validated_sdk_version(root: Path, required_version: str) -> str | None:
+    try:
+        launcher = _find_entrypoint(root)
+        real_root = root.resolve(strict=True)
+        real_launcher = launcher.resolve(strict=True)
+    except (FileNotFoundError, OSError, RuntimeError):
+        return None
+    if not real_launcher.is_file() or not os.access(real_launcher, os.R_OK):
+        return None
+    if not real_launcher.is_relative_to(real_root):
+        return None
+    if real_launcher.suffix != ".py" and os.name != "nt" and not os.access(real_launcher, os.X_OK):
+        return None
+    installed_version = _sdk_internal_version(real_root)
+    if installed_version is None or not _compatible_sdk_version(installed_version, required_version):
+        return None
+    return installed_version
+
+
+def _first_valid_sdk(candidates: Iterable[Path], version: str) -> Path | None:
+    for candidate in candidates:
+        if _validated_sdk_version(candidate, version) is not None:
+            return candidate.resolve()
+    return None
+
+
+def _cache_candidates(version: str) -> list[Path]:
+    cache_root = _cache_dir()
+    exact = _cache_version_dir(version)
+    resolved_cache_root = cache_root.resolve(strict=False)
+    compatible: list[tuple[tuple[int, int, int], Path]] = []
+    try:
+        children = list(cache_root.iterdir())
+    except OSError:
+        children = []
+    for child in children:
+        if child.name.startswith(".") or _version_tuple(child.name) is None:
+            continue
+        try:
+            resolved_child = child.resolve(strict=False)
+            admissible = resolved_child.is_relative_to(resolved_cache_root)
+            is_directory = child.is_dir()
+        except (OSError, RuntimeError):
+            continue
+        if not admissible or not is_directory or child == exact:
+            continue
+        installed = _validated_sdk_version(child, version)
+        installed_tuple = _version_tuple(installed or "")
+        if installed_tuple is not None:
+            compatible.append((installed_tuple, child))
+    compatible.sort(key=lambda item: item[0])
+    candidates = [path for _, path in compatible]
+    try:
+        if exact.resolve(strict=False).is_relative_to(resolved_cache_root):
+            candidates.insert(0, exact)
+    except (OSError, RuntimeError):
+        pass
+    return candidates
+
+
+def _directory_entry_exists(path: Path) -> bool:
+    try:
+        expected_name = os.path.normcase(path.name)
+        return any(
+            os.path.normcase(entry.name) == expected_name
+            for entry in path.parent.iterdir()
+        )
+    except OSError:
+        try:
+            path.lstat()
+        except FileNotFoundError:
+            return False
+        except OSError:
+            return True
+        return True
+
+
+@contextmanager
+def _sdk_install_lock(version: str) -> Iterable[None]:
+    lock_path = _cache_dir() / f".{version.replace(os.sep, '_')}.lock"
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    with lock_path.open("a+b") as lock_file:
+        if os.name == "nt":
+            import msvcrt
+
+            lock_file.seek(0)
+            if lock_file.read(1) == b"":
+                lock_file.write(b"\0")
+                lock_file.flush()
+            lock_file.seek(0)
+            msvcrt.locking(lock_file.fileno(), msvcrt.LK_LOCK, 1)
             try:
-                _ = _find_entrypoint(candidate)
-            except FileNotFoundError:
-                continue
-            yield candidate
+                yield
+            finally:
+                lock_file.seek(0)
+                msvcrt.locking(lock_file.fileno(), msvcrt.LK_UNLCK, 1)
+        else:
+            import fcntl
+
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+            try:
+                yield
+            finally:
+                fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
 
 
 def _archive_base_url() -> str:
@@ -284,32 +460,77 @@ class RenpySdk:
         return self.command(str(project_root), *args)
 
 
-def get_or_install_sdk(version: str = "stable") -> RenpySdk:
+def get_or_install_sdk(
+    version: str = "stable",
+    *,
+    project_root: Path | None = None,
+) -> RenpySdk:
     """
     Discover or prepare a Ren'Py SDK directory.
     """
-    resolved_version = _resolve_version(version)
-    for sdk_root in _iter_existing_sdk_roots(resolved_version):
-        _patch_sdk_json_dump(sdk_root)
-        return RenpySdk(version=resolved_version, root=sdk_root)
+    resolved_version = _validate_version_identifier(_resolve_version(version))
+    if project_root is not None:
+        local_root = _first_valid_sdk(
+            _project_candidate_roots(project_root, resolved_version),
+            resolved_version,
+        )
+        if local_root is not None:
+            return RenpySdk(version=resolved_version, root=local_root)
 
-    cache_root = _cache_version_dir(resolved_version)
-    cache_root.parent.mkdir(parents=True, exist_ok=True)
+    explicit_root = _first_valid_sdk(
+        _explicit_candidate_roots(resolved_version),
+        resolved_version,
+    )
+    if explicit_root is not None:
+        _patch_sdk_json_dump(explicit_root)
+        return RenpySdk(version=resolved_version, root=explicit_root)
 
-    with tempfile.TemporaryDirectory(dir=_cache_dir()) as scratch:
-        scratch_dir = Path(scratch)
-        archive_path = _download_archive(_archive_url(resolved_version), scratch_dir)
-        extraction_root = scratch_dir / "extracted"
-        extraction_root.mkdir(parents=True, exist_ok=True)
-        _extract_archive(archive_path, extraction_root)
-        discovered_root = _find_sdk_root(extraction_root)
-        try:
-            os.replace(discovered_root, cache_root)
-        except OSError as exc:
-            if exc.errno != errno.EEXIST:
+    cached_root = _first_valid_sdk(_cache_candidates(resolved_version), resolved_version)
+    if cached_root is not None:
+        _patch_sdk_json_dump(cached_root)
+        return RenpySdk(version=resolved_version, root=cached_root)
+
+    with _sdk_install_lock(resolved_version):
+        cached_root = _first_valid_sdk(_cache_candidates(resolved_version), resolved_version)
+        if cached_root is not None:
+            _patch_sdk_json_dump(cached_root)
+            return RenpySdk(version=resolved_version, root=cached_root)
+
+        cache_root = _managed_cache_child(_cache_version_dir(resolved_version))
+        cache_root.parent.mkdir(parents=True, exist_ok=True)
+        with tempfile.TemporaryDirectory(
+            prefix=f".{cache_root.name}.install-",
+            dir=cache_root.parent,
+        ) as scratch:
+            scratch_dir = Path(scratch)
+            archive_path = _download_archive(_archive_url(resolved_version), scratch_dir)
+            extraction_root = scratch_dir / "extracted"
+            extraction_root.mkdir(parents=True, exist_ok=True)
+            _extract_archive(archive_path, extraction_root)
+            discovered_root = _find_sdk_root(extraction_root)
+            if _validated_sdk_version(discovered_root, resolved_version) is None:
+                raise ValueError(
+                    f"Downloaded Ren'Py SDK is invalid or incompatible with {resolved_version}."
+                )
+            _patch_sdk_json_dump(discovered_root)
+
+            quarantine = _managed_cache_child(
+                cache_root.with_name(
+                    f".{cache_root.name}.corrupt-{os.getpid()}-{uuid.uuid4().hex}"
+                )
+            )
+            quarantined = False
+            if _directory_entry_exists(cache_root):
+                os.replace(cache_root, quarantine)
+                quarantined = True
+            try:
+                os.replace(discovered_root, cache_root)
+            except BaseException:
+                if quarantined and not _directory_entry_exists(cache_root):
+                    os.replace(quarantine, cache_root)
                 raise
-            if not _is_sdk_root(cache_root):
-                raise
+            else:
+                if quarantined:
+                    shutil.rmtree(quarantine, ignore_errors=True)
 
-    _patch_sdk_json_dump(cache_root)
     return RenpySdk(version=resolved_version, root=cache_root)

--- a/src/renforge/server.py
+++ b/src/renforge/server.py
@@ -114,17 +114,46 @@ def _register_tools(app: Any) -> None:
     ) -> dict:
         if cancel_event is not None and cancel_event.is_set():
             return live.cancelled_launch_result(phase="detecting_environment")
-        from .dashboard_client import launch_game as launch_via_dashboard
+        from .dashboard_client import (
+            launch_game as launch_via_dashboard,
+            stop_game as stop_via_dashboard,
+        )
 
         # Dashboard owns its own display process; only warp/version are delegated.
         delegated = launch_via_dashboard(project_path, version=version, warp=warp)
         if delegated is not None:
             if cancel_event is not None and cancel_event.is_set():
-                live.stop_external_game(project_path)
+                stopped = stop_via_dashboard(project_path)
+                if stopped is None:
+                    message = (
+                        "The dashboard launch was cancelled, but its owning "
+                        "dashboard is unavailable to stop it."
+                    )
+                    return {
+                        "ok": False,
+                        "ready": False,
+                        "code": "DASHBOARD_STOP_UNAVAILABLE",
+                        "phase": "stopping_cancelled_dashboard_launch",
+                        "message": message,
+                        "error": message,
+                        "launch_cancel_requested": True,
+                    }
+                if not stopped.get("ok"):
+                    return {
+                        **stopped,
+                        "ready": False,
+                        "launch_cancel_requested": True,
+                    }
                 return live.cancelled_launch_result(phase="starting_renpy")
             return delegated
         if cancel_event is not None and cancel_event.is_set():
-            live.stop_external_game(project_path)
+            stopped = live.stop_external_game(project_path)
+            if not stopped.get("ok"):
+                return {
+                    **stopped,
+                    "ready": False,
+                    "launch_cancel_requested": True,
+                }
             return live.cancelled_launch_result(phase="starting_renpy")
         return live.launch_game(
             project_path,
@@ -139,6 +168,12 @@ def _register_tools(app: Any) -> None:
             session=session,
             cancel_event=cancel_event,
         )
+
+    def _stop_game(project_path: str) -> dict:
+        from .dashboard_client import stop_game as stop_via_dashboard
+
+        delegated = stop_via_dashboard(project_path)
+        return delegated if delegated is not None else live.stop_game(project_path)
 
     def _start_launch(project_path: str, **kwargs: Any) -> dict:
         def _launch(cancel_event: threading.Event) -> dict:
@@ -433,7 +468,7 @@ def _register_tools(app: Any) -> None:
             name="renforge_stop",
             params={"project_path": project_path},
             project_root=project_path,
-            fn=live.stop_game,
+            fn=_stop_game,
             args=(project_path,),
             kwargs={},
         )

--- a/src/renforge/tools/live.py
+++ b/src/renforge/tools/live.py
@@ -24,7 +24,12 @@ from typing import Any, Callable
 
 from ..autopilot import autopilot as _autopilot
 from ..bridge.client import BridgeClient, BridgeError
-from ..bridge.launcher import BridgeSession, launch_with_bridge, remove_bridge_artifacts
+from ..bridge.launcher import (
+    BridgeSession,
+    ProjectBridgeLock,
+    launch_with_bridge,
+    remove_bridge_artifacts,
+)
 from ..effect_wait import expected_events_for_action
 from ..effect_wait import wait_for_effect as _wait_for_business_effect
 from ..launch_env import LaunchError
@@ -259,10 +264,33 @@ def launch_game(
             except Exception:
                 pass  # unreachable session; fall through and relaunch
         try:
-            existing.close()
-        except Exception:
-            pass
-        _SESSIONS.pop(key, None)
+            cleaned = existing.close()
+        except Exception as exc:
+            message = f"Could not stop the existing bridge session: {type(exc).__name__}: {exc}"
+            return {
+                "ok": False,
+                "ready": False,
+                "code": "BRIDGE_TEARDOWN_INCOMPLETE",
+                "phase": "stopping_existing_session",
+                "message": message,
+                "error": message,
+                "cleaned": {},
+                "failed": ["close"],
+            }
+        if not existing.closed:
+            message = "The existing bridge session did not stop completely; retry stop or launch."
+            return {
+                "ok": False,
+                "ready": False,
+                "code": "BRIDGE_TEARDOWN_INCOMPLETE",
+                "phase": "stopping_existing_session",
+                "message": message,
+                "error": message,
+                "cleaned": cleaned.get("cleaned", {}),
+                "failed": cleaned.get("failed", []),
+            }
+        if _SESSIONS.get(key) is existing:
+            _SESSIONS.pop(key, None)
 
     if warp is None:
         try:
@@ -278,15 +306,29 @@ def launch_game(
         except Exception:
             pass
     else:
-        # A dashboard or another MCP process may own the live session. A warp
-        # needs a single fresh process, so stop that external session first.
-        stop_external_game(str(project.root))
+        try:
+            _client(project.root).get_state()
+        except Exception:
+            pass
+        else:
+            message = (
+                "Another RenForge bridge session is active for this project. "
+                "Stop it from the owning RenForge session before launching with warp."
+            )
+            return {
+                "ok": False,
+                "ready": False,
+                "code": "BRIDGE_PROJECT_LOCKED",
+                "phase": "acquiring_project_lock",
+                "message": message,
+                "error": message,
+            }
 
     if cancel_event is not None and cancel_event.is_set():
         return cancelled_launch_result(phase="detecting_environment")
 
     try:
-        sdk = get_or_install_sdk(version)
+        sdk = get_or_install_sdk(version, project_root=project.abs_root)
         launch_kwargs: dict[str, object] = {
             "display": display,
             "audio": audio,
@@ -351,6 +393,8 @@ def stop_game(project_path: str) -> dict:
         task.cancel_event.set()
         if not task.done_event.wait(_LAUNCH_CANCEL_WAIT_SECONDS):
             external = stop_external_game(project_path)
+            if not external.get("ok"):
+                return {**external, "launch_cancel_requested": True}
             return {
                 "ok": True,
                 "was_running": True,
@@ -363,9 +407,13 @@ def stop_game(project_path: str) -> dict:
             if _LAUNCHES.get(key) is task:
                 _LAUNCHES.pop(key, None)
 
-    session = _SESSIONS.pop(key, None)
+    session = _SESSIONS.get(key)
     if session is not None:
-        cleaned = session.close()
+        try:
+            cleaned = session.close()
+        finally:
+            if session.closed and _SESSIONS.get(key) is session:
+                _SESSIONS.pop(key, None)
         return {"ok": True, "was_running": True, **cleaned}
     if (
         was_starting
@@ -396,29 +444,38 @@ def stop_external_game(project_path: str) -> dict:
     except Exception as exc:
         return {"ok": False, "error": f"{type(exc).__name__}: {exc}"}
 
-    info_path = project.root / ".renforge" / "bridge.json"
-    if not info_path.exists():
-        return {"ok": True, "was_running": False}
+    project_lock = ProjectBridgeLock(project.root / ".renforge" / "bridge.lock")
+    try:
+        project_lock.acquire()
+    except LaunchError as exc:
+        return {**exc.to_dict(), "ready": False}
 
     try:
-        info = json.loads(info_path.read_text(encoding="utf-8"))
-    except Exception:
-        info = {}
+        info_path = project.root / ".renforge" / "bridge.json"
+        if not info_path.exists():
+            return {"ok": True, "was_running": False}
 
-    alive = False
-    try:
-        reply = BridgeClient.from_project(project.root, timeout=1.0).ping()
-        alive = isinstance(reply, dict) and reply.get("pong") is True
-    except Exception:
+        try:
+            info = json.loads(info_path.read_text(encoding="utf-8"))
+        except Exception:
+            info = {}
+
         alive = False
+        try:
+            reply = BridgeClient.from_project(project.root, timeout=1.0).ping()
+            alive = isinstance(reply, dict) and reply.get("pong") is True
+        except Exception:
+            alive = False
 
-    was_running = False
-    pid = info.get("pid")
-    if alive and isinstance(pid, int):
-        was_running = _terminate_pid(pid)
+        was_running = False
+        pid = info.get("pid")
+        if alive and isinstance(pid, int):
+            was_running = _terminate_pid(pid)
 
-    remove_bridge_artifacts(project.root)
-    return {"ok": True, "was_running": was_running}
+        remove_bridge_artifacts(project.root)
+        return {"ok": True, "was_running": was_running}
+    finally:
+        project_lock.release()
 
 
 def _terminate_pid(pid: int) -> bool:
@@ -444,12 +501,13 @@ def stop_all() -> None:
         task.done_event.wait(_LAUNCH_CANCEL_WAIT_SECONDS)
     with _LAUNCH_LOCK:
         _LAUNCHES.clear()
-    for session in list(_SESSIONS.values()):
+    for key, session in list(_SESSIONS.items()):
         try:
             session.close()
         except Exception:
             pass
-    _SESSIONS.clear()
+        if session.closed and _SESSIONS.get(key) is session:
+            _SESSIONS.pop(key, None)
 
 
 def game_state(
@@ -1116,7 +1174,7 @@ def run_autopilot(project_path: str, version: str = "stable", max_runs: int = 16
     """Explore the game's branches and return a coverage/crash report."""
     try:
         project = RenpyProject(Path(project_path))
-        sdk = get_or_install_sdk(version)
+        sdk = get_or_install_sdk(version, project_root=project.abs_root)
     except Exception as exc:
         return {"ok": False, "error": f"{type(exc).__name__}: {exc}"}
     # Autopilot launches its own throwaway sessions; free any manual one first.

--- a/src/renforge/tools/project_ops.py
+++ b/src/renforge/tools/project_ops.py
@@ -28,7 +28,7 @@ def _sdk_project(project_path: str, version: str) -> tuple[RenpySdk | None, Renp
     if err:
         return None, None, err
     try:
-        return get_or_install_sdk(version), project, None
+        return get_or_install_sdk(version, project_root=project.abs_root), project, None
     except Exception as exc:
         return None, None, {"ok": False, "error": f"{type(exc).__name__}: {exc}"}
 

--- a/src/renforge/ui/graph.py
+++ b/src/renforge/ui/graph.py
@@ -139,7 +139,7 @@ def build_story_map(project_root: str) -> dict:
     native_locations: dict[str, dict] = {}
     try:
         project = RenpyProject(root)
-        sdk = get_or_install_sdk()
+        sdk = get_or_install_sdk(project_root=project.abs_root)
         raw_dump = run_native_dump(sdk, project)
         for definition in normalize_definitions(raw_dump):
             if definition.get("kind") == "label" and definition.get("name"):

--- a/tests/test_bridge_launcher.py
+++ b/tests/test_bridge_launcher.py
@@ -1,5 +1,6 @@
 import errno
 import json
+import os
 import signal
 import threading
 import time
@@ -16,6 +17,9 @@ from renforge.bridge.launcher import (
 from renforge.launch_env import LaunchError
 from renforge.project import RenpyProject
 from renforge.sdk import RenpySdk
+
+
+_LAUNCHER_NAME = "renpy.exe" if os.name == "nt" else "renpy.sh"
 
 
 class _FakeProcess:
@@ -72,7 +76,7 @@ def _make_project(
     (project_root / "game").mkdir(parents=True)
     sdk_root = tmp_path / f"sdk-{name}"
     sdk_root.mkdir(parents=True)
-    (sdk_root / "renpy.sh").write_text("#!/bin/sh\n", encoding="utf-8")
+    (sdk_root / _LAUNCHER_NAME).write_text("#!/bin/sh\n", encoding="utf-8")
     return RenpyProject(project_root), RenpySdk(version="8.3.7", root=sdk_root), project_root
 
 
@@ -100,7 +104,7 @@ def test_launch_with_bridge_builds_run_command(monkeypatch, tmp_path: Path, warp
     assert session is not None
     command = list(captured["command"])  # type: ignore[arg-type]
     assert len(command) >= 3
-    assert command[0].endswith("renpy.sh")
+    assert command[0].endswith(_LAUNCHER_NAME)
     assert command[1] == str(project_root.resolve())
     if warp is None:
         assert command[2:] == ["run"]
@@ -152,7 +156,7 @@ def test_launch_without_display_falls_back_to_xvfb(monkeypatch, tmp_path: Path) 
     session = launch_with_bridge(sdk, project)
     command = list(captured["command"])  # type: ignore[arg-type]
     assert command[:2] == ["xvfb-run", "-a"]
-    assert command[2].endswith("renpy.sh")
+    assert command[2].endswith(_LAUNCHER_NAME)
     assert captured["start_new_session"] is True
     assert session.headless is True
 

--- a/tests/test_bridge_launcher.py
+++ b/tests/test_bridge_launcher.py
@@ -1,10 +1,19 @@
+import errno
+import json
 import signal
 import threading
+import time
 from pathlib import Path
 
 import pytest
 
-from renforge.bridge.launcher import BridgeSession, launch_with_bridge, remove_bridge_artifacts
+from renforge.bridge.launcher import (
+    BridgeSession,
+    ProjectBridgeLock,
+    launch_with_bridge,
+    remove_bridge_artifacts,
+)
+from renforge.launch_env import LaunchError
 from renforge.project import RenpyProject
 from renforge.sdk import RenpySdk
 
@@ -35,18 +44,42 @@ class _FakeProcess:
         self.returncode = 0
 
 
+class _ResistantProcess(_FakeProcess):
+    def terminate(self):
+        self.terminated = True
+
+    def kill(self):
+        self.killed = True
+
+    def wait(self, timeout: float | None = None):
+        self.waited = True
+        if self.returncode is None:
+            raise TimeoutError("process is still alive")
+
+    def exit(self):
+        self.returncode = 0
+
+
 class _FakeClient:
     def ping(self):
         return {"ok": True, "pong": True}
 
 
-def _make_project(tmp_path: Path) -> tuple[RenpyProject, RenpySdk, Path]:
-    project_root = tmp_path / "project"
+def _make_project(
+    tmp_path: Path, name: str = "project"
+) -> tuple[RenpyProject, RenpySdk, Path]:
+    project_root = tmp_path / name
     (project_root / "game").mkdir(parents=True)
-    sdk_root = tmp_path / "sdk"
+    sdk_root = tmp_path / f"sdk-{name}"
     sdk_root.mkdir(parents=True)
     (sdk_root / "renpy.sh").write_text("#!/bin/sh\n", encoding="utf-8")
     return RenpyProject(project_root), RenpySdk(version="8.3.7", root=sdk_root), project_root
+
+
+def _write_bridge_info(project_root: Path, token: str) -> None:
+    info_path = project_root / ".renforge" / "bridge.json"
+    info_path.parent.mkdir(parents=True, exist_ok=True)
+    info_path.write_text(json.dumps({"token": token}), encoding="utf-8")
 
 
 @pytest.mark.parametrize("warp", [None, "game/script.rpy:123"])
@@ -57,9 +90,7 @@ def test_launch_with_bridge_builds_run_command(monkeypatch, tmp_path: Path, warp
 
     def fake_popen(command, env=None, stdout=None, stderr=None, start_new_session=False):
         captured["command"] = command
-        info_path = project_root / ".renforge" / "bridge.json"
-        info_path.parent.mkdir(parents=True, exist_ok=True)
-        info_path.write_text("{}", encoding="utf-8")
+        _write_bridge_info(project_root, env["RENFORGE_BRIDGE_TOKEN"])
         return _FakeProcess()
 
     monkeypatch.setattr("renforge.bridge.launcher.subprocess.Popen", fake_popen)
@@ -112,9 +143,7 @@ def test_launch_without_display_falls_back_to_xvfb(monkeypatch, tmp_path: Path) 
     def fake_popen(command, env=None, stdout=None, stderr=None, start_new_session=False):
         captured["command"] = command
         captured["start_new_session"] = start_new_session
-        info_path = project_root / ".renforge" / "bridge.json"
-        info_path.parent.mkdir(parents=True, exist_ok=True)
-        info_path.write_text("{}", encoding="utf-8")
+        _write_bridge_info(project_root, env["RENFORGE_BRIDGE_TOKEN"])
         return _FakeProcess()
 
     monkeypatch.setattr("renforge.bridge.launcher.subprocess.Popen", fake_popen)
@@ -156,9 +185,7 @@ def test_launch_accepts_display_provided_via_extra_env(monkeypatch, tmp_path: Pa
     project, sdk, project_root = _make_project(tmp_path)
 
     def fake_popen(command, env=None, stdout=None, stderr=None, start_new_session=False):
-        info_path = project_root / ".renforge" / "bridge.json"
-        info_path.parent.mkdir(parents=True, exist_ok=True)
-        info_path.write_text("{}", encoding="utf-8")
+        _write_bridge_info(project_root, env["RENFORGE_BRIDGE_TOKEN"])
         return _FakeProcess()
 
     monkeypatch.setattr("renforge.bridge.launcher.subprocess.Popen", fake_popen)
@@ -201,6 +228,13 @@ def test_bridge_session_close_kills_running_game(tmp_path: Path) -> None:
 
     assert process.killed is True
     assert process.terminated is False
+    assert session.closed is True
+
+    injected = tmp_path / "game" / "renforge_bridge.rpy"
+    injected.parent.mkdir()
+    injected.write_text("# belongs to a later session\n", encoding="utf-8")
+    session.close()
+    assert injected.exists()
 
 
 def test_failed_launch_removes_every_generated_bridge_artifact(monkeypatch, tmp_path: Path) -> None:
@@ -242,9 +276,7 @@ def test_launch_retries_until_ping_returns_pong(monkeypatch, tmp_path: Path) -> 
             return {"ok": True, "pong": True}
 
     def fake_popen(*_args, **_kwargs):
-        info_path = project_root / ".renforge" / "bridge.json"
-        info_path.parent.mkdir(parents=True, exist_ok=True)
-        info_path.write_text("{}", encoding="utf-8")
+        _write_bridge_info(project_root, _kwargs["env"]["RENFORGE_BRIDGE_TOKEN"])
         return _FakeProcess()
 
     monkeypatch.setattr("renforge.bridge.launcher.subprocess.Popen", fake_popen)
@@ -268,9 +300,7 @@ def test_launch_cancellation_stops_process_and_cleans_artifacts(monkeypatch, tmp
             return {"error": "timeout_waiting_for_main_thread"}
 
     def fake_popen(*_args, **_kwargs):
-        info_path = project_root / ".renforge" / "bridge.json"
-        info_path.parent.mkdir(parents=True, exist_ok=True)
-        info_path.write_text("{}", encoding="utf-8")
+        _write_bridge_info(project_root, _kwargs["env"]["RENFORGE_BRIDGE_TOKEN"])
         return process
 
     monkeypatch.setattr("renforge.bridge.launcher.subprocess.Popen", fake_popen)
@@ -291,3 +321,292 @@ def test_launch_cancellation_stops_process_and_cleans_artifacts(monkeypatch, tmp
     assert process.terminated is True
     assert not (project_root / "game" / "renforge_bridge.rpy").exists()
     assert not (project_root / ".renforge" / "bridge.json").exists()
+
+
+def test_second_launch_same_project_fails_without_touching_first_session(
+    monkeypatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("DISPLAY", ":0")
+    project, sdk, project_root = _make_project(tmp_path)
+    popen_calls = {"count": 0}
+
+    def fake_popen(*_args, **kwargs):
+        popen_calls["count"] += 1
+        _write_bridge_info(project_root, kwargs["env"]["RENFORGE_BRIDGE_TOKEN"])
+        return _FakeProcess()
+
+    monkeypatch.setattr("renforge.bridge.launcher.subprocess.Popen", fake_popen)
+    monkeypatch.setattr(
+        "renforge.bridge.launcher.BridgeClient.from_project",
+        lambda _project_root: _FakeClient(),
+    )
+
+    first = launch_with_bridge(sdk, project, token="first-token")
+    injected_before = (project_root / "game" / "renforge_bridge.rpy").read_bytes()
+    manifest_before = (project_root / ".renforge" / "bridge.json").read_bytes()
+
+    with pytest.raises(LaunchError) as excinfo:
+        launch_with_bridge(sdk, project, token="second-token")
+
+    assert getattr(excinfo.value, "code", None) == "BRIDGE_PROJECT_LOCKED"
+    assert getattr(excinfo.value, "phase", None) == "acquiring_project_lock"
+    assert popen_calls["count"] == 1
+    assert (project_root / "game" / "renforge_bridge.rpy").read_bytes() == injected_before
+    assert (project_root / ".renforge" / "bridge.json").read_bytes() == manifest_before
+
+    first.close(timeout=0.1)
+    assert (project_root / ".renforge" / "bridge.lock").exists()
+
+
+def test_sessions_for_different_projects_are_isolated(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("DISPLAY", ":0")
+    project_a, sdk, root_a = _make_project(tmp_path, "project-a")
+    project_b, _, root_b = _make_project(tmp_path, "project-b")
+
+    def fake_popen(command, env=None, **_kwargs):
+        _write_bridge_info(Path(command[1]), env["RENFORGE_BRIDGE_TOKEN"])
+        return _FakeProcess()
+
+    monkeypatch.setattr("renforge.bridge.launcher.subprocess.Popen", fake_popen)
+    monkeypatch.setattr(
+        "renforge.bridge.launcher.BridgeClient.from_project",
+        lambda _project_root: _FakeClient(),
+    )
+
+    session_a = launch_with_bridge(sdk, project_a, token="token-a")
+    session_b = launch_with_bridge(sdk, project_b, token="token-b")
+    session_a.close(timeout=0.1)
+
+    assert not (root_a / "game" / "renforge_bridge.rpy").exists()
+    assert not (root_a / ".renforge" / "bridge.json").exists()
+    assert (root_b / "game" / "renforge_bridge.rpy").exists()
+    assert json.loads((root_b / ".renforge" / "bridge.json").read_text())["token"] == "token-b"
+
+    session_b.close(timeout=0.1)
+
+
+def test_project_lock_is_released_after_cancelled_launch(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("DISPLAY", ":0")
+    project, sdk, project_root = _make_project(tmp_path)
+    cancel_event = threading.Event()
+    launches = {"count": 0}
+
+    class _CancellingClient:
+        def ping(self):
+            cancel_event.set()
+            return {"error": "not-ready"}
+
+    def fake_popen(*_args, **kwargs):
+        launches["count"] += 1
+        _write_bridge_info(project_root, kwargs["env"]["RENFORGE_BRIDGE_TOKEN"])
+        return _FakeProcess()
+
+    monkeypatch.setattr("renforge.bridge.launcher.subprocess.Popen", fake_popen)
+    monkeypatch.setattr(
+        "renforge.bridge.launcher.BridgeClient.from_project",
+        lambda _project_root: _CancellingClient(),
+    )
+
+    with pytest.raises(LaunchError) as excinfo:
+        launch_with_bridge(sdk, project, cancel_event=cancel_event)
+    assert getattr(excinfo.value, "code", None) == "LAUNCH_CANCELLED"
+
+    cancel_event.clear()
+    monkeypatch.setattr(
+        "renforge.bridge.launcher.BridgeClient.from_project",
+        lambda _project_root: _FakeClient(),
+    )
+    session = launch_with_bridge(sdk, project)
+    assert launches["count"] == 2
+    session.close(timeout=0.1)
+
+
+def test_bridge_manifest_with_wrong_token_is_never_accepted(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("DISPLAY", ":0")
+    project, sdk, project_root = _make_project(tmp_path)
+    clock = iter((0.0, 0.0, 2.0))
+
+    def fake_popen(*_args, **_kwargs):
+        _write_bridge_info(project_root, "another-session-token")
+        return _FakeProcess()
+
+    def fail_from_project(_project_root):
+        raise AssertionError("A manifest for another session must not create a client")
+
+    monkeypatch.setattr("renforge.bridge.launcher.subprocess.Popen", fake_popen)
+    monkeypatch.setattr("renforge.bridge.launcher.BridgeClient.from_project", fail_from_project)
+    monkeypatch.setattr("renforge.bridge.launcher.time.time", lambda: next(clock))
+    monkeypatch.setattr("renforge.bridge.launcher.time.sleep", lambda _seconds: None)
+
+    with pytest.raises(LaunchError) as excinfo:
+        launch_with_bridge(sdk, project, token="expected-token", startup_timeout=1.0)
+
+    assert getattr(excinfo.value, "code", None) == "BRIDGE_CONNECTION_TIMEOUT"
+    assert not (project_root / ".renforge" / "bridge.json").exists()
+
+
+def test_close_keeps_lock_and_artifacts_until_process_exit(
+    monkeypatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("DISPLAY", ":0")
+    project, sdk, project_root = _make_project(tmp_path)
+    resistant = _ResistantProcess()
+    launches = {"count": 0}
+
+    def fake_popen(*_args, **kwargs):
+        launches["count"] += 1
+        _write_bridge_info(project_root, kwargs["env"]["RENFORGE_BRIDGE_TOKEN"])
+        return resistant if launches["count"] == 1 else _FakeProcess()
+
+    monkeypatch.setattr("renforge.bridge.launcher.subprocess.Popen", fake_popen)
+    monkeypatch.setattr(
+        "renforge.bridge.launcher.BridgeClient.from_project",
+        lambda _project_root: _FakeClient(),
+    )
+
+    first = launch_with_bridge(sdk, project, token="first-token")
+    first_close = first.close(timeout=0.01)
+
+    assert "process_alive" in first_close["failed"]
+    assert first.closed is False
+    assert (project_root / "game" / "renforge_bridge.rpy").exists()
+    assert (project_root / ".renforge" / "bridge.json").exists()
+    with pytest.raises(LaunchError) as excinfo:
+        launch_with_bridge(sdk, project, token="blocked-token")
+    assert excinfo.value.code == "BRIDGE_PROJECT_LOCKED"
+    assert launches["count"] == 1
+
+    resistant.exit()
+    retry_close = first.close(timeout=0.01)
+    assert retry_close.get("failed") is None
+    assert first.closed is True
+    assert not (project_root / "game" / "renforge_bridge.rpy").exists()
+    assert not (project_root / ".renforge" / "bridge.json").exists()
+
+    second = launch_with_bridge(sdk, project, token="second-token")
+    assert launches["count"] == 2
+    second.close(timeout=0.01)
+
+
+def test_failed_launch_escalates_to_kill_before_releasing_lock(
+    monkeypatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("DISPLAY", ":0")
+    project, sdk, project_root = _make_project(tmp_path)
+
+    class _DiesOnKill(_ResistantProcess):
+        def kill(self):
+            super().kill()
+            self.returncode = -9
+
+    process = _DiesOnKill()
+    cancel_event = threading.Event()
+    launches = {"count": 0}
+
+    class _CancellingClient:
+        def ping(self):
+            cancel_event.set()
+            return {"error": "not-ready"}
+
+    def fake_popen(*_args, **kwargs):
+        launches["count"] += 1
+        _write_bridge_info(project_root, kwargs["env"]["RENFORGE_BRIDGE_TOKEN"])
+        return process if launches["count"] == 1 else _FakeProcess()
+
+    monkeypatch.setattr("renforge.bridge.launcher.subprocess.Popen", fake_popen)
+    monkeypatch.setattr(
+        "renforge.bridge.launcher.BridgeClient.from_project",
+        lambda _project_root: _CancellingClient(),
+    )
+
+    with pytest.raises(LaunchError) as excinfo:
+        launch_with_bridge(sdk, project, cancel_event=cancel_event)
+
+    assert excinfo.value.code == "LAUNCH_CANCELLED"
+    assert process.terminated is True
+    assert process.killed is True
+    assert process.poll() == -9
+    assert not (project_root / "game" / "renforge_bridge.rpy").exists()
+
+    cancel_event.clear()
+    monkeypatch.setattr(
+        "renforge.bridge.launcher.BridgeClient.from_project",
+        lambda _project_root: _FakeClient(),
+    )
+    session = launch_with_bridge(sdk, project)
+    session.close(timeout=0.01)
+
+
+def test_lock_file_open_permission_error_is_not_reported_as_contention(
+    monkeypatch, tmp_path: Path
+) -> None:
+    original_open = Path.open
+
+    def denied_open(path, *args, **kwargs):
+        if path.name == "bridge.lock":
+            raise PermissionError(errno.EACCES, "permission denied", str(path))
+        return original_open(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "open", denied_open)
+
+    with pytest.raises(LaunchError) as excinfo:
+        ProjectBridgeLock(tmp_path / ".renforge" / "bridge.lock").acquire()
+
+    assert excinfo.value.code == "BRIDGE_PROJECT_LOCK_FAILED"
+    assert excinfo.value.phase == "acquiring_project_lock"
+
+
+def test_failed_launch_defers_cleanup_and_unlock_until_process_exits(
+    monkeypatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("DISPLAY", ":0")
+    project, sdk, project_root = _make_project(tmp_path)
+    process = _ResistantProcess()
+    cancel_event = threading.Event()
+    launches = {"count": 0}
+
+    class _CancellingClient:
+        def ping(self):
+            cancel_event.set()
+            return {"error": "not-ready"}
+
+    def fake_popen(*_args, **kwargs):
+        launches["count"] += 1
+        _write_bridge_info(project_root, kwargs["env"]["RENFORGE_BRIDGE_TOKEN"])
+        return process if launches["count"] == 1 else _FakeProcess()
+
+    monkeypatch.setattr("renforge.bridge.launcher.subprocess.Popen", fake_popen)
+    monkeypatch.setattr(
+        "renforge.bridge.launcher.BridgeClient.from_project",
+        lambda _project_root: _CancellingClient(),
+    )
+
+    with pytest.raises(LaunchError) as excinfo:
+        launch_with_bridge(sdk, project, cancel_event=cancel_event)
+    assert excinfo.value.code == "LAUNCH_CANCELLED"
+    assert (project_root / "game" / "renforge_bridge.rpy").exists()
+
+    with pytest.raises(LaunchError) as locked:
+        launch_with_bridge(sdk, project)
+    assert locked.value.code == "BRIDGE_PROJECT_LOCKED"
+    assert launches["count"] == 1
+
+    process.exit()
+    cancel_event.clear()
+    monkeypatch.setattr(
+        "renforge.bridge.launcher.BridgeClient.from_project",
+        lambda _project_root: _FakeClient(),
+    )
+    deadline = time.monotonic() + 1.0
+    while True:
+        try:
+            session = launch_with_bridge(sdk, project)
+            break
+        except LaunchError as exc:
+            assert exc.code == "BRIDGE_PROJECT_LOCKED"
+            if time.monotonic() >= deadline:
+                raise
+            time.sleep(0.01)
+
+    assert launches["count"] == 2
+    session.close(timeout=0.01)

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -1,13 +1,17 @@
+import os
 from pathlib import Path
 
 from renforge.build import _launcher_command
 from renforge.sdk import RenpySdk
 
 
+_LAUNCHER_NAME = "renpy.exe" if os.name == "nt" else "renpy.sh"
+
+
 def _fake_sdk(tmp_path: Path) -> RenpySdk:
     root = tmp_path / "sdk"
     (root / "launcher").mkdir(parents=True)
-    (root / "renpy.sh").write_text("#!/bin/sh\n")
+    (root / _LAUNCHER_NAME).write_text("#!/bin/sh\n")
     return RenpySdk(version="8.3.7", root=root)
 
 
@@ -15,7 +19,7 @@ def test_launcher_command_targets_the_launcher_project(tmp_path: Path) -> None:
     sdk = _fake_sdk(tmp_path)
     cmd = _launcher_command(sdk, "web_build", "/path/to/game", "--destination", "/out")
 
-    assert Path(cmd[0]).name == "renpy.sh"
+    assert Path(cmd[0]).name == _LAUNCHER_NAME
     assert Path(cmd[1]).name == "launcher"  # launcher is the base directory
     assert cmd[2] == "web_build"
     assert "/path/to/game" in cmd

--- a/tests/test_dashboard_client.py
+++ b/tests/test_dashboard_client.py
@@ -74,3 +74,38 @@ def test_launch_game_ignores_dashboard_for_another_project(tmp_path: Path, monke
     )
 
     assert dashboard_client.launch_game(str(tmp_path / "other")) is None
+
+
+def test_stop_game_delegates_to_matching_dashboard(tmp_path: Path, monkeypatch) -> None:
+    from renforge import dashboard_client
+
+    project = tmp_path / "game-project"
+    calls = {}
+    monkeypatch.setattr(
+        dashboard_client,
+        "dashboard_connection",
+        lambda: {
+            "project": str(project),
+            "url": "http://127.0.0.1:8765/",
+            "token": "secret token",
+        },
+    )
+
+    def fake_urlopen(request, timeout: int):
+        calls.update(
+            url=request.full_url,
+            payload=json.loads(request.data.decode("utf-8")),
+            timeout=timeout,
+        )
+        return _Response({"ok": True, "was_running": True})
+
+    monkeypatch.setattr(dashboard_client, "urlopen", fake_urlopen)
+
+    result = dashboard_client.stop_game(str(project))
+
+    assert result == {"ok": True, "was_running": True, "via": "dashboard"}
+    assert calls == {
+        "url": "http://127.0.0.1:8765/api/live/stop?token=secret+token",
+        "payload": {},
+        "timeout": 45,
+    }

--- a/tests/test_live_stop.py
+++ b/tests/test_live_stop.py
@@ -7,6 +7,8 @@ import threading
 import time
 from pathlib import Path
 
+import pytest
+
 from renforge.tools import live
 
 
@@ -39,6 +41,39 @@ class _DeadClient:
 class _StateClient(_AliveClient):
     def get_state(self) -> dict:
         return {"current_label": "dashboard_scene"}
+
+
+class _LaunchedSession:
+    display_mode = "native"
+    startup_ms = 10
+    phases: list[dict] = []
+    environment: dict = {}
+    temporary_savedir = None
+    headless = False
+
+    def __init__(self) -> None:
+        self.client = _StateClient()
+
+
+class _RetryingSession:
+    def __init__(self, *, process_exited: bool = False) -> None:
+        self.process_exited = process_exited
+        self.closed = False
+        self.close_calls = 0
+
+    def close(self) -> dict:
+        self.close_calls += 1
+        if not self.process_exited:
+            return {"cleaned": {}, "failed": ["process_alive"]}
+        self.closed = True
+        return {"cleaned": {"renpy_process": True}, "failed": []}
+
+
+class _RaisingSession:
+    closed = False
+
+    def close(self) -> dict:
+        raise RuntimeError("teardown failed")
 
 
 def _wait_for_launch_status(
@@ -108,6 +143,73 @@ def test_stop_game_cleans_stale_bridge_without_killing(tmp_path: Path, monkeypat
     assert not (project / "game" / "renforge_bridge.rpy").exists()
 
 
+def test_external_stop_refuses_to_touch_an_active_lock_owner(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    project = _make_project(tmp_path, pid=4242)
+    project_lock = live.ProjectBridgeLock(project / ".renforge" / "bridge.lock")
+    project_lock.acquire()
+    monkeypatch.setattr(
+        live.BridgeClient,
+        "from_project",
+        lambda *_args, **_kwargs: pytest.fail("must not ping a locked bridge"),
+    )
+    monkeypatch.setattr(
+        live,
+        "_terminate_pid",
+        lambda *_args, **_kwargs: pytest.fail("must not kill a locked bridge"),
+    )
+    monkeypatch.setattr(
+        live,
+        "remove_bridge_artifacts",
+        lambda *_args, **_kwargs: pytest.fail("must not clean a locked bridge"),
+    )
+
+    try:
+        result = live.stop_external_game(str(project))
+    finally:
+        project_lock.release()
+
+    assert result["ok"] is False
+    assert result["ready"] is False
+    assert result["code"] == "BRIDGE_PROJECT_LOCKED"
+    assert result["phase"] == "acquiring_project_lock"
+    assert (project / ".renforge" / "bridge.json").exists()
+    assert (project / "game" / "renforge_bridge.rpy").exists()
+    assert (project / "game" / "renforge_bridge.rpyc").exists()
+
+
+def test_external_cleanup_holds_project_lock_until_artifacts_are_removed(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    project = _make_project(tmp_path)
+    monkeypatch.setattr(
+        live.BridgeClient,
+        "from_project",
+        classmethod(lambda cls, root, *, timeout=1.0: _DeadClient()),
+    )
+    cleanup_observed = {"locked": False}
+
+    def fake_remove(_project_root: Path) -> None:
+        competing_lock = live.ProjectBridgeLock(project / ".renforge" / "bridge.lock")
+        with pytest.raises(live.LaunchError) as excinfo:
+            competing_lock.acquire()
+        assert excinfo.value.code == "BRIDGE_PROJECT_LOCKED"
+        cleanup_observed["locked"] = True
+
+    monkeypatch.setattr(live, "remove_bridge_artifacts", fake_remove)
+
+    result = live.stop_external_game(str(project))
+
+    assert result == {"ok": True, "was_running": False}
+    assert cleanup_observed["locked"] is True
+    next_owner = live.ProjectBridgeLock(project / ".renforge" / "bridge.lock")
+    next_owner.acquire()
+    next_owner.release()
+
+
 def test_launch_reuses_a_game_started_by_the_dashboard(tmp_path: Path, monkeypatch) -> None:
     project = _make_project(tmp_path)
     monkeypatch.setattr(
@@ -130,6 +232,118 @@ def test_launch_reuses_a_game_started_by_the_dashboard(tmp_path: Path, monkeypat
         "ready": True,
         "current_label": "dashboard_scene",
     }
+
+
+def test_warp_refuses_to_stop_a_live_external_bridge(tmp_path: Path, monkeypatch) -> None:
+    project = _make_project(tmp_path)
+    monkeypatch.setattr(
+        live.BridgeClient,
+        "from_project",
+        classmethod(lambda cls, root, **_kwargs: _StateClient()),
+    )
+    monkeypatch.setattr(
+        live,
+        "stop_external_game",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("must not stop another bridge owner")
+        ),
+    )
+    monkeypatch.setattr(
+        live,
+        "get_or_install_sdk",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("must not resolve an SDK while the project is locked")
+        ),
+    )
+
+    result = live.launch_game(str(project), warp="chapter_one")
+
+    assert result["ok"] is False
+    assert result["ready"] is False
+    assert result["code"] == "BRIDGE_PROJECT_LOCKED"
+    assert result["phase"] == "acquiring_project_lock"
+    assert "owning RenForge session" in result["message"]
+    assert result["error"] == result["message"]
+
+
+def test_new_launch_resolves_sdk_for_exact_project_root(tmp_path: Path, monkeypatch) -> None:
+    project = _make_project(tmp_path, with_bridge=False)
+    project_path = project / ".." / project.name
+    resolved: dict[str, object] = {}
+
+    def fake_resolve(version: str, *, project_root: Path):
+        resolved["version"] = version
+        resolved["project_root"] = project_root
+        return "sdk"
+
+    monkeypatch.setattr(live, "get_or_install_sdk", fake_resolve)
+    monkeypatch.setattr(
+        live,
+        "launch_with_bridge",
+        lambda sdk, renpy_project, **_kwargs: _LaunchedSession(),
+    )
+
+    result = live.launch_game(str(project_path), version="8.5.3")
+
+    assert result["ok"] is True
+    assert resolved == {
+        "version": "8.5.3",
+        "project_root": project.resolve(),
+    }
+    live._SESSIONS.pop(str(project.resolve()), None)
+
+
+def test_warp_retries_incomplete_existing_session_teardown(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    project = _make_project(tmp_path, with_bridge=False)
+    key = live._key(project)
+    session = _RetryingSession()
+    live._SESSIONS[key] = session
+    monkeypatch.setattr(
+        live,
+        "get_or_install_sdk",
+        lambda *_args, **_kwargs: "sdk",
+    )
+    monkeypatch.setattr(
+        live,
+        "launch_with_bridge",
+        lambda *_args, **_kwargs: _LaunchedSession(),
+    )
+
+    first = live.launch_game(str(project), warp="chapter_one")
+
+    assert first["ok"] is False
+    assert first["code"] == "BRIDGE_TEARDOWN_INCOMPLETE"
+    assert first["phase"] == "stopping_existing_session"
+    assert first["failed"] == ["process_alive"]
+    assert live._SESSIONS[key] is session
+    session.process_exited = True
+
+    second = live.launch_game(str(project), warp="chapter_one")
+
+    assert second["ok"] is True
+    assert session.close_calls == 2
+    assert live._SESSIONS[key] is not session
+    live._SESSIONS.pop(key, None)
+
+
+def test_warp_keeps_existing_session_when_teardown_raises(tmp_path: Path) -> None:
+    project = _make_project(tmp_path, with_bridge=False)
+    key = live._key(project)
+    session = _RaisingSession()
+    live._SESSIONS[key] = session
+
+    result = live.launch_game(str(project), warp="chapter_one")
+
+    assert result["ok"] is False
+    assert result["code"] == "BRIDGE_TEARDOWN_INCOMPLETE"
+    assert result["phase"] == "stopping_existing_session"
+    assert result["failed"] == ["close"]
+    assert "RuntimeError: teardown failed" in result["error"]
+    assert live._SESSIONS[key] is session
+    live._SESSIONS.pop(key, None)
 
 
 def test_start_launch_returns_before_slow_startup_and_exposes_ready_status(tmp_path: Path) -> None:
@@ -205,6 +419,42 @@ def test_stop_game_cancels_a_pending_launch(tmp_path: Path) -> None:
     idle = live.launch_status(str(project))
     assert idle["ok"] is True
     assert idle["status"] == "idle"
+
+
+def test_stop_game_keeps_a_partial_session_registered_for_retry(tmp_path: Path) -> None:
+    project = _make_project(tmp_path, with_bridge=False)
+    key = live._key(project)
+    session = _RetryingSession()
+    live._SESSIONS[key] = session
+
+    first = live.stop_game(str(project))
+
+    assert first["failed"] == ["process_alive"]
+    assert live._SESSIONS[key] is session
+    session.process_exited = True
+
+    second = live.stop_game(str(project))
+
+    assert second["failed"] == []
+    assert session.close_calls == 2
+    assert key not in live._SESSIONS
+
+
+def test_stop_all_keeps_partial_sessions_registered_for_retry(tmp_path: Path) -> None:
+    partial_key = live._key(tmp_path / "partial")
+    closed_key = live._key(tmp_path / "closed")
+    partial = _RetryingSession()
+    closed = _RetryingSession(process_exited=True)
+    live._SESSIONS[partial_key] = partial
+    live._SESSIONS[closed_key] = closed
+
+    live.stop_all()
+
+    assert live._SESSIONS[partial_key] is partial
+    assert closed_key not in live._SESSIONS
+    partial.process_exited = True
+    live.stop_all()
+    assert partial_key not in live._SESSIONS
 
 
 def test_stop_game_attempts_external_stop_when_cancellation_is_still_pending(

--- a/tests/test_sdk.py
+++ b/tests/test_sdk.py
@@ -1,7 +1,9 @@
 import io
+import os
 import tarfile
-from pathlib import Path
 import uuid
+from contextlib import contextmanager
+from pathlib import Path
 
 import pytest
 
@@ -11,13 +13,25 @@ from renforge import sdk
 def _write_fake_sdk_archive(path: Path, version: str) -> Path:
     source_root = path / "staging"
     fake_sdk_root = source_root / f"renpy-{version}-sdk"
-    fake_sdk_root.mkdir(parents=True)
+    renpy_package = fake_sdk_root / "renpy"
+    renpy_package.mkdir(parents=True)
     (fake_sdk_root / "renpy.py").write_text("print('renpy')")
+    (renpy_package / "vc_version.py").write_text(f"version = {version!r}\n")
 
     archive_path = path / "renpy-sdk.tar.bz2"
     with tarfile.open(archive_path, "w:bz2") as archive:
-        archive.add(fake_sdk_root / "renpy.py", arcname=f"{fake_sdk_root.name}/renpy.py")
+        archive.add(fake_sdk_root, arcname=fake_sdk_root.name)
     return archive_path
+
+
+def _write_fake_sdk(root: Path, version: str, *, shell_launcher: bool = False) -> Path:
+    (root / "renpy").mkdir(parents=True)
+    (root / "renpy" / "vc_version.py").write_text(f"version = {version!r}\n")
+    launcher = root / ("renpy.sh" if shell_launcher else "renpy.py")
+    launcher.write_text("#!/bin/sh\n" if shell_launcher else "print('renpy')\n")
+    if shell_launcher:
+        launcher.chmod(0o755)
+    return root
 
 
 def _write_traversal_archive(path: Path) -> Path:
@@ -58,6 +72,259 @@ def test_get_or_install_sdk_rejects_path_traversal_in_archive(monkeypatch: pytes
 
     with pytest.raises(ValueError, match="path traversal"):
         sdk.get_or_install_sdk(f"8.3.7-{uuid.uuid4().hex}")
+
+
+def test_get_or_install_sdk_rejects_version_path_traversal(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    cache_dir = tmp_path / "cache"
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    marker = outside / "marker.txt"
+    marker.write_text("preserve")
+    monkeypatch.setenv(sdk.RENPY_SDK_CACHE_ENV, str(cache_dir))
+
+    with pytest.raises(ValueError, match="Invalid Ren'Py version identifier"):
+        sdk.get_or_install_sdk("8.5.3/../../outside")
+
+    assert marker.read_text() == "preserve"
+    assert list(outside.iterdir()) == [marker]
+
+
+def test_project_local_compatible_sdk_has_priority_without_download(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    project = tmp_path / "project"
+    local_sdk = _write_fake_sdk(project / "renpy-sdk", "8.5.4.26010101")
+    cache_sdk = _write_fake_sdk(tmp_path / "cache" / "8.5.3", "8.5.3.26010101")
+    monkeypatch.setenv(sdk.RENPY_SDK_CACHE_ENV, str(cache_sdk.parent))
+    monkeypatch.delenv(sdk.RENPY_SDK_ENV, raising=False)
+    monkeypatch.setattr(
+        sdk,
+        "_download_archive",
+        lambda *_args, **_kwargs: pytest.fail("download must not be attempted"),
+    )
+
+    discovered = sdk.get_or_install_sdk("8.5.3", project_root=project)
+
+    assert discovered.root == local_sdk
+
+
+def test_project_local_sdk_is_not_patched(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    project = tmp_path / "project"
+    local_sdk = _write_fake_sdk(project / "renpy-sdk", "8.5.3")
+    dump = local_sdk / "renpy" / "dump.py"
+    dump.write_text(sdk._DUMP_NAMEMAP_LOOP)
+    monkeypatch.setenv(sdk.RENPY_SDK_CACHE_ENV, str(tmp_path / "cache"))
+    monkeypatch.delenv(sdk.RENPY_SDK_ENV, raising=False)
+
+    discovered = sdk.get_or_install_sdk("8.5.3", project_root=project)
+
+    assert discovered.root == local_sdk
+    assert "renforge: unwrap Node-keyed namemap" not in dump.read_text()
+
+
+def test_explicit_sdk_is_patched(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    explicit_sdk = _write_fake_sdk(tmp_path / "explicit-sdk", "8.5.3")
+    dump = explicit_sdk / "renpy" / "dump.py"
+    dump.write_text(sdk._DUMP_NAMEMAP_LOOP)
+    monkeypatch.setenv(sdk.RENPY_SDK_ENV, str(explicit_sdk))
+    monkeypatch.setenv(sdk.RENPY_SDK_CACHE_ENV, str(tmp_path / "cache"))
+
+    discovered = sdk.get_or_install_sdk("8.5.3")
+
+    assert discovered.root == explicit_sdk
+    assert "renforge: unwrap Node-keyed namemap" in dump.read_text()
+
+
+def test_incompatible_project_sdk_falls_back_to_compatible_cache(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    project = tmp_path / "project"
+    local_sdk = _write_fake_sdk(project / "renpy-sdk", "8.4.9")
+    cache_sdk = _write_fake_sdk(tmp_path / "cache" / "8.5.4", "8.5.4.26010101")
+    monkeypatch.setenv(sdk.RENPY_SDK_CACHE_ENV, str(cache_sdk.parent))
+    monkeypatch.delenv(sdk.RENPY_SDK_ENV, raising=False)
+    monkeypatch.setattr(
+        sdk,
+        "_download_archive",
+        lambda *_args, **_kwargs: pytest.fail("download must not be attempted"),
+    )
+
+    discovered = sdk.get_or_install_sdk("8.5.3", project_root=project)
+
+    assert discovered.root == cache_sdk
+    assert local_sdk.exists()
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX launcher selection")
+def test_windows_native_launcher_is_rejected_on_posix_even_when_executable(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    project = tmp_path / "project"
+    local_sdk = _write_fake_sdk(project / "renpy-sdk", "8.5.3")
+    (local_sdk / "renpy.py").unlink()
+    native_launcher = local_sdk / "renpy.exe"
+    native_launcher.write_text("native")
+    native_launcher.chmod(0o755)
+    cache_sdk = _write_fake_sdk(tmp_path / "cache" / "8.5.3", "8.5.3")
+    monkeypatch.setenv(sdk.RENPY_SDK_CACHE_ENV, str(cache_sdk.parent))
+    monkeypatch.delenv(sdk.RENPY_SDK_ENV, raising=False)
+
+    discovered = sdk.get_or_install_sdk("8.5.3", project_root=project)
+
+    assert discovered.root == cache_sdk
+
+
+def test_project_sdk_symlink_outside_project_is_rejected(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    outside = _write_fake_sdk(tmp_path / "outside-sdk", "8.5.3")
+    (project / "renpy-sdk").symlink_to(outside, target_is_directory=True)
+    cache_sdk = _write_fake_sdk(tmp_path / "cache" / "8.5.3", "8.5.3")
+    monkeypatch.setenv(sdk.RENPY_SDK_CACHE_ENV, str(cache_sdk.parent))
+    monkeypatch.delenv(sdk.RENPY_SDK_ENV, raising=False)
+
+    discovered = sdk.get_or_install_sdk("8.5.3", project_root=project)
+
+    assert discovered.root == cache_sdk
+
+
+def test_cache_sdk_symlink_outside_cache_is_rejected(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    version = "8.5.3"
+    cache_dir = tmp_path / "cache"
+    cache_dir.mkdir()
+    outside = _write_fake_sdk(tmp_path / "outside-sdk", version)
+    (cache_dir / version).symlink_to(outside, target_is_directory=True)
+    archive_path = _write_fake_sdk_archive(tmp_path, version)
+    monkeypatch.setenv(sdk.RENPY_SDK_CACHE_ENV, str(cache_dir))
+    monkeypatch.setenv(sdk.RENPY_SDK_ARCHIVE_URL_ENV, archive_path.as_uri())
+    monkeypatch.delenv(sdk.RENPY_SDK_ENV, raising=False)
+
+    discovered = sdk.get_or_install_sdk(version)
+
+    assert discovered.root == cache_dir / version
+    assert discovered.root.resolve() != outside.resolve()
+    assert outside.exists()
+
+
+def test_corrupt_cache_is_replaced_atomically(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    version = "8.5.3"
+    cache_dir = tmp_path / "cache"
+    corrupt_root = cache_dir / version
+    corrupt_root.mkdir(parents=True)
+    (corrupt_root / "partial.txt").write_text("corrupt")
+    archive_path = _write_fake_sdk_archive(tmp_path, version)
+    monkeypatch.setenv(sdk.RENPY_SDK_CACHE_ENV, str(cache_dir))
+    monkeypatch.setenv(sdk.RENPY_SDK_ARCHIVE_URL_ENV, archive_path.as_uri())
+    monkeypatch.delenv(sdk.RENPY_SDK_ENV, raising=False)
+
+    discovered = sdk.get_or_install_sdk(version)
+
+    assert discovered.root == corrupt_root
+    assert discovered.launcher == corrupt_root / "renpy.py"
+    assert not (corrupt_root / "partial.txt").exists()
+    assert list(cache_dir.glob(f".{version}.corrupt-*")) == []
+    assert (cache_dir / f".{version}.lock").exists()
+
+
+def test_hidden_temporary_cache_sdk_is_never_selected(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    version = "8.5.3"
+    cache_dir = tmp_path / "cache"
+    hidden_sdk = _write_fake_sdk(
+        cache_dir / ".8.5.4.install-concurrent",
+        "8.5.4",
+    )
+    archive_path = _write_fake_sdk_archive(tmp_path, version)
+    monkeypatch.setenv(sdk.RENPY_SDK_CACHE_ENV, str(cache_dir))
+    monkeypatch.setenv(sdk.RENPY_SDK_ARCHIVE_URL_ENV, archive_path.as_uri())
+    monkeypatch.delenv(sdk.RENPY_SDK_ENV, raising=False)
+
+    discovered = sdk.get_or_install_sdk(version)
+
+    assert discovered.root == cache_dir / version
+    assert discovered.root != hidden_sdk
+    assert hidden_sdk.exists()
+
+
+def test_corrupt_target_is_quarantined_when_exists_reports_false(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    version = "8.5.3"
+    cache_dir = tmp_path / "cache"
+    corrupt_root = cache_dir / version
+    corrupt_root.mkdir(parents=True)
+    corrupt_marker = corrupt_root / "partial.txt"
+    corrupt_marker.write_text("corrupt")
+    archive_path = _write_fake_sdk_archive(tmp_path, version)
+    monkeypatch.setenv(sdk.RENPY_SDK_CACHE_ENV, str(cache_dir))
+    monkeypatch.setenv(sdk.RENPY_SDK_ARCHIVE_URL_ENV, archive_path.as_uri())
+    monkeypatch.delenv(sdk.RENPY_SDK_ENV, raising=False)
+    original_exists = Path.exists
+
+    def access_denied_exists(path: Path) -> bool:
+        if path == corrupt_root and original_exists(corrupt_marker):
+            return False
+        return original_exists(path)
+
+    monkeypatch.setattr(Path, "exists", access_denied_exists)
+
+    discovered = sdk.get_or_install_sdk(version)
+
+    assert discovered.root == corrupt_root
+    assert not corrupt_marker.exists()
+    assert discovered.launcher == corrupt_root / "renpy.py"
+
+
+def test_sdk_install_rechecks_cache_after_acquiring_lock(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    version = "8.5.3"
+    cache_dir = tmp_path / "cache"
+    monkeypatch.setenv(sdk.RENPY_SDK_CACHE_ENV, str(cache_dir))
+    monkeypatch.delenv(sdk.RENPY_SDK_ENV, raising=False)
+    original_lock = sdk._sdk_install_lock
+
+    @contextmanager
+    def populate_while_waiting(requested_version: str):
+        with original_lock(requested_version):
+            _write_fake_sdk(cache_dir / requested_version, requested_version)
+            yield
+
+    monkeypatch.setattr(sdk, "_sdk_install_lock", populate_while_waiting)
+    monkeypatch.setattr(
+        sdk,
+        "_download_archive",
+        lambda *_args, **_kwargs: pytest.fail("download must not be attempted"),
+    )
+
+    discovered = sdk.get_or_install_sdk(version)
+
+    assert discovered.root == cache_dir / version
 
 
 def test_patch_sdk_json_dump_unwraps_node_keyed_namemap(tmp_path: Path) -> None:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2,10 +2,23 @@ import asyncio
 import base64
 import io
 import json
+import threading
 
 import pytest
 
-from renforge.server import _FallbackServer, create_app
+from renforge.server import _FallbackServer, _register_tools, create_app
+
+
+class _ToolRegistry:
+    def __init__(self) -> None:
+        self.tools = {}
+
+    def tool(self):
+        def register(fn):
+            self.tools[fn.__name__] = fn
+            return fn
+
+        return register
 
 EXPECTED_TOOLS = {
     # static
@@ -290,6 +303,199 @@ def test_launch_tool_prefers_the_active_dashboard_process(tmp_path, monkeypatch)
         "version": "stable",
         "warp": "game/script.rpy:42",
     }
+
+
+def test_stop_tool_prefers_the_active_dashboard_process(tmp_path, monkeypatch) -> None:
+    from renforge import dashboard_client
+    from renforge.tools import live
+
+    calls = {}
+
+    def fake_dashboard_stop(project_path: str):
+        calls["project_path"] = project_path
+        return {"ok": True, "was_running": True, "via": "dashboard"}
+
+    monkeypatch.setattr(dashboard_client, "stop_game", fake_dashboard_stop)
+    monkeypatch.setattr(
+        live,
+        "stop_game",
+        lambda *_args, **_kwargs: pytest.fail("direct stop should not run"),
+    )
+
+    app = _ToolRegistry()
+    _register_tools(app)
+    result = app.tools["renforge_stop"](str(tmp_path))
+
+    assert result == {
+        "ok": True,
+        "was_running": True,
+        "via": "dashboard",
+    }
+    assert calls == {"project_path": str(tmp_path)}
+
+
+def test_stop_tool_falls_back_when_dashboard_is_unavailable(tmp_path, monkeypatch) -> None:
+    from renforge import dashboard_client
+    from renforge.tools import live
+
+    calls = {}
+    monkeypatch.setattr(dashboard_client, "stop_game", lambda _project_path: None)
+
+    def fake_direct_stop(project_path: str):
+        calls["project_path"] = project_path
+        return {"ok": True, "was_running": False}
+
+    monkeypatch.setattr(live, "stop_game", fake_direct_stop)
+
+    app = _ToolRegistry()
+    _register_tools(app)
+    result = app.tools["renforge_stop"](str(tmp_path))
+
+    assert result == {"ok": True, "was_running": False}
+    assert calls == {"project_path": str(tmp_path)}
+
+
+def test_cancelled_dashboard_launch_stops_through_its_owner(tmp_path, monkeypatch) -> None:
+    from renforge import dashboard_client
+    from renforge.tools import live
+
+    cancel_event = threading.Event()
+    calls = {"stops": 0}
+
+    def fake_dashboard_launch(*_args, **_kwargs):
+        cancel_event.set()
+        return {"ok": True, "via": "dashboard"}
+
+    def fake_dashboard_stop(project_path: str):
+        calls["stops"] += 1
+        calls["project_path"] = project_path
+        return {"ok": True, "via": "dashboard"}
+
+    monkeypatch.setattr(dashboard_client, "launch_game", fake_dashboard_launch)
+    monkeypatch.setattr(dashboard_client, "stop_game", fake_dashboard_stop)
+    monkeypatch.setattr(
+        live,
+        "start_launch",
+        lambda _project_path, launch: launch(cancel_event),
+    )
+    monkeypatch.setattr(
+        live,
+        "stop_external_game",
+        lambda *_args, **_kwargs: pytest.fail("must stop through the dashboard owner"),
+    )
+
+    app = _ToolRegistry()
+    _register_tools(app)
+    result = app.tools["renforge_launch"](str(tmp_path))
+
+    assert result["code"] == "LAUNCH_CANCELLED"
+    assert calls == {"stops": 1, "project_path": str(tmp_path)}
+
+
+@pytest.mark.parametrize(
+    ("stop_result", "expected_code"),
+    [
+        (None, "DASHBOARD_STOP_UNAVAILABLE"),
+        (
+            {
+                "ok": False,
+                "code": "DASHBOARD_STOP_REJECTED",
+                "error": "owner refused stop",
+                "details": {"owner": "dashboard"},
+            },
+            "DASHBOARD_STOP_REJECTED",
+        ),
+    ],
+)
+def test_cancelled_dashboard_launch_reports_owner_stop_failure(
+    tmp_path,
+    monkeypatch,
+    stop_result,
+    expected_code,
+) -> None:
+    from renforge import dashboard_client
+    from renforge.tools import live
+
+    cancel_event = threading.Event()
+
+    def fake_dashboard_launch(*_args, **_kwargs):
+        cancel_event.set()
+        return {"ok": True, "via": "dashboard"}
+
+    monkeypatch.setattr(dashboard_client, "launch_game", fake_dashboard_launch)
+    monkeypatch.setattr(
+        dashboard_client,
+        "stop_game",
+        lambda _project_path: stop_result,
+    )
+    monkeypatch.setattr(
+        live,
+        "start_launch",
+        lambda _project_path, launch: launch(cancel_event),
+    )
+    monkeypatch.setattr(
+        live,
+        "stop_external_game",
+        lambda *_args, **_kwargs: pytest.fail("must not bypass dashboard ownership"),
+    )
+
+    app = _ToolRegistry()
+    _register_tools(app)
+    result = app.tools["renforge_launch"](str(tmp_path))
+
+    assert result["ok"] is False
+    assert result["ready"] is False
+    assert result["code"] == expected_code
+    assert result["launch_cancel_requested"] is True
+    if stop_result is not None:
+        assert result["error"] == "owner refused stop"
+        assert result["details"] == {"owner": "dashboard"}
+
+
+def test_cancelled_launch_propagates_external_lock_conflict(tmp_path, monkeypatch) -> None:
+    from renforge import dashboard_client
+    from renforge.tools import live
+
+    cancel_event = threading.Event()
+
+    def unavailable_dashboard(*_args, **_kwargs):
+        cancel_event.set()
+        return None
+
+    monkeypatch.setattr(dashboard_client, "launch_game", unavailable_dashboard)
+    monkeypatch.setattr(
+        dashboard_client,
+        "stop_game",
+        lambda *_args, **_kwargs: pytest.fail("dashboard did not own this launch"),
+    )
+    monkeypatch.setattr(
+        live,
+        "start_launch",
+        lambda _project_path, launch: launch(cancel_event),
+    )
+    monkeypatch.setattr(
+        live,
+        "stop_external_game",
+        lambda _project_path: {
+            "ok": False,
+            "ready": False,
+            "code": "BRIDGE_PROJECT_LOCKED",
+            "phase": "acquiring_project_lock",
+            "error": "another owner holds the lock",
+            "details": {"owner": "external"},
+        },
+    )
+
+    app = _ToolRegistry()
+    _register_tools(app)
+    result = app.tools["renforge_launch"](str(tmp_path))
+
+    assert result["ok"] is False
+    assert result["ready"] is False
+    assert result["code"] == "BRIDGE_PROJECT_LOCKED"
+    assert result["phase"] == "acquiring_project_lock"
+    assert result["launch_cancel_requested"] is True
+    assert result["details"] == {"owner": "external"}
 
 
 def test_jump_tool_resolves_a_label_and_relaunches_at_it(tmp_path, monkeypatch) -> None:

--- a/tests/test_ui_backend.py
+++ b/tests/test_ui_backend.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -501,8 +502,12 @@ def test_story_map_caches_after_first_build(tmp_path: Path, monkeypatch) -> None
     monkeypatch.setattr(graph, "scan_project", fake_scan)
     monkeypatch.setattr(graph, "run_native_dump", fake_run_native)
     monkeypatch.setattr(graph, "normalize_definitions", fake_normalize)
-    monkeypatch.setattr(graph, "RenpyProject", lambda _root: object())
-    monkeypatch.setattr(graph, "get_or_install_sdk", lambda: "sdk")
+    monkeypatch.setattr(
+        graph,
+        "RenpyProject",
+        lambda root: SimpleNamespace(abs_root=Path(root).resolve()),
+    )
+    monkeypatch.setattr(graph, "get_or_install_sdk", lambda **_kwargs: "sdk")
 
     first = graph.build_story_map(project)
     second = graph.build_story_map(project)


### PR DESCRIPTION
## What changed

- resolve Ren'Py runtimes from validated project-local candidates before the managed cache
- validate runtime provenance, executability, platform and compatibility
- repair corrupt managed SDKs under an inter-process lock with atomic publication
- isolate bridge ownership per project and retain ownership through incomplete teardown
- preserve dashboard-owned launch and stop paths
- add targeted regression coverage for runtime fallback, project locks and cancellation paths

## Why

Concurrent RenForge servers could race over bridge artifacts, while runtime discovery could select an unrelated or incompatible SDK. This makes runtime selection project-aware and makes bridge lifecycle ownership explicit across processes.

## Validation

- `python3 -m pytest -q` — 242 passed, 66 skipped
- `python3 -m compileall -q src/renforge tests`
- `git diff --check`
- `cd ui && npm ci && npm run build`
- independent inter-process lock contention and reacquisition check
