### PR TITLE
fix(scanner): gérer la clause Ren’Py call from

### DIFF
--- a/src/renforge/scanner.py
+++ b/src/renforge/scanner.py
@@ -11,6 +11,9 @@ LABEL_RE = re.compile(
 )
 JUMP_RE = re.compile(r"^\s*jump\s+(.+?)\s*(?:#.*)?$")
 CALL_RE = re.compile(r"^\s*call\s+(.+?)\s*(?:#.*)?$")
+CALL_FROM_RE = re.compile(
+    r"\s+from\s+(?:(?:[A-Za-z_][\w]*(?:\.[A-Za-z_][\w]*)*)|(?:\.[A-Za-z_][\w]*))\s*$"
+)
 MENU_RE = re.compile(r"^\s*menu\b(.*):\s*(?:#.*)?$")
 SCREEN_RE = re.compile(r"^\s*screen\s+[A-Za-z_][\w]*")
 CHOICE_RE = re.compile(r"^\s*['\"](.+?)['\"]\s*:\s*(?:#.*)?$")
@@ -187,7 +190,7 @@ def scan_project(project_path: str) -> Dict[str, Any]:
 
                 match = CALL_RE.match(line)
                 if match:
-                    target = match.group(1).strip()
+                    target = CALL_FROM_RE.sub("", match.group(1)).strip()
                     if target.startswith(".") and current_global_label:
                         target = current_global_label + target
                     item_fields = {"target": target}

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -108,6 +108,60 @@ def test_scan_project_resolves_local_and_dotted_labels(tmp_path: Path) -> None:
     assert result["jumps"][0]["target"] == "route.chapter.detail"
 
 
+def test_scan_project_strips_from_clause_from_static_call_target(tmp_path: Path) -> None:
+    game = tmp_path / "game"
+    game.mkdir(parents=True)
+    (game / "script.rpy").write_text(
+        "label start:\n"
+        "    call destination from _call_destination_1\n"
+        "label destination:\n"
+        "    return\n",
+        encoding="utf-8",
+    )
+
+    result = scan_project(str(tmp_path))
+
+    assert result["calls"][0]["target"] == "destination"
+    assert result["calls"][0]["kind"] == "static"
+    assert result["unresolved_targets"] == []
+
+
+def test_scan_project_strips_from_clause_and_resolves_local_call_target(tmp_path: Path) -> None:
+    game = tmp_path / "game"
+    game.mkdir(parents=True)
+    (game / "script.rpy").write_text(
+        "label route:\n"
+        "    call .detail from _call_detail_1\n"
+        "label .detail:\n"
+        "    return\n",
+        encoding="utf-8",
+    )
+
+    result = scan_project(str(tmp_path))
+
+    assert result["calls"][0]["target"] == "route.detail"
+    assert result["calls"][0]["kind"] == "static"
+    assert result["unresolved_targets"] == []
+
+
+def test_scan_project_strips_from_clause_without_breaking_dynamic_call_target(
+    tmp_path: Path,
+) -> None:
+    game = tmp_path / "game"
+    game.mkdir(parents=True)
+    (game / "script.rpy").write_text(
+        "label start:\n"
+        "    call expression next_label from _call_expression_1\n",
+        encoding="utf-8",
+    )
+
+    result = scan_project(str(tmp_path))
+
+    assert result["calls"][0]["target"] == "expression next_label"
+    assert result["calls"][0]["kind"] == "dynamic"
+    assert result["unresolved_targets"] == []
+
+
 def test_scan_project_excludes_screen_language_labels(tmp_path: Path) -> None:
     game = tmp_path / "game"
     game.mkdir(parents=True)


### PR DESCRIPTION
## Résumé
- retire la clause terminale `from <statement-label>` des cibles `call`
- préserve les appels dynamiques `call expression`
- résout correctement les labels locaux
- évite les nœuds fantômes dans la Story Map et les résultats MCP

## Vérifications
- `python -m pytest -q tests/test_scanner.py` : 8 réussis
- `python -m pytest -q` : 298 réussis, 13 ignorés
- `python -m compileall -q src tests` : OK

## Summary by Sourcery

Handle Ren'Py `call` statements with `from` clauses correctly in the scanner to produce accurate call targets.

Bug Fixes:
- Strip trailing `from <label>` clauses from static call targets while preserving dynamic `call expression` targets.
- Resolve local call targets correctly after removing the `from` clause, avoiding ghost nodes in story maps and MCP results.

Tests:
- Add scanner tests covering static calls with `from` clauses, local-label calls with `from` clauses, and dynamic calls with `from` clauses to ensure correct target resolution.