### PR TITLE
fix: prevent project picker root tabs from shrinking when file list overflows

### DIFF
--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -340,7 +340,7 @@ a { color: var(--accent); text-decoration: none; }
 .eyebrow { font-family: var(--font-mono); font-size: 10px; letter-spacing: .1em; text-transform: uppercase; color: var(--meta); margin-bottom: 3px; }
 .project-picker-close { width: 30px; height: 30px; border: 0; border-radius: 50%; background: var(--surface); color: var(--fg-2); cursor: pointer; font-size: 22px; line-height: 1; }
 .project-picker-close:hover { background: var(--raised); color: var(--fg); }
-.project-picker-roots { display: flex; gap: 6px; overflow-x: auto; padding: var(--space-3) var(--space-5) 0; }
+.project-picker-roots { display: flex; gap: 6px; overflow-x: auto; padding: var(--space-3) var(--space-5) 0; flex-shrink: 0; }
 .project-picker-root { flex: none; border: 1px solid var(--border-soft); border-radius: var(--radius-pill); padding: 5px 10px; background: transparent; color: var(--muted); cursor: pointer; font-size: 12px; }
 .project-picker-root:hover, .project-picker-root.active { border-color: var(--accent); background: var(--accent-soft); color: var(--accent); }
 .project-picker-path { display: flex; align-items: center; gap: var(--space-3); min-width: 0; padding: var(--space-3) var(--space-5); }


### PR DESCRIPTION
The `.project-picker-roots` row (drive tabs) lacks `flex-shrink: 0`, so when the file list contains many entries, the flex column layout compresses the root tabs row to make room — making them unreadable.

This adds `flex-shrink: 0` so the root tabs always retain their natural height regardless of list content.

Before: root tabs (C: D: E: …) get squished when browsing a directory with many subfolders.
After: root tabs stay fixed height, file list scrolls independently.
<img width="1141" height="483" alt="image" src="https://github.com/user-attachments/assets/bf2651f9-cb2e-4884-9739-5c6b96ddddba" />

## Summary by Sourcery

Corrections de bugs :
- Empêcher les onglets racine du sélecteur de projet de se rétrécir verticalement lorsque les répertoires contiennent de nombreuses entrées.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent project picker root tabs from shrinking vertically when directories contain many entries.

</details>