### PR TITLE
fix: release synthetic pointer state after bridge input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@ versioning.
 
 ### Fixed
 
+- Pointer operations now use one shared bridge input layer. Native hover prefers
+  `renpy.set_mouse_pos(..., duration=0)`, clicks synchronously deliver balanced
+  test-marked mouse-button events to the focused displayable, and fallbacks always
+  release `testmouse` state so physical input immediately reclaims hover control.
 - Runtime discovery now prefers validated project-local Ren'Py SDKs and safely
   falls back to compatible managed SDKs with locked, atomic cache repair.
 - Concurrent RenForge servers now isolate bridge ownership per project,

--- a/src/renforge/bridge/bridge.rpy
+++ b/src/renforge/bridge/bridge.rpy
@@ -1466,8 +1466,154 @@ init python:
             pass
         return result
 
+    def _renforge_is_end_interaction(exc):
+        end_interaction = getattr(
+            getattr(getattr(renpy, "display", None), "core", None),
+            "EndInteraction",
+            None,
+        )
+        return end_interaction is not None and isinstance(exc, end_interaction)
+
+
+    def _renforge_reset_testmouse_state():
+        testmouse = getattr(getattr(renpy, "test", None), "testmouse", None)
+        if testmouse is None:
+            return
+        try:
+            setattr(testmouse, "mouse_pos", None)
+        except Exception:
+            pass
+        mouse_buttons = getattr(testmouse, "mouse_buttons", None)
+        if mouse_buttons is None:
+            return
+        if isinstance(mouse_buttons, dict):
+            for key in list(mouse_buttons.keys()):
+                mouse_buttons[key] = False
+            return
+        if isinstance(mouse_buttons, tuple):
+            mouse_buttons = list(mouse_buttons)
+            setattr(testmouse, "mouse_buttons", mouse_buttons)
+        if isinstance(mouse_buttons, list):
+            for index in range(len(mouse_buttons)):
+                try:
+                    mouse_buttons[index] = False
+                except Exception:
+                    mouse_buttons[index] = 0
+
+
+    def _renforge_dispatch_mouse_motion(px, py):
+        if pygame is None:
+            return False
+        event_type = getattr(pygame, "MOUSEMOTION", None)
+        event_factory = getattr(getattr(pygame, "event", None), "Event", None)
+        post = getattr(getattr(pygame, "event", None), "post", None)
+        if event_type is None or not callable(event_factory):
+            return False
+        payload = {"pos": (px, py), "rel": (0, 0), "buttons": (0, 0, 0)}
+        try:
+            event = event_factory(event_type, **payload)
+        except TypeError:
+            event = event_factory(event_type, payload)
+        if callable(post):
+            post(event)
+        mouse_handler = getattr(
+            getattr(getattr(renpy, "display", None), "focus", None), "mouse_handler", None
+        )
+        if callable(mouse_handler):
+            mouse_handler(event, px, py, False)
+        return True
+
+    def _renforge_dispatch_mouse_click(x, y, button=1):
+        if pygame is None:
+            return False
+        event_factory = getattr(getattr(pygame, "event", None), "Event", None)
+        if event_factory is None:
+            return False
+        event_type = getattr(pygame, "MOUSEBUTTONDOWN", None)
+        up_type = getattr(pygame, "MOUSEBUTTONUP", None)
+        if event_type is None or up_type is None:
+            return False
+        payload = {
+            "button": button,
+            "pos": (x, y),
+            "x": x,
+            "y": y,
+            "touch": False,
+            "test": True,
+            "mod": 0,
+        }
+        try:
+            down = event_factory(event_type, **payload)
+            up = event_factory(up_type, **payload)
+        except TypeError:
+            down = event_factory(event_type, payload)
+            up = event_factory(up_type, payload)
+        focus_module = getattr(getattr(renpy, "display", None), "focus", None)
+        mouse_handler = getattr(focus_module, "mouse_handler", None)
+        get_focused = getattr(focus_module, "get_focused", None)
+        if not callable(mouse_handler) or not callable(get_focused):
+            return False
+        mouse_handler(down, x, y, False)
+        focused = get_focused()
+        event_handler = getattr(focused, "event", None)
+        if not callable(event_handler):
+            return False
+        local_x, local_y = x, y
+        for focus in reversed(list(getattr(focus_module, "focus_list", []) or [])):
+            if getattr(focus, "widget", None) is not focused:
+                continue
+            focus_x = getattr(focus, "x", None)
+            focus_y = getattr(focus, "y", None)
+            if focus_x is not None and focus_y is not None:
+                local_x, local_y = x - focus_x, y - focus_y
+            break
+        ignore_event = getattr(getattr(renpy, "display", None), "core", None)
+        ignore_event = getattr(ignore_event, "IgnoreEvent", None)
+        no_interaction_result = object()
+        interaction_result = no_interaction_result
+        for event in (down, up):
+            try:
+                rv = event_handler(event, local_x, local_y, 0)
+                if rv is not None and interaction_result is no_interaction_result:
+                    interaction_result = rv
+            except Exception as exc:
+                if ignore_event is None or not isinstance(exc, ignore_event):
+                    raise
+        if interaction_result is not no_interaction_result:
+            end_interaction = getattr(renpy, "end_interaction", None)
+            if callable(end_interaction):
+                end_interaction(interaction_result)
+        return True
+
+    def _renforge_click_pointer(x, y):
+        interface = getattr(getattr(renpy, "display", None), "interface", None)
+        if interface is not None:
+            try:
+                interface.mouse_focused = True
+            except Exception:
+                pass
+            try:
+                interface.ignore_touch = False
+            except Exception:
+                pass
+
+        _renforge_reset_testmouse_state()
+        try:
+            _renforge_dispatch_mouse_motion(x, y)
+            if _renforge_dispatch_mouse_click(x, y):
+                return "renpy"
+
+            testmouse = getattr(getattr(renpy, "test", None), "testmouse", None)
+            click_mouse = getattr(testmouse, "click_mouse", None)
+            if callable(click_mouse):
+                click_mouse(1, x, y)
+                return "renpy-test"
+            raise RuntimeError("Ren'Py synthetic mouse API is unavailable")
+        finally:
+            _renforge_reset_testmouse_state()
+
     def _renforge_click_focus(focus):
-        """Click a focus center through Ren'Py's synthetic test input path."""
+        """Click a focus center through shared synthetic input path."""
         fx = getattr(focus, "x", None)
         fy = getattr(focus, "y", None)
         fw = getattr(focus, "w", None)
@@ -1483,21 +1629,13 @@ init python:
             px, py = find_position(focus, (None, None))
             x, y = int(px), int(py)
 
-        interface = getattr(getattr(renpy, "display", None), "interface", None)
-        if interface is not None:
-            try:
-                interface.mouse_focused = True
-            except Exception:
-                pass
-            try:
-                interface.ignore_touch = False
-            except Exception:
-                pass
-        testmouse = getattr(getattr(renpy, "test", None), "testmouse", None)
-        click_mouse = getattr(testmouse, "click_mouse", None)
-        if not callable(click_mouse):
-            raise RuntimeError("Ren'Py synthetic mouse API is unavailable")
-        click_mouse(1, x, y)
+        try:
+            _renforge_click_pointer(x, y)
+        except Exception as exc:
+            if not _renforge_is_end_interaction(exc):
+                raise
+            setattr(exc, "renforge_pointer", (x, y))
+            raise
         return x, y
 
     def _renforge_resolve_ui_element(payload, action):
@@ -1558,7 +1696,14 @@ init python:
                 }
         if not element.get("enabled", True):
             return {"ok": False, "error": "UI element is disabled", "element": element}
-        x, y = _renforge_click_focus(focus)
+        pending_end_interaction = None
+        try:
+            x, y = _renforge_click_focus(focus)
+        except Exception as exc:
+            if not _renforge_is_end_interaction(exc):
+                raise
+            pending_end_interaction = exc
+            x, y = getattr(exc, "renforge_pointer")
         # Report which focusable actually owns this coordinate (coverage).
         hit = _renforge_hit_stack(x, y)
         topmost = hit.get("topmost")
@@ -1615,6 +1760,9 @@ init python:
             )
         if screenshot_digest is not None:
             result["sha256"] = screenshot_digest
+        if pending_end_interaction is not None:
+            setattr(pending_end_interaction, "renforge_result", result)
+            raise pending_end_interaction
         return result
 
     def _renforge_hit_stack(x, y):
@@ -1699,57 +1847,55 @@ init python:
             except Exception:
                 pass
 
-        def _renforge_dispatch_mouse_motion(px, py):
-            """Drive Ren'Py focus/hover state without a player interact loop.
-
-            Posting MOUSEMOTION to pygame is not enough: ImageButton hover uses
-            ``focus.mouse_handler`` during event dispatch. Bridge RPC must call
-            it directly on the main thread after ``testmouse.move_mouse``.
-            """
-            if pygame is None:
-                return False
-            event_type = getattr(pygame, "MOUSEMOTION", None)
-            event_factory = getattr(getattr(pygame, "event", None), "Event", None)
-            post = getattr(getattr(pygame, "event", None), "post", None)
-            if event_type is None or not callable(event_factory):
-                return False
-            event = event_factory(event_type, {"pos": (px, py), "rel": (0, 0), "buttons": (0, 0, 0)})
-            if callable(post):
-                post(event)
-            mouse_handler = getattr(getattr(getattr(renpy, "display", None), "focus", None), "mouse_handler", None)
-            if callable(mouse_handler):
-                mouse_handler(event, px, py, False)
-            return True
-
-        restart_interaction = getattr(renpy, "restart_interaction", None)
+        set_mouse_pos = getattr(renpy, "set_mouse_pos", None)
         testmouse = getattr(getattr(renpy, "test", None), "testmouse", None)
         move_mouse = getattr(testmouse, "move_mouse", None)
-        if callable(move_mouse):
-            try:
-                move_mouse(x, y)
-            except TypeError:
-                pass
-            else:
-                _renforge_dispatch_mouse_motion(x, y)
-                if callable(restart_interaction):
-                    restart_interaction()
-                return x, y, "renpy-test"
-        set_mouse_pos = getattr(renpy, "set_mouse_pos", None)
-        if callable(set_mouse_pos):
-            try:
-                set_mouse_pos(x, y)
-            except TypeError:
-                pass
-            else:
-                _renforge_dispatch_mouse_motion(x, y)
-                if callable(restart_interaction):
-                    restart_interaction()
-                return x, y, "renpy"
-        if not _renforge_dispatch_mouse_motion(x, y):
-            raise RuntimeError("hover unavailable: pygame mouse-motion API is unavailable")
-        if callable(restart_interaction):
-            restart_interaction()
-        return x, y, "pygame"
+        restart_interaction = getattr(renpy, "restart_interaction", None)
+        used_native_set_mouse = False
+
+        _renforge_reset_testmouse_state()
+        try:
+            if callable(set_mouse_pos):
+                try:
+                    set_mouse_pos(x, y, duration=0)
+                except TypeError:
+                    try:
+                        set_mouse_pos(x, y, 0)
+                    except TypeError:
+                        try:
+                            set_mouse_pos(x, y)
+                        except TypeError:
+                            pass
+                        else:
+                            used_native_set_mouse = True
+                    else:
+                        used_native_set_mouse = True
+                else:
+                    used_native_set_mouse = True
+                if used_native_set_mouse:
+                    _renforge_dispatch_mouse_motion(x, y)
+                    if callable(restart_interaction):
+                        restart_interaction()
+                    return x, y, "renpy"
+
+            if callable(move_mouse):
+                try:
+                    move_mouse(x, y)
+                except TypeError:
+                    pass
+                else:
+                    _renforge_dispatch_mouse_motion(x, y)
+                    if callable(restart_interaction):
+                        restart_interaction()
+                    return x, y, "renpy-test"
+
+            if not _renforge_dispatch_mouse_motion(x, y):
+                raise RuntimeError("hover unavailable: pygame mouse-motion API is unavailable")
+            if callable(restart_interaction):
+                restart_interaction()
+            return x, y, "pygame"
+        finally:
+            _renforge_reset_testmouse_state()
 
     def _renforge_h_hover_element(payload):
         payload = payload or {}
@@ -1977,24 +2123,19 @@ init python:
         if coordinate_error is not None:
             return {"ok": False, "error": coordinate_error}
 
-        interface = getattr(getattr(renpy, "display", None), "interface", None)
-        if interface is not None:
-            try:
-                interface.mouse_focused = True
-            except Exception:
-                pass
-            try:
-                interface.ignore_touch = False
-            except Exception:
-                pass
-        testmouse = getattr(getattr(renpy, "test", None), "testmouse", None)
-        click_mouse = getattr(testmouse, "click_mouse", None)
-        if not callable(click_mouse):
-            return {"ok": False, "error": "Ren'Py synthetic mouse API is unavailable"}
-        click_mouse(1, x, y)
+        pending_end_interaction = None
+        try:
+            _renforge_click_pointer(x, y)
+        except Exception as exc:
+            if not _renforge_is_end_interaction(exc):
+                raise
+            pending_end_interaction = exc
         result = {"ok": True, "x": x, "y": y, "coordinate_space": coordinate_space}
         if screenshot_digest is not None:
             result["sha256"] = screenshot_digest
+        if pending_end_interaction is not None:
+            setattr(pending_end_interaction, "renforge_result", result)
+            raise pending_end_interaction
         return result
 
     def _renforge_h_get_displayable_bounds(payload):
@@ -2193,8 +2334,18 @@ init python:
             except Exception:
                 pass
 
-        renpy.test.testmouse.click_mouse(1, x, y)
-        return {"ok": True, "text": chosen, "x": x, "y": y}
+        pending_end_interaction = None
+        try:
+            _renforge_click_pointer(x, y)
+        except Exception as exc:
+            if not _renforge_is_end_interaction(exc):
+                raise
+            pending_end_interaction = exc
+        result = {"ok": True, "text": chosen, "x": x, "y": y}
+        if pending_end_interaction is not None:
+            setattr(pending_end_interaction, "renforge_result", result)
+            raise pending_end_interaction
+        return result
 
     # -- scene_tree: full-scene perception for non-multimodal agents -------
     #
@@ -2807,6 +2958,9 @@ init python:
         bridge = _renforge_runtime.bridge
         if bridge is None:
             return
+        if bridge.stop.is_set():
+            _renforge_reset_testmouse_state()
+            return
         _renforge_watch_runtime_effects()
         while True:
             try:
@@ -2816,6 +2970,7 @@ init python:
             handler = _RENFORGE_HANDLERS.get(req.command)
             correlation = None
             explicit_correlation = None
+            propagate = None
             try:
                 if handler is None:
                     req.error = "unknown_command: %s" % req.command
@@ -2843,10 +2998,30 @@ init python:
                         result.setdefault("interaction_id", explicit_correlation)
                     req.result = result
             except Exception as exc:
-                req.error = "%s: %s" % (type(exc).__name__, exc)
+                end_interaction = getattr(
+                    getattr(getattr(renpy, "display", None), "core", None),
+                    "EndInteraction",
+                    None,
+                )
+                if end_interaction is not None and isinstance(exc, end_interaction):
+                    preserved_result = getattr(exc, "renforge_result", None)
+                    if isinstance(preserved_result, builtins.dict):
+                        preserved_result = builtins.dict(preserved_result)
+                        preserved_result["ended_interaction"] = True
+                        if explicit_correlation is not None:
+                            preserved_result.setdefault("interaction_id", explicit_correlation)
+                        req.result = preserved_result
+                    else:
+                        req.result = {"ok": True, "ended_interaction": True}
+                    propagate = exc
+                else:
+                    req.error = "%s: %s" % (type(exc).__name__, exc)
             finally:
                 bridge.current_correlation_id = None
+                _renforge_reset_testmouse_state()
                 req.event.set()
+            if propagate is not None:
+                raise propagate
 
     # --- listener: background thread --------------------------------------
 

--- a/tests/test_bridge_runtime.py
+++ b/tests/test_bridge_runtime.py
@@ -125,6 +125,13 @@ def _fake_renpy(store):
     renpy._clicks = []
     renpy._moves = []
 
+    def _move_mouse(x, y):
+        renpy._moves.append((x, y))
+        renpy.test.testmouse.mouse_pos = (x, y)
+
+    def _click_mouse(button, x, y):
+        renpy._clicks.append((button, x, y))
+
     def _find_focus(pattern, raw=False):
         for focus in focus_list:
             if focus.widget is None:
@@ -139,8 +146,10 @@ def _fake_renpy(store):
     renpy.test = types.SimpleNamespace(
         testfocus=types.SimpleNamespace(find_focus=_find_focus, find_position=_find_position),
         testmouse=types.SimpleNamespace(
-            click_mouse=lambda button, x, y: renpy._clicks.append((button, x, y)),
-            move_mouse=lambda x, y: renpy._moves.append((x, y)),
+            click_mouse=_click_mouse,
+            move_mouse=_move_mouse,
+            mouse_pos=None,
+            mouse_buttons=[False, False, False],
         ),
     )
 
@@ -219,6 +228,7 @@ def running_bridge(tmp_path, monkeypatch):
     pygame.TEXTINPUT = 1
     pygame.KEYDOWN = 2
     pygame.KEYUP = 3
+    pygame.MOUSEMOTION = 6
     pygame.MOUSEBUTTONDOWN = 4
     pygame.MOUSEBUTTONUP = 5
     pygame.K_F1 = 101
@@ -637,6 +647,319 @@ def test_select_choice_without_match_returns_error(running_bridge):
     assert "error" in reply
 
 
+def test_dispatch_mouse_click_delivers_down_and_up_to_focused_widget(running_bridge):
+    globs = running_bridge.globs
+    renpy = running_bridge.renpy
+    pygame = globs["pygame"]
+    seen = []
+
+    class Focused:
+        def event(self, event, x, y, st):
+            seen.append((event, x, y, st))
+
+    focus_module = renpy.display.focus
+    original_get_focused = getattr(focus_module, "get_focused", None)
+    original_mouse_handler = getattr(focus_module, "mouse_handler", None)
+    focus_module.get_focused = lambda: Focused()
+    focus_module.mouse_handler = lambda event, x, y, default: None
+    try:
+        assert globs["_renforge_dispatch_mouse_click"](60, 50) is True
+    finally:
+        if original_get_focused is None:
+            delattr(focus_module, "get_focused")
+        else:
+            focus_module.get_focused = original_get_focused
+        if original_mouse_handler is None:
+            delattr(focus_module, "mouse_handler")
+        else:
+            focus_module.mouse_handler = original_mouse_handler
+
+    down, up = seen[0][0], seen[1][0]
+    assert [down.type, up.type] == [pygame.MOUSEBUTTONDOWN, pygame.MOUSEBUTTONUP]
+    assert down.button == up.button == 1
+    assert down.pos == up.pos == (60, 50)
+    assert down.test is up.test is True
+    assert [(item[1], item[2], item[3]) for item in seen] == [(60, 50, 0), (60, 50, 0)]
+
+
+def test_dispatch_mouse_click_uses_focused_displayable_local_coordinates(running_bridge):
+    globs = running_bridge.globs
+    renpy = running_bridge.renpy
+    seen = []
+
+    class Focused:
+        def event(self, event, x, y, st):
+            seen.append((x, y, st))
+
+    focused = Focused()
+    focus_record = types.SimpleNamespace(widget=focused, x=40, y=30)
+    focus_module = renpy.display.focus
+    original_get_focused = getattr(focus_module, "get_focused", None)
+    original_mouse_handler = getattr(focus_module, "mouse_handler", None)
+    focus_module.focus_list.append(focus_record)
+    focus_module.get_focused = lambda: focused
+    focus_module.mouse_handler = lambda event, x, y, default: None
+    try:
+        assert globs["_renforge_dispatch_mouse_click"](70, 80) is True
+    finally:
+        focus_module.focus_list.remove(focus_record)
+        if original_get_focused is None:
+            delattr(focus_module, "get_focused")
+        else:
+            focus_module.get_focused = original_get_focused
+        if original_mouse_handler is None:
+            delattr(focus_module, "mouse_handler")
+        else:
+            focus_module.mouse_handler = original_mouse_handler
+
+    assert seen == [(30, 50, 0), (30, 50, 0)]
+
+
+def test_dispatch_mouse_click_delivers_up_after_down_is_ignored(running_bridge):
+    globs = running_bridge.globs
+    renpy = running_bridge.renpy
+    pygame = globs["pygame"]
+    seen = []
+
+    class FakeIgnoreEvent(Exception):
+        pass
+
+    class Focused:
+        def event(self, event, x, y, st):
+            seen.append(event.type)
+            if event.type == pygame.MOUSEBUTTONDOWN:
+                raise FakeIgnoreEvent()
+
+    focus_module = renpy.display.focus
+    original_core_module = getattr(renpy.display, "core", None)
+    core_module = original_core_module or types.SimpleNamespace()
+    renpy.display.core = core_module
+    original_get_focused = getattr(focus_module, "get_focused", None)
+    original_mouse_handler = getattr(focus_module, "mouse_handler", None)
+    original_ignore_event = getattr(core_module, "IgnoreEvent", None)
+    focus_module.get_focused = lambda: Focused()
+    focus_module.mouse_handler = lambda event, x, y, default: None
+    core_module.IgnoreEvent = FakeIgnoreEvent
+    try:
+        assert globs["_renforge_dispatch_mouse_click"](22, 33) is True
+    finally:
+        if original_get_focused is None:
+            delattr(focus_module, "get_focused")
+        else:
+            focus_module.get_focused = original_get_focused
+        if original_mouse_handler is None:
+            delattr(focus_module, "mouse_handler")
+        else:
+            focus_module.mouse_handler = original_mouse_handler
+        if original_ignore_event is None:
+            delattr(core_module, "IgnoreEvent")
+        else:
+            core_module.IgnoreEvent = original_ignore_event
+        if original_core_module is None:
+            delattr(renpy.display, "core")
+
+    assert seen == [pygame.MOUSEBUTTONDOWN, pygame.MOUSEBUTTONUP]
+
+
+def test_click_pointer_delivers_up_before_propagating_end_interaction(running_bridge):
+    globs = running_bridge.globs
+    renpy = running_bridge.renpy
+    pygame = globs["pygame"]
+    seen = []
+
+    class FakeEndInteraction(Exception):
+        def __init__(self, value):
+            super().__init__(value)
+            self.value = value
+
+    class Focused:
+        def event(self, event, x, y, st):
+            seen.append(event.type)
+            if event.type == pygame.MOUSEBUTTONDOWN:
+                return "branch-result"
+            return None
+
+    def _end_interaction(value):
+        raise FakeEndInteraction(value)
+
+    focus_module = renpy.display.focus
+    original_core_module = getattr(renpy.display, "core", None)
+    core_module = original_core_module or types.SimpleNamespace()
+    renpy.display.core = core_module
+    original_get_focused = getattr(focus_module, "get_focused", None)
+    original_mouse_handler = getattr(focus_module, "mouse_handler", None)
+    original_end_interaction_class = getattr(core_module, "EndInteraction", None)
+    original_end_interaction = getattr(renpy, "end_interaction", None)
+    focus_module.get_focused = lambda: Focused()
+    focus_module.mouse_handler = lambda event, x, y, default: None
+    core_module.EndInteraction = FakeEndInteraction
+    renpy.end_interaction = _end_interaction
+    renpy.test.testmouse.mouse_pos = (91, 92)
+    renpy.test.testmouse.mouse_buttons = [True, False, False]
+
+    try:
+        with pytest.raises(FakeEndInteraction) as raised:
+            globs["_renforge_click_pointer"](44, 55)
+    finally:
+        if original_get_focused is None:
+            delattr(focus_module, "get_focused")
+        else:
+            focus_module.get_focused = original_get_focused
+        if original_mouse_handler is None:
+            delattr(focus_module, "mouse_handler")
+        else:
+            focus_module.mouse_handler = original_mouse_handler
+        if original_end_interaction_class is None:
+            delattr(core_module, "EndInteraction")
+        else:
+            core_module.EndInteraction = original_end_interaction_class
+        if original_end_interaction is None:
+            delattr(renpy, "end_interaction")
+        else:
+            renpy.end_interaction = original_end_interaction
+        if original_core_module is None:
+            delattr(renpy.display, "core")
+
+    assert raised.value.value == "branch-result"
+    assert seen == [pygame.MOUSEBUTTONDOWN, pygame.MOUSEBUTTONUP]
+    assert renpy.test.testmouse.mouse_pos is None
+    assert renpy.test.testmouse.mouse_buttons == [False, False, False]
+
+
+def test_click_at_preserves_reply_metadata_when_interaction_ends(running_bridge):
+    globs = running_bridge.globs
+    renpy = running_bridge.renpy
+    pygame = globs["pygame"]
+
+    class FakeEndInteraction(Exception):
+        pass
+
+    class Focused:
+        def event(self, event, x, y, st):
+            if event.type == pygame.MOUSEBUTTONUP:
+                return "next-screen"
+            return None
+
+    def _end_interaction(value):
+        raise FakeEndInteraction(value)
+
+    focus_module = renpy.display.focus
+    original_core_module = getattr(renpy.display, "core", None)
+    core_module = original_core_module or types.SimpleNamespace()
+    renpy.display.core = core_module
+    original_get_focused = getattr(focus_module, "get_focused", None)
+    original_mouse_handler = getattr(focus_module, "mouse_handler", None)
+    original_end_interaction_class = getattr(core_module, "EndInteraction", None)
+    original_end_interaction = getattr(renpy, "end_interaction", None)
+    focus_module.get_focused = lambda: Focused()
+    focus_module.mouse_handler = lambda event, x, y, default: None
+    core_module.EndInteraction = FakeEndInteraction
+    renpy.end_interaction = _end_interaction
+
+    try:
+        with pytest.raises(FakeEndInteraction) as raised:
+            globs["_renforge_h_click_at"]({"x": 44, "y": 55})
+    finally:
+        if original_get_focused is None:
+            delattr(focus_module, "get_focused")
+        else:
+            focus_module.get_focused = original_get_focused
+        if original_mouse_handler is None:
+            delattr(focus_module, "mouse_handler")
+        else:
+            focus_module.mouse_handler = original_mouse_handler
+        if original_end_interaction_class is None:
+            delattr(core_module, "EndInteraction")
+        else:
+            core_module.EndInteraction = original_end_interaction_class
+        if original_end_interaction is None:
+            delattr(renpy, "end_interaction")
+        else:
+            renpy.end_interaction = original_end_interaction
+        if original_core_module is None:
+            delattr(renpy.display, "core")
+
+    assert getattr(raised.value, "renforge_result", None) == {
+        "ok": True,
+        "x": 44,
+        "y": 55,
+        "coordinate_space": "logical",
+    }
+
+
+def test_click_element_preserves_action_metadata_when_interaction_ends(running_bridge):
+    globs = running_bridge.globs
+    renpy = running_bridge.renpy
+    pygame = globs["pygame"]
+    target = running_bridge.client.list_ui_elements()[1]
+    focus, element, error = globs["_renforge_resolve_ui_element"](
+        {"id": target["id"]}, "click_element"
+    )
+    assert error is None
+
+    class FakeEndInteraction(Exception):
+        pass
+
+    def _event(event, x, y, st):
+        if event.type == pygame.MOUSEBUTTONUP:
+            return "next-screen"
+        return None
+
+    def _end_interaction(value):
+        raise FakeEndInteraction(value)
+
+    focus_module = renpy.display.focus
+    core_module = getattr(renpy.display, "core", None) or types.SimpleNamespace()
+    original_core_module = getattr(renpy.display, "core", None)
+    original_get_focused = getattr(focus_module, "get_focused", None)
+    original_mouse_handler = getattr(focus_module, "mouse_handler", None)
+    original_event = getattr(focus.widget, "event", None)
+    original_end_interaction_class = getattr(core_module, "EndInteraction", None)
+    original_end_interaction = getattr(renpy, "end_interaction", None)
+    renpy.display.core = core_module
+    focus_module.get_focused = lambda: focus.widget
+    focus_module.mouse_handler = lambda event, x, y, default: None
+    focus.widget.event = _event
+    core_module.EndInteraction = FakeEndInteraction
+    renpy.end_interaction = _end_interaction
+
+    try:
+        with pytest.raises(FakeEndInteraction) as raised:
+            globs["_renforge_h_click_element"]({"id": target["id"]})
+    finally:
+        if original_get_focused is None:
+            delattr(focus_module, "get_focused")
+        else:
+            focus_module.get_focused = original_get_focused
+        if original_mouse_handler is None:
+            delattr(focus_module, "mouse_handler")
+        else:
+            focus_module.mouse_handler = original_mouse_handler
+        if original_event is None:
+            delattr(focus.widget, "event")
+        else:
+            focus.widget.event = original_event
+        if original_end_interaction_class is None:
+            delattr(core_module, "EndInteraction")
+        else:
+            core_module.EndInteraction = original_end_interaction_class
+        if original_end_interaction is None:
+            delattr(renpy, "end_interaction")
+        else:
+            renpy.end_interaction = original_end_interaction
+        if original_core_module is None:
+            delattr(renpy.display, "core")
+
+    result = getattr(raised.value, "renforge_result", None)
+    assert result is not None
+    assert result["ok"] is True
+    assert result["action"] == element["action"]
+    assert result["element"] == element
+    assert result["received_by"] is not None
+    assert result["x"] == target["center"]["x"]
+    assert result["y"] == target["center"]["y"]
+
+
 def test_list_ui_elements_reports_bounds_and_semantic_fields(running_bridge):
     elements = running_bridge.client.list_ui_elements()
     assert [element["text"] for element in elements] == [
@@ -671,11 +994,133 @@ def test_hit_test_reports_topmost_focusable(running_bridge):
 def test_hover_element_moves_without_clicking(running_bridge):
     element = running_bridge.client.list_ui_elements()[1]
     hovered = running_bridge.client.hover_element(id=element["id"])
-    assert hovered["ok"] is True
+    assert hovered["ok"] is True, hovered
     assert hovered["hovered"] is True
     assert hovered["x"] == 60 and hovered["y"] == 50
     assert running_bridge.renpy._moves == [(60, 50)]
     assert running_bridge.renpy._clicks == []
+
+
+def test_hover_element_prefers_set_mouse_pos_without_legacy_move_mouse(running_bridge):
+    renpy = running_bridge.renpy
+    focus_list = renpy.display.focus.focus_list
+    calls = []
+    previous_set_mouse_pos = getattr(renpy, "set_mouse_pos", None)
+    previous_move_mouse = renpy.test.testmouse.move_mouse
+
+    def _set_mouse_pos(x, y, *, duration):
+        calls.append((x, y, duration))
+        renpy._moves.append((x, y))
+
+    def _legacy_move_mouse(x, y):
+        renpy._moves.append((x, y))
+
+    def _widget_at(x, y):
+        for focus in reversed(focus_list):
+            widget = getattr(focus, "widget", None)
+            if widget is None:
+                continue
+            fx = getattr(focus, "x", None)
+            fy = getattr(focus, "y", None)
+            fw = getattr(focus, "w", None)
+            fh = getattr(focus, "h", None)
+            if fx is None or fy is None or fw is None or fh is None:
+                continue
+            if fx <= x < fx + fw and fy <= y < fy + fh:
+                return widget
+        return None
+
+    def _focus_mouse_handler(event, x, y, _):
+        renpy._focused_widget = _widget_at(int(x), int(y))
+
+    try:
+        renpy.display.focus.mouse_handler = _focus_mouse_handler
+        renpy.set_mouse_pos = _set_mouse_pos
+        renpy.test.testmouse.move_mouse = _legacy_move_mouse
+        renpy.test.testmouse.mouse_pos = (99, 99)
+        renpy.test.testmouse.mouse_buttons = [True, False, False]
+
+        element = running_bridge.client.list_ui_elements()[1]
+        hovered = running_bridge.client.hover_element(id=element["id"])
+        assert hovered["ok"] is True
+        assert hovered["method"] == "renpy"
+        assert calls == [(60, 50, 0)]
+        assert renpy._moves == [(60, 50)]
+        assert renpy._focused_widget is focus_list[2].widget
+        assert renpy.test.testmouse.mouse_pos is None
+        assert renpy.test.testmouse.mouse_buttons == [False, False, False]
+
+        running_bridge.renpy.display.focus.mouse_handler(types.SimpleNamespace(), 60, 20, False)
+        assert renpy._focused_widget is focus_list[1].widget
+    finally:
+        renpy.set_mouse_pos = previous_set_mouse_pos
+        renpy.test.testmouse.move_mouse = previous_move_mouse
+
+
+def test_move_mouse_cleanup_when_exception_injected(running_bridge):
+    renpy = running_bridge.renpy
+    globs = running_bridge.globs
+    focus = renpy.display.focus.focus_list[1]
+
+    renpy.test.testmouse.mouse_pos = (42, 42)
+    renpy.test.testmouse.mouse_buttons = [True, False, False]
+    original_mouse_handler = getattr(renpy.display.focus, "mouse_handler", None)
+
+    def _boom_mouse_handler(_event, _x, _y, _):
+        raise RuntimeError("mouse-handler-bad")
+
+    renpy.display.focus.mouse_handler = _boom_mouse_handler
+
+    try:
+        with pytest.raises(RuntimeError, match="mouse-handler-bad"):
+            globs["_renforge_move_mouse"](focus)
+    finally:
+        if original_mouse_handler is not None:
+            renpy.display.focus.mouse_handler = original_mouse_handler
+        else:
+            renpy.display.focus.__dict__.pop("mouse_handler", None)
+
+    assert renpy.test.testmouse.mouse_pos is None
+    assert renpy.test.testmouse.mouse_buttons == [False, False, False]
+
+
+def test_hover_clears_testmouse_override_and_allows_physical_focus_changes(running_bridge):
+    focus_list = running_bridge.renpy.display.focus.focus_list
+
+    def _widget_at(x, y):
+        for focus in reversed(focus_list):
+            widget = getattr(focus, "widget", None)
+            if widget is None:
+                continue
+            fx = getattr(focus, "x", None)
+            fy = getattr(focus, "y", None)
+            fw = getattr(focus, "w", None)
+            fh = getattr(focus, "h", None)
+            if fx is None or fy is None or fw is None or fh is None:
+                continue
+            if fx <= x < fx + fw and fy <= y < fy + fh:
+                return widget
+        return None
+
+    def _focus_mouse_handler(event, x, y, _):
+        mouse_pos = getattr(running_bridge.renpy.test.testmouse, "mouse_pos", None)
+        if isinstance(mouse_pos, (tuple, list)) and len(mouse_pos) == 2:
+            x, y = int(mouse_pos[0]), int(mouse_pos[1])
+        running_bridge.renpy._focused_widget = _widget_at(x, y)
+
+    running_bridge.renpy.display.focus.mouse_handler = _focus_mouse_handler
+    running_bridge.renpy.test.testmouse.mouse_buttons = [True, False, False]
+    element = running_bridge.client.list_ui_elements()[1]
+    hovered = running_bridge.client.hover_element(id=element["id"])
+    assert hovered["ok"] is True
+    assert running_bridge.renpy.test.testmouse.mouse_pos is None
+    assert running_bridge.renpy.test.testmouse.mouse_buttons == [False, False, False]
+    assert running_bridge.renpy._focused_widget is focus_list[2].widget
+
+    event = types.SimpleNamespace()
+    running_bridge.renpy.display.focus.mouse_handler(event, 60, 20, False)
+    assert running_bridge.renpy.test.testmouse.mouse_buttons == [False, False, False]
+    assert running_bridge.renpy._focused_widget is focus_list[1].widget
 
 
 def test_hover_element_frame_guard_blocks_motion(running_bridge):
@@ -723,6 +1168,8 @@ def test_click_element_by_id_and_click_at_guards(running_bridge):
     assert clicked["ok"] is True
     assert clicked["x"] == 60 and clicked["y"] == 50
 
+    assert running_bridge.renpy._clicks[-1] == (1, 60, 50)
+
     frame_hash = running_bridge.client.screenshot_hash()
     guarded = running_bridge.client.click_at(
         123,
@@ -762,6 +1209,100 @@ def test_click_at_translates_screenshot_pixels_to_logical_coordinates(running_br
         "coordinate_space": "screenshot",
     }
     assert running_bridge.renpy._clicks[-1] == (1, 100, 200)
+
+
+def test_click_element_click_at_and_select_choice_use_shared_pointer_path(running_bridge):
+    element = running_bridge.client.list_ui_elements()[1]
+    calls = {"click_mouse": 0}
+
+    original_click_mouse = running_bridge.renpy.test.testmouse.click_mouse
+
+    def _counted_click_mouse(button, x, y):
+        calls["click_mouse"] += 1
+        return original_click_mouse(button, x, y)
+
+    running_bridge.renpy.test.testmouse.click_mouse = _counted_click_mouse
+
+    try:
+        clicked = running_bridge.client.click_element(id=element["id"])
+        clicked_at = running_bridge.client.click_at(80, 90)
+        selected = running_bridge.client.select_choice(text="Beta")
+        assert clicked["ok"] is True
+        assert clicked["x"] == 60
+        assert clicked["y"] == 50
+        assert clicked_at["ok"] is True
+        assert clicked_at["x"] == 80
+        assert clicked_at["y"] == 90
+        assert clicked_at["coordinate_space"] == "logical"
+        assert selected["ok"] is True
+        assert selected["x"] == 60
+        assert selected["y"] == 50
+        assert calls["click_mouse"] == 3
+        assert running_bridge.renpy._clicks[-3:] == [
+            (1, 60, 50),
+            (1, 80, 90),
+            (1, 60, 50),
+        ]
+    finally:
+        running_bridge.renpy.test.testmouse.click_mouse = original_click_mouse
+
+
+def test_fallback_pointer_path_clears_sticky_mouse_state(running_bridge):
+    renpy = running_bridge.renpy
+    globs = running_bridge.globs
+
+    previous_set_mouse_pos = getattr(renpy, "set_mouse_pos", None)
+    previous_mouse = globs["pygame"]
+    globs["pygame"] = None
+    renpy.set_mouse_pos = None
+
+    def _legacy_move_mouse(x, y):
+        renpy._moves.append((x, y))
+        renpy.test.testmouse.mouse_pos = (x, y)
+
+    def _legacy_click_mouse(button, x, y):
+        renpy._clicks.append((button, x, y))
+        renpy.test.testmouse.mouse_pos = (x, y)
+        renpy.test.testmouse.mouse_buttons = [True, False, False]
+
+    renpy.test.testmouse.move_mouse = _legacy_move_mouse
+    renpy.test.testmouse.click_mouse = _legacy_click_mouse
+
+    try:
+        element = running_bridge.client.list_ui_elements()[1]
+        hovered = running_bridge.client.hover_element(id=element["id"])
+        assert hovered["ok"] is True
+        assert hovered["method"] == "renpy-test"
+        assert renpy.test.testmouse.mouse_pos is None
+        assert renpy.test.testmouse.mouse_buttons == [False, False, False]
+
+        clicked = running_bridge.client.click_element(id=element["id"])
+        assert clicked["ok"] is True
+        assert renpy.test.testmouse.mouse_pos is None
+        assert renpy.test.testmouse.mouse_buttons == [False, False, False]
+        selected = running_bridge.client.select_choice(text="Beta")
+        assert selected["ok"] is True
+        assert renpy.test.testmouse.mouse_pos is None
+        assert renpy.test.testmouse.mouse_buttons == [False, False, False]
+    finally:
+        renpy.set_mouse_pos = previous_set_mouse_pos
+        globs["pygame"] = previous_mouse
+
+
+def test_drain_bridge_cleans_testmouse_state_when_stop_is_set(running_bridge):
+    import sys
+
+    renpy = running_bridge.renpy
+    renpy.test.testmouse.mouse_pos = (12, 34)
+    renpy.test.testmouse.mouse_buttons = [True, False, False]
+
+    bridge = sys.modules["_renforge_runtime"].bridge
+    bridge.stop.set()
+
+    running_bridge.globs["renforge_drain_bridge"]()
+
+    assert renpy.test.testmouse.mouse_pos is None
+    assert renpy.test.testmouse.mouse_buttons == [False, False, False]
 
 
 def test_get_displayable_bounds_reports_logical_rect(running_bridge):

--- a/tests/test_integration_sdk.py
+++ b/tests/test_integration_sdk.py
@@ -300,11 +300,16 @@ def test_live_menu_selection_takes_the_branch(sdk, demo_copy: Path) -> None:
             time.sleep(1.0)
         assert any(c["text"] == "Take the lantern and go." for c in choices), choices
 
-        session.client.select_choice(text="Take the lantern and go.")
+        selected = session.client.select_choice(text="Take the lantern and go.")
+        assert selected["ok"] is True, selected
+        assert selected["text"] == "Take the lantern and go."
+        assert isinstance(selected["x"], int) and isinstance(selected["y"], int)
+        assert selected.get("ended_interaction") is True
         time.sleep(1.5)
 
         assert session.client.get_var("lantern") is True
         assert session.client.get_var("courage") == 1
+        assert session.client.eval_expr("renpy.test.testmouse.mouse_pos") is None
         # The branch dialogue is still displayed inside ``village_gate``;
         # the jump to ``crossroads`` follows after that line is dismissed.
         assert session.client.get_state()["current_label"] == "village_gate"
@@ -571,11 +576,56 @@ def test_live_imagebutton_hover_bounds_and_capture(sdk, demo_copy: Path) -> None
         assert hovered["ok"] is True, hovered
         assert hovered.get("hovered") is True, hovered
         assert hovered["method"] in {"renpy", "renpy-test", "pygame"}
+        assert client.eval_expr("renpy.test.testmouse.mouse_pos") is None
         assert client.get_var("renforge_sdk_button_clicks") == clicks_before
 
         errors = live.get_errors(str(demo_copy))
         assert errors.get("ok") is True, errors
         assert not errors.get("events"), errors
+
+
+@pytest.mark.skipif(not os.environ.get("DISPLAY"), reason="live bridge needs a display (set DISPLAY, or run under xvfb)")
+def test_live_imagebutton_click_paths_release_testmouse(sdk, demo_copy: Path) -> None:
+    """Exercise click_element and click_at against a real Ren'Py ImageButton."""
+    from renforge.bridge.launcher import launch_with_bridge
+    from renforge.project import RenpyProject
+
+    _add_hover_fixtures(demo_copy)
+
+    with launch_with_bridge(sdk, RenpyProject(demo_copy), startup_timeout=90) as session:
+        client = session.client
+        client.eval_expr('renpy.show_screen("renforge_sdk_imagebutton_fixture")')
+        client.eval_expr("renpy.restart_interaction()")
+
+        elements = []
+        for _ in range(40):
+            elements = client.list_ui_elements()
+            if elements:
+                break
+            time.sleep(0.25)
+        assert elements, elements
+
+        button = elements[0]
+        center = button["center"]
+        before = client.get_var("renforge_sdk_button_clicks")
+
+        clicked = client.click_element(id=button["id"])
+        assert clicked["ok"] is True, clicked
+        for _ in range(40):
+            if client.get_var("renforge_sdk_button_clicks") == before + 1:
+                break
+            time.sleep(0.1)
+        assert client.get_var("renforge_sdk_button_clicks") == before + 1, clicked
+        assert client.eval_expr("renpy.test.testmouse.mouse_pos") is None
+
+        clicked_at = client.click_at(center["x"], center["y"])
+        assert clicked_at["ok"] is True, clicked_at
+        for _ in range(40):
+            if client.get_var("renforge_sdk_button_clicks") == before + 2:
+                break
+            time.sleep(0.1)
+        assert client.get_var("renforge_sdk_button_clicks") == before + 2
+        assert client.eval_expr("renpy.test.testmouse.mouse_pos") is None
 
 
 @pytest.mark.skipif(not os.environ.get("DISPLAY"), reason="live bridge needs a display (set DISPLAY, or run under xvfb)")


### PR DESCRIPTION
## Summary

- prefer native `renpy.set_mouse_pos(..., duration=0)` for hover and always clear legacy `testmouse` pointer/button state
- route `click_element`, `click_at`, and `select_choice` through one main-thread pointer path
- synchronously deliver balanced test-marked mouse down/up events to the focused displayable, including correct `IgnoreEvent` and `EndInteraction` handling
- add runtime and live Ren’Py 8.5.3 regressions covering physical hover recovery, ImageButton clicks, menu selection, fallbacks, exceptions, and shutdown cleanup

## Root cause

Ren’Py 8.5.3’s `renpy.test.testmouse.move_mouse()` stores its synthetic position in the module-global `mouse_pos`. `get_mouse_pos()` then keeps returning that value, so the physical pointer can no longer change hover until `testmouse.reset()` is called.

## Verification

- `72 passed` — `tests/test_bridge_runtime.py`
- `417 passed, 17 skipped` — complete pytest suite
- `3 passed` — live Ren’Py 8.5.3 menu, hover/capture, and ImageButton click scenarios
- `python3 -m compileall -q src tests`
- `git diff --check`
