### PR TITLE
docs: finalize 0.7.0 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable RenForge releases are recorded here. Versions follow semantic
 versioning.
 
-## [0.7.0] - 2026-07-22
+## [0.7.0] - Unreleased
 
 ### Added
 
@@ -21,12 +21,29 @@ versioning.
   or literal bounds without vision: `align`, `gap`, `distribute`, `center`,
   `overlap`, `fit`, and WCAG `contrast`. Returns logical-pixel deltas and, when
   a `tolerance` is given, a `pass` verdict.
+- Complete Simplified Chinese (`zh-CN`) coverage for the dashboard, including
+  localized runtime status messages, project-browser roots, and Story Map node
+  types.
+
+### Changed
+
+- Dashboard bundles are now generated once by CI and release workflows, remain
+  untracked in Git, and are validated inside both wheels and source archives.
+  PyPI and `uvx` users continue to receive a ready-to-run dashboard without
+  needing Node.js.
 
 ### Fixed
 
 - The `test` extra now installs `httpx2>=2.0.0`, the client backend required by
   current Starlette `TestClient`, instead of falling back to deprecated `httpx`
   compatibility and emitting `StarletteDeprecationWarning`.
+- Missing dashboard assets now return a stable, actionable HTTP 503 response
+  instead of a generic 404.
+
+### Thanks
+
+- Thanks to [@AxelBeary](https://github.com/AxelBeary) for the complete
+  Simplified Chinese dashboard translation and the related i18n fixes.
 
 ## [0.6.6] - 2026-07-24
 
@@ -79,19 +96,6 @@ versioning.
   process was eventually closed. The listener and its helpers now use
   function-local imports (read from `sys.modules`, which reload never
   touches), and the accept loop also tolerates non-timeout `OSError`.
-
-## [Unreleased]
-
-### Added
-
-- Complete Simplified Chinese (`zh-CN`) coverage for the dashboard, including
-  localized runtime status messages, project-browser roots, and Story Map node
-  types.
-
-### Thanks
-
-- Thanks to [@AxelBeary](https://github.com/AxelBeary) for the complete
-  Simplified Chinese dashboard translation and the related i18n fixes.
 
 ## [0.6.2] - 2026-07-19
 


### PR DESCRIPTION
## Summary

- mark `0.7.0` as unreleased instead of assigning a past release date
- move the complete zh-CN dashboard entry and @AxelBeary acknowledgement into the prepared `0.7.0` notes
- document the generated UI artifact pipeline and actionable missing-assets response in `0.7.0`
- remove the duplicate misplaced `Unreleased` section

## Verification

- reproduced the release workflow's CHANGELOG extraction for `0.7.0`
- confirmed the extracted notes include `### Thanks`, `@AxelBeary`, and the UI packaging changes
- `git diff --check`

## Summary by Sourcery

Clarifier et consolider l’entrée du changelog de la version 0.7.0 tout en la conservant marquée comme non publiée.

Documentation :
- Déplacer la traduction du tableau de bord zh-CN et la mention du contributeur dans les notes de version 0.7.0, et y documenter le packaging des ressources du tableau de bord ainsi que la gestion des erreurs.

Tâches diverses :
- Supprimer une section « Unreleased » en double et mal placée dans le changelog.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Clarify and consolidate the 0.7.0 changelog entry while keeping it marked as unreleased.

Documentation:
- Move the zh-CN dashboard translation and contributor acknowledgement into the 0.7.0 release notes and document dashboard asset packaging and error handling there.

Chores:
- Remove a duplicate misplaced Unreleased section from the changelog.

</details>