### PR TITLE
Complete the in-game editor drag workflow

### DIFF
--- a/examples/demo_game/game/editor_playground.rpy
+++ b/examples/demo_game/game/editor_playground.rpy
@@ -1,0 +1,43 @@
+# RenForge editor playground.
+#
+# A standalone manual test bed for the visual editor. Deliberately kept out of
+# village_gate_choices: every focusable on screen contributes snap anchors, so
+# adding these controls there would change the acceptance fixture's snap
+# results. Open it in game with Escape, then "Editor playground".
+
+screen editor_playground():
+    tag menu
+    modal True
+
+    # A plain canvas: the red alignment guides must stand out, and the demo art
+    # would only add noise to a positioning test bed.
+    add Solid("#12141a")
+
+    text "Editor playground" id "pg_title" xpos 60 ypos 40 size 28
+
+    # Literal positions: editable, and deliberately aligned so the red guides
+    # have something to catch. Alpha/Beta share a y, Alpha/Gamma/Bar share an x.
+    textbutton "Alpha" id "pg_alpha" xpos 120 ypos 140 action NullAction()
+    textbutton "Beta" id "pg_beta" xpos 420 ypos 140 action NullAction()
+    textbutton "Gamma" id "pg_gamma" xpos 120 ypos 300 action NullAction()
+
+    # Displayable kinds other than textbutton.
+    add Transform("wisp glow", zoom=0.25) id "pg_sprite" xpos 700 ypos 260
+    imagebutton id "pg_imgbtn" idle Transform("wisp glow", zoom=0.2) xpos 880 ypos 100 action NullAction()
+    bar id "pg_bar" value 50 range 100 xpos 120 ypos 460 xysize (240, 26)
+
+    frame id "pg_frame" xpos 640 ypos 460 xysize (240, 96):
+        text "Framed panel"
+
+    # Children of a dynamic layout: the hbox computes their position, so the
+    # editor must refuse to write these back.
+    hbox id "pg_row" xpos 640 ypos 580 spacing 20:
+        textbutton "Row left" id "pg_row_left" action NullAction()
+        textbutton "Row right" id "pg_row_right" action NullAction()
+
+    # Two instances from a single source line with no stable identity: the
+    # ambiguous-instance lock case.
+    for _pg_i in range(2):
+        textbutton "Clone" xpos 120 + _pg_i * 140 ypos 580 action NullAction()
+
+    textbutton "Close" id "pg_close" xpos 1100 ypos 40 action Return()

--- a/examples/demo_game/game/screens.rpy
+++ b/examples/demo_game/game/screens.rpy
@@ -236,6 +236,7 @@ screen village_gate_choices():
     text "The gate is silent. Choose your path." xpos 140 ypos 240
     textbutton "Take the lantern and go." id "demo_lantern_take" xpos 160 ypos 320 action Return("take_lantern")
     textbutton "Ask the Elder to send someone else." id "demo_lantern_decline" xpos 160 ypos 380 action Return("decline_lantern")
+    textbutton "Hold the gate (locked demo)." id "demo_locked_expr" xpos gui.choice_spacing ypos 440 action NullAction()
 
 
 ## Quick Menu screen ###########################################################
@@ -315,6 +316,8 @@ screen navigation():
         textbutton _("Load") action ShowMenu("load")
 
         textbutton _("Preferences") action ShowMenu("preferences")
+
+        textbutton _("Editor playground") action ShowMenu("editor_playground")
 
         if _in_replay:
 

--- a/src/renforge/bridge/bridge.rpy
+++ b/src/renforge/bridge/bridge.rpy
@@ -644,7 +644,11 @@ init python:
 
     def _renforge_h_send_input(payload):
         payload = payload or {}
-        supplied = [name for name in ("text", "key", "scroll") if name in payload and payload.get(name) is not None]
+        supplied = [
+            name
+            for name in ("text", "key", "scroll", "drag")
+            if name in payload and payload.get(name) is not None
+        ]
         if len(supplied) != 1:
             return {
                 "ok": False,
@@ -710,6 +714,120 @@ init python:
                 )
                 pygame.event.post(event)
             return {"ok": True, "mode": "key", "key": key, "keycode": keycode}
+
+
+        if supplied[0] == "drag":
+            drag = payload.get("drag")
+            if not isinstance(drag, builtins.dict):
+                return {"ok": False, "error": "drag must be an object with points and button"}
+            raw_points = drag.get("points")
+            if not isinstance(raw_points, builtins.list) or not raw_points:
+                return {"ok": False, "error": "drag points must be a non-empty list"}
+            coordinate_space = str(drag.get("coordinate_space", "logical") or "logical").casefold()
+            if coordinate_space not in ("logical", "screenshot"):
+                return {"ok": False, "error": "coordinate_space must be logical or screenshot"}
+            button = drag.get("button", 1)
+            if isinstance(button, bool) or not isinstance(button, builtins.int):
+                return {"ok": False, "error": "drag button must be an integer"}
+            frame_data = None
+            if coordinate_space == "screenshot":
+                frame_data = renpy.screenshot_to_bytes(None)
+            logical_points = []
+            for raw_point in raw_points:
+                if not isinstance(raw_point, builtins.list) or len(raw_point) != 2:
+                    return {"ok": False, "error": "drag points must be coordinate pairs"}
+                raw_x, raw_y = raw_point
+                if (
+                    isinstance(raw_x, bool)
+                    or not isinstance(raw_x, (builtins.int, builtins.float))
+                    or isinstance(raw_y, bool)
+                    or not isinstance(raw_y, (builtins.int, builtins.float))
+                ):
+                    return {"ok": False, "error": "drag points must be numeric"}
+                try:
+                    point_x = int(round(float(raw_x)))
+                    point_y = int(round(float(raw_y)))
+                except (TypeError, ValueError, OverflowError):
+                    return {"ok": False, "error": "drag points must be numeric"}
+                if point_x < 0 or point_y < 0:
+                    return {"ok": False, "error": "drag coordinates must be non-negative"}
+                point_x, point_y, frame_data, coordinate_error = _renforge_to_logical_coordinates(
+                    point_x, point_y, coordinate_space, frame_data
+                )
+                if coordinate_error is not None:
+                    return {"ok": False, "error": coordinate_error}
+                logical_points.append([point_x, point_y])
+            if pygame is None:
+                return {"ok": False, "error": "pygame_sdl2 event API is unavailable"}
+            interface = getattr(getattr(renpy, "display", None), "interface", None)
+            if interface is not None:
+                try:
+                    interface.mouse_focused = True
+                except Exception:
+                    pass
+                try:
+                    interface.ignore_touch = False
+                except Exception:
+                    pass
+            event_factory = getattr(getattr(pygame, "event", None), "Event", None)
+            post = getattr(getattr(pygame, "event", None), "post", None)
+            down_type = getattr(pygame, "MOUSEBUTTONDOWN", None)
+            motion_type = getattr(pygame, "MOUSEMOTION", None)
+            up_type = getattr(pygame, "MOUSEBUTTONUP", None)
+            if (
+                not callable(event_factory)
+                or not callable(post)
+                or down_type is None
+                or motion_type is None
+                or up_type is None
+            ):
+                return {"ok": False, "error": "pygame_sdl2 event API is unavailable"}
+
+            def make_event(event_type, attrs):
+                try:
+                    return event_factory(event_type, **attrs)
+                except TypeError:
+                    return event_factory(event_type, attrs)
+
+            first_x, first_y = logical_points[0]
+            button_payload = {
+                "button": button,
+                "pos": (first_x, first_y),
+                "x": first_x,
+                "y": first_y,
+                "touch": False,
+                "test": True,
+                "mod": 0,
+            }
+            post(make_event(down_type, button_payload))
+            for point_x, point_y in logical_points[1:]:
+                post(
+                    make_event(
+                        motion_type,
+                        {
+                            "pos": (point_x, point_y),
+                            "rel": (0, 0),
+                            "buttons": (1, 0, 0) if button == 1 else (0, 0, 0),
+                        },
+                    )
+                )
+            last_x, last_y = logical_points[-1]
+            button_payload = {
+                "button": button,
+                "pos": (last_x, last_y),
+                "x": last_x,
+                "y": last_y,
+                "touch": False,
+                "test": True,
+                "mod": 0,
+            }
+            post(make_event(up_type, button_payload))
+            return {
+                "ok": True,
+                "mode": "drag",
+                "points": logical_points,
+                "button": button,
+            }
 
         scroll = payload.get("scroll")
         if not isinstance(scroll, builtins.dict):

--- a/src/renforge/bridge/bridge.rpy
+++ b/src/renforge/bridge/bridge.rpy
@@ -800,17 +800,20 @@ init python:
                 "mod": 0,
             }
             post(make_event(down_type, button_payload))
+            previous_x, previous_y = first_x, first_y
+            held_buttons = tuple(int(button == candidate) for candidate in (1, 2, 3))
             for point_x, point_y in logical_points[1:]:
                 post(
                     make_event(
                         motion_type,
                         {
                             "pos": (point_x, point_y),
-                            "rel": (0, 0),
-                            "buttons": (1, 0, 0) if button == 1 else (0, 0, 0),
+                            "rel": (point_x - previous_x, point_y - previous_y),
+                            "buttons": held_buttons,
                         },
                     )
                 )
+                previous_x, previous_y = point_x, point_y
             last_x, last_y = logical_points[-1]
             button_payload = {
                 "button": button,

--- a/src/renforge/bridge/client.py
+++ b/src/renforge/bridge/client.py
@@ -207,13 +207,15 @@ class BridgeClient:
         text: str | None = None,
         key: str | None = None,
         scroll: dict[str, Any] | None = None,
+        drag: dict[str, Any] | None = None,
         submit: bool = False,
     ) -> dict:
-        """Send exactly one text, named-key, or scroll input operation."""
+        """Send exactly one text, named-key, scroll, or drag input operation."""
         payload: dict[str, Any] = {
             "text": text,
             "key": key,
             "scroll": scroll,
+            "drag": drag,
             "submit": bool(submit),
         }
         # Keep omitted optional modes out of the wire payload so callers can

--- a/src/renforge/bridge/editor.rpy
+++ b/src/renforge/bridge/editor.rpy
@@ -210,7 +210,6 @@ init 1100 python:
     import hashlib
     import json
     import os
-    import queue
     import socket
     import sys
     import threading
@@ -222,19 +221,6 @@ init 1100 python:
         import pygame_sdl2 as pygame
     except Exception:
         pygame = None
-
-    _RENFORGE_DRAG_FRAME_EVENT = None
-    if pygame is not None:
-        _register_drag_frame_event = getattr(
-            getattr(pygame, "event", None), "register", None
-        )
-        if callable(_register_drag_frame_event):
-            try:
-                _RENFORGE_DRAG_FRAME_EVENT = _register_drag_frame_event(
-                    "RENFORGE_EDITOR_DRAG_FRAME"
-                )
-            except Exception:
-                _RENFORGE_DRAG_FRAME_EVENT = None
 
     if "_renforge_runtime" not in sys.modules:
         raise Exception("RenForge bridge must load before editor.rpy")
@@ -293,9 +279,6 @@ init 1100 python:
             state.drag_active = False
             state.drag_offset = [0, 0]
             state.drag_start_position = None
-            state.pending_drag_pointer = None
-            state.pending_drag_shift = False
-            state.drag_frame_scheduled = False
             state.snap_anchor_x = None
             state.snap_anchor_y = None
             state.snap_offset_x = None
@@ -366,12 +349,6 @@ init 1100 python:
             state.pending_reload_draw_generation = None
         if not hasattr(state, "pending_reload_started"):
             state.pending_reload_started = False
-        if not hasattr(state, "pending_drag_pointer"):
-            state.pending_drag_pointer = None
-        if not hasattr(state, "pending_drag_shift"):
-            state.pending_drag_shift = False
-        if not hasattr(state, "drag_frame_scheduled"):
-            state.drag_frame_scheduled = False
         return state
 
 
@@ -508,8 +485,10 @@ init 1100 python:
 
     class _RenforgeEditorCoordinatorIO(object):
         def __init__(self):
-            self.requests = queue.Queue()
-            self.results = queue.Queue()
+            import queue as queue_module
+
+            self.requests = queue_module.Queue()
+            self.results = queue_module.Queue()
             self.stop = threading.Event()
             self.counter = 0
             state = _renforge_editor_state()
@@ -598,10 +577,13 @@ init 1100 python:
             raise RuntimeError("editor host request failed: %s" % last_error)
 
         def _loop(self):
+            import queue as queue_module
+
+            empty = queue_module.Empty
             while not self.stop.is_set():
                 try:
                     request = self.requests.get(timeout=0.1)
-                except queue.Empty:
+                except empty:
                     continue
                 result = builtins.dict(request)
                 try:
@@ -622,11 +604,14 @@ init 1100 python:
                 self.results.put(result)
 
         def collect_nowait(self):
+            import queue as queue_module
+
+            empty = queue_module.Empty
             items = []
             while True:
                 try:
                     items.append(self.results.get_nowait())
-                except queue.Empty:
+                except empty:
                     break
             return items
 
@@ -1726,63 +1711,12 @@ init 1100 python:
         return _renforge_editor_apply_preview(desired_x, desired_y, shift=shift, allow_snap=True, record=False)
 
 
-    _DRAG_FRAME_INTERVAL_MS = 16
-
-    def _renforge_editor_clear_drag_timer():
-        if _RENFORGE_DRAG_FRAME_EVENT is None or pygame is None:
-            return
-        set_timer = getattr(getattr(pygame, "time", None), "set_timer", None)
-        if callable(set_timer):
-            set_timer(_RENFORGE_DRAG_FRAME_EVENT, 0)
-
-
-    def _renforge_editor_queue_drag_frame(pointer_x, pointer_y, shift):
-        state = _renforge_editor_state()
-        state.pending_drag_pointer = [int(pointer_x), int(pointer_y)]
-        state.pending_drag_shift = bool(shift)
-        if state.drag_frame_scheduled:
-            return {"ok": True, "scheduled": True}
-        set_timer = getattr(getattr(pygame, "time", None), "set_timer", None)
-        if _RENFORGE_DRAG_FRAME_EVENT is None or not callable(set_timer):
-            return _renforge_editor_apply_drag_from_pointer(
-                int(pointer_x), int(pointer_y), bool(shift)
-            )
-        state.drag_frame_scheduled = True
-        try:
-            set_timer(_RENFORGE_DRAG_FRAME_EVENT, _DRAG_FRAME_INTERVAL_MS, once=True)
-        except TypeError:
-            set_timer(_RENFORGE_DRAG_FRAME_EVENT, _DRAG_FRAME_INTERVAL_MS)
-        return {"ok": True, "scheduled": True}
-
-
-    def _renforge_editor_flush_drag_frame():
-        state = _renforge_editor_state()
-        pending = state.pending_drag_pointer
-        shift = state.pending_drag_shift
-        _renforge_editor_clear_drag_timer()
-        state.pending_drag_pointer = None
-        state.pending_drag_shift = False
-        state.drag_frame_scheduled = False
-        if (
-            not state.drag_active
-            or not isinstance(pending, (builtins.list, builtins.tuple))
-            or len(pending) != 2
-        ):
-            return {"ok": True, "flushed": False}
-        return _renforge_editor_apply_drag_from_pointer(
-            int(pending[0]), int(pending[1]), shift
-        )
-
     def _renforge_editor_end_drag():
         state = _renforge_editor_state()
         state.drag_active = False
         state.drag_offset = [0, 0]
         state.snap_anchors_x = None
         state.snap_anchors_y = None
-        state.pending_drag_pointer = None
-        state.pending_drag_shift = False
-        state.drag_frame_scheduled = False
-        _renforge_editor_clear_drag_timer()
         if state.preview_position is not None and state.drag_start_position is not None:
             _renforge_editor_push_history(state.preview_position, before=state.drag_start_position)
         state.drag_start_position = None
@@ -1800,10 +1734,6 @@ init 1100 python:
         state.snap_offset_y = None
         state.snap_anchors_x = None
         state.snap_anchors_y = None
-        state.pending_drag_pointer = None
-        state.pending_drag_shift = False
-        state.drag_frame_scheduled = False
-        _renforge_editor_clear_drag_timer()
         state.guide_x = None
         state.guide_y = None
         renpy.hide_screen(_EDITOR_SCREEN, layer="screens")
@@ -1816,14 +1746,6 @@ init 1100 python:
         if not state.active:
             return None
         event_type = getattr(event, "type", None)
-        if (
-            _RENFORGE_DRAG_FRAME_EVENT is not None
-            and event_type == _RENFORGE_DRAG_FRAME_EVENT
-        ):
-            if state.drag_active and state.drag_frame_scheduled:
-                _renforge_editor_flush_drag_frame()
-                raise renpy.IgnoreEvent()
-            return None
         pointer_x, pointer_y = _renforge_editor_event_pos(event, x, y)
         key = getattr(event, "key", None)
         shift = _renforge_editor_event_shift(event)
@@ -1836,14 +1758,12 @@ init 1100 python:
                     _renforge_editor_apply_drag_from_pointer(pointer_x, pointer_y, shift)
                 raise renpy.IgnoreEvent()
             if event_type == getattr(pygame, "MOUSEMOTION", None) and state.drag_active:
-                _renforge_editor_queue_drag_frame(pointer_x, pointer_y, shift)
+                # Ren'Py already coalesces MOUSEMOTION to the latest event before
+                # dispatch. Apply that motion immediately; do not re-queue it.
+                _renforge_editor_apply_drag_from_pointer(pointer_x, pointer_y, shift)
                 raise renpy.IgnoreEvent()
             if event_type == getattr(pygame, "MOUSEBUTTONUP", None) and getattr(event, "button", 0) == 1:
                 if state.drag_active:
-                    state.pending_drag_pointer = None
-                    state.pending_drag_shift = False
-                    state.drag_frame_scheduled = False
-                    _renforge_editor_clear_drag_timer()
                     _renforge_editor_apply_drag_from_pointer(pointer_x, pointer_y, shift)
                 _renforge_editor_end_drag()
                 raise renpy.IgnoreEvent()
@@ -2172,10 +2092,6 @@ init 1100 python:
         state.drag_active = False
         state.drag_offset = [0, 0]
         state.drag_start_position = None
-        state.pending_drag_pointer = None
-        state.pending_drag_shift = False
-        state.drag_frame_scheduled = False
-        _renforge_editor_clear_drag_timer()
         state.selected_original_position = None
         state.selected_source_position = None
         state.selected_rect = None
@@ -2268,43 +2184,85 @@ init 1100 python:
         state = _renforge_editor_state()
         if not state.active:
             return {"ok": False, "error": "editor is not active"}
-        samples = []
         if pygame is None:
             return {"ok": False, "error": "pygame_sdl2 is unavailable"}
-        first = points[0]
-        if not builtins.isinstance(first, (builtins.list, tuple)) or len(first) < 2:
-            return {"ok": False, "error": "invalid point"}
-        down_reply = _renforge_editor_apply_drag_from_pointer(int(first[0]), int(first[1]), shift)
-        if not down_reply.get("ok", False):
-            return down_reply
+
+        normalized_points = []
         for point in points:
             if not builtins.isinstance(point, (builtins.list, tuple)) or len(point) < 2:
                 return {"ok": False, "error": "invalid point"}
-            px = int(point[0])
-            py = int(point[1])
-            motion_reply = _renforge_editor_apply_drag_from_pointer(px, py, shift)
-            if not motion_reply.get("ok", False):
-                state.drag_active = False
-                state.drag_offset = [0, 0]
-                return motion_reply
-            state_after = _renforge_editor_state()
-            preview = list(state_after.preview_position or [])
-            samples.append(
-                {
-                    "point": [px, py],
-                    "preview_position": preview if len(preview) == 2 else None,
-                    "guide_x": state_after.guide_x,
-                    "guide_y": state_after.guide_y,
-                }
+            normalized_points.append([int(point[0]), int(point[1])])
+
+        def dispatch(event, px, py):
+            try:
+                _renforge_editor_handle_event(event, px, py, 0.0)
+            except renpy.IgnoreEvent:
+                pass
+
+        def sample(point):
+            current = _renforge_editor_state()
+            preview = list(current.preview_position or [])
+            return {
+                "point": list(point),
+                "preview_position": preview if len(preview) == 2 else None,
+                "guide_x": current.guide_x,
+                "guide_y": current.guide_y,
+            }
+
+        mod = getattr(pygame, "KMOD_SHIFT", 0) if shift else 0
+        first_x, first_y = normalized_points[0]
+        dispatch(
+            _renforge_editor_fake_event(
+                getattr(pygame, "MOUSEBUTTONDOWN", None),
+                button=1,
+                pos=(first_x, first_y),
+                mod=mod,
+            ),
+            first_x,
+            first_y,
+        )
+        if not state.drag_active:
+            return {
+                "ok": False,
+                "error": state.selected_lock_reason or "drag did not start",
+            }
+
+        samples = [sample(normalized_points[0])]
+        previous_x, previous_y = first_x, first_y
+        for px, py in normalized_points[1:]:
+            dispatch(
+                _renforge_editor_fake_event(
+                    getattr(pygame, "MOUSEMOTION", None),
+                    pos=(px, py),
+                    rel=(px - previous_x, py - previous_y),
+                    buttons=(1, 0, 0),
+                    mod=mod,
+                ),
+                px,
+                py,
             )
-        up_reply = _renforge_editor_end_drag()
-        if not up_reply.get("ok", False):
-            return up_reply
+            samples.append(sample([px, py]))
+            previous_x, previous_y = px, py
+
+        preview_before_mouse_up = list(state.preview_position or [])
+        drag_active_before_mouse_up = bool(state.drag_active)
+        dispatch(
+            _renforge_editor_fake_event(
+                getattr(pygame, "MOUSEBUTTONUP", None),
+                button=1,
+                pos=(previous_x, previous_y),
+                mod=mod,
+            ),
+            previous_x,
+            previous_y,
+        )
         return {
             "ok": True,
-            "event_method": "Displayable.event",
+            "event_method": "_renforge_editor_handle_event",
             "preview_method": state.last_preview_method,
             "samples": samples,
+            "preview_before_mouse_up": preview_before_mouse_up,
+            "drag_active_before_mouse_up": drag_active_before_mouse_up,
             "guide_x": state.guide_x,
             "guide_y": state.guide_y,
         }

--- a/src/renforge/bridge/editor.rpy
+++ b/src/renforge/bridge/editor.rpy
@@ -27,6 +27,7 @@ screen _renforge_editor_overlay():
         $ _rf_selection = _renforge_editor_selection_snapshot()
         $ _rf_label = _renforge_editor_label_snapshot()
         $ _rf_distance = _renforge_editor_distance_snapshot()
+        $ _rf_measure = _renforge_editor_measure_snapshot()
         $ _rf_tools_visible = _renforge_editor_tools_visible()
 
         fixed:
@@ -45,9 +46,26 @@ screen _renforge_editor_overlay():
                     id "rf_guide_y"
                     xpos 0
                     ypos int(_renforge_editor_guide_y())
+            if _rf_tools_visible and _rf_measure is not None and _rf_measure["line_x"] is not None:
+                add Solid("#ff3b30", xysize=(max(2, int(_rf_measure["line_x"][2])), 2)):
+                    id "rf_measure_x"
+                    xpos int(_rf_measure["line_x"][0])
+                    ypos int(_rf_measure["line_x"][1])
 
-            if _rf_tools_visible and _rf_distance is not None and _renforge_editor_guide_x() is not None:
-                $ _rf_distance_x = max(4, min(config.screen_width - 92, int(_renforge_editor_guide_x()) + 8))
+            if _rf_tools_visible and _rf_measure is not None and _rf_measure["line_y"] is not None:
+                add Solid("#ff3b30", xysize=(2, max(2, int(_rf_measure["line_y"][2])))):
+                    id "rf_measure_y"
+                    xpos int(_rf_measure["line_y"][0])
+                    ypos int(_rf_measure["line_y"][1])
+
+            $ _rf_guide_x_val = _renforge_editor_guide_x()
+            $ _rf_guide_y_val = _renforge_editor_guide_y()
+            $ _rf_show_dx = _rf_distance is not None and (_rf_guide_x_val is not None or (_rf_measure is not None and _rf_measure["dx"] != 0))
+            $ _rf_show_dy = _rf_distance is not None and (_rf_guide_y_val is not None or (_rf_measure is not None and _rf_measure["dy"] != 0))
+
+            if _rf_tools_visible and _rf_show_dx:
+                $ _rf_anchor_x = _rf_guide_x_val if _rf_guide_x_val is not None else int(_rf_distance["x"]) + int(_rf_distance["w"])
+                $ _rf_distance_x = max(4, min(config.screen_width - 92, int(_rf_anchor_x) + 8))
                 $ _rf_distance_y = max(48, min(config.screen_height - 28, int(_rf_distance["y"]) + int(_rf_distance["h"]) + 6))
                 frame:
                     id "rf_distance_x"
@@ -60,9 +78,10 @@ screen _renforge_editor_overlay():
                         color "#ffffff"
                         size 12
 
-            if _rf_tools_visible and _rf_distance is not None and _renforge_editor_guide_y() is not None:
+            if _rf_tools_visible and _rf_show_dy:
+                $ _rf_anchor_y = _rf_guide_y_val if _rf_guide_y_val is not None else int(_rf_distance["y"]) + int(_rf_distance["h"])
                 $ _rf_distance_x = max(4, min(config.screen_width - 92, int(_rf_distance["x"]) + int(_rf_distance["w"]) + 6))
-                $ _rf_distance_y = max(48, min(config.screen_height - 28, int(_renforge_editor_guide_y()) + 8))
+                $ _rf_distance_y = max(48, min(config.screen_height - 28, int(_rf_anchor_y) + 8))
                 frame:
                     id "rf_distance_y"
                     xpos _rf_distance_x
@@ -204,6 +223,19 @@ init 1100 python:
     except Exception:
         pygame = None
 
+    _RENFORGE_DRAG_FRAME_EVENT = None
+    if pygame is not None:
+        _register_drag_frame_event = getattr(
+            getattr(pygame, "event", None), "register", None
+        )
+        if callable(_register_drag_frame_event):
+            try:
+                _RENFORGE_DRAG_FRAME_EVENT = _register_drag_frame_event(
+                    "RENFORGE_EDITOR_DRAG_FRAME"
+                )
+            except Exception:
+                _RENFORGE_DRAG_FRAME_EVENT = None
+
     if "_renforge_runtime" not in sys.modules:
         raise Exception("RenForge bridge must load before editor.rpy")
     _renforge_runtime_module = sys.modules["_renforge_runtime"]
@@ -261,6 +293,9 @@ init 1100 python:
             state.drag_active = False
             state.drag_offset = [0, 0]
             state.drag_start_position = None
+            state.pending_drag_pointer = None
+            state.pending_drag_shift = False
+            state.drag_frame_scheduled = False
             state.snap_anchor_x = None
             state.snap_anchor_y = None
             state.snap_offset_x = None
@@ -331,6 +366,12 @@ init 1100 python:
             state.pending_reload_draw_generation = None
         if not hasattr(state, "pending_reload_started"):
             state.pending_reload_started = False
+        if not hasattr(state, "pending_drag_pointer"):
+            state.pending_drag_pointer = None
+        if not hasattr(state, "pending_drag_shift"):
+            state.pending_drag_shift = False
+        if not hasattr(state, "drag_frame_scheduled"):
+            state.drag_frame_scheduled = False
         return state
 
 
@@ -1413,6 +1454,25 @@ init 1100 python:
             state.guide_x = None
             state.guide_y = None
             snapped_x, snapped_y = desired_x, desired_y
+        if (
+            not record
+            and state.preview_position is not None
+            and len(state.preview_position) == 2
+            and [int(snapped_x), int(snapped_y)] == [int(state.preview_position[0]), int(state.preview_position[1])]
+        ):
+            # A pinned snap or a sub-pixel move: rebuilding the screen would
+            # change nothing visible and costs a full interaction restart.
+            if state.drag_active:
+                renpy.restart_interaction()
+            return {
+                "ok": True,
+                "x": int(snapped_x),
+                "y": int(snapped_y),
+                "method": "_widget_properties",
+                "snap": snap_detail,
+                "guide_x": state.guide_x,
+                "guide_y": state.guide_y,
+            }
         if record:
             _renforge_editor_push_history([int(snapped_x), int(snapped_y)])
         result = _renforge_editor_set_target_position(
@@ -1644,6 +1704,7 @@ init 1100 python:
 
     def _renforge_editor_apply_drag_from_pointer(pointer_x, pointer_y, shift):
         state = _renforge_editor_state()
+        state.pointer = [int(pointer_x), int(pointer_y)]
         if not state.drag_active:
             base = state.preview_position or state.selected_original_position
             if base is None:
@@ -1665,12 +1726,63 @@ init 1100 python:
         return _renforge_editor_apply_preview(desired_x, desired_y, shift=shift, allow_snap=True, record=False)
 
 
+    _DRAG_FRAME_INTERVAL_MS = 16
+
+    def _renforge_editor_clear_drag_timer():
+        if _RENFORGE_DRAG_FRAME_EVENT is None or pygame is None:
+            return
+        set_timer = getattr(getattr(pygame, "time", None), "set_timer", None)
+        if callable(set_timer):
+            set_timer(_RENFORGE_DRAG_FRAME_EVENT, 0)
+
+
+    def _renforge_editor_queue_drag_frame(pointer_x, pointer_y, shift):
+        state = _renforge_editor_state()
+        state.pending_drag_pointer = [int(pointer_x), int(pointer_y)]
+        state.pending_drag_shift = bool(shift)
+        if state.drag_frame_scheduled:
+            return {"ok": True, "scheduled": True}
+        set_timer = getattr(getattr(pygame, "time", None), "set_timer", None)
+        if _RENFORGE_DRAG_FRAME_EVENT is None or not callable(set_timer):
+            return _renforge_editor_apply_drag_from_pointer(
+                int(pointer_x), int(pointer_y), bool(shift)
+            )
+        state.drag_frame_scheduled = True
+        try:
+            set_timer(_RENFORGE_DRAG_FRAME_EVENT, _DRAG_FRAME_INTERVAL_MS, once=True)
+        except TypeError:
+            set_timer(_RENFORGE_DRAG_FRAME_EVENT, _DRAG_FRAME_INTERVAL_MS)
+        return {"ok": True, "scheduled": True}
+
+
+    def _renforge_editor_flush_drag_frame():
+        state = _renforge_editor_state()
+        pending = state.pending_drag_pointer
+        shift = state.pending_drag_shift
+        _renforge_editor_clear_drag_timer()
+        state.pending_drag_pointer = None
+        state.pending_drag_shift = False
+        state.drag_frame_scheduled = False
+        if (
+            not state.drag_active
+            or not isinstance(pending, (builtins.list, builtins.tuple))
+            or len(pending) != 2
+        ):
+            return {"ok": True, "flushed": False}
+        return _renforge_editor_apply_drag_from_pointer(
+            int(pending[0]), int(pending[1]), shift
+        )
+
     def _renforge_editor_end_drag():
         state = _renforge_editor_state()
         state.drag_active = False
         state.drag_offset = [0, 0]
         state.snap_anchors_x = None
         state.snap_anchors_y = None
+        state.pending_drag_pointer = None
+        state.pending_drag_shift = False
+        state.drag_frame_scheduled = False
+        _renforge_editor_clear_drag_timer()
         if state.preview_position is not None and state.drag_start_position is not None:
             _renforge_editor_push_history(state.preview_position, before=state.drag_start_position)
         state.drag_start_position = None
@@ -1688,6 +1800,10 @@ init 1100 python:
         state.snap_offset_y = None
         state.snap_anchors_x = None
         state.snap_anchors_y = None
+        state.pending_drag_pointer = None
+        state.pending_drag_shift = False
+        state.drag_frame_scheduled = False
+        _renforge_editor_clear_drag_timer()
         state.guide_x = None
         state.guide_y = None
         renpy.hide_screen(_EDITOR_SCREEN, layer="screens")
@@ -1699,8 +1815,16 @@ init 1100 python:
         state = _renforge_editor_state()
         if not state.active:
             return None
-        pointer_x, pointer_y = _renforge_editor_event_pos(event, x, y)
         event_type = getattr(event, "type", None)
+        if (
+            _RENFORGE_DRAG_FRAME_EVENT is not None
+            and event_type == _RENFORGE_DRAG_FRAME_EVENT
+        ):
+            if state.drag_active and state.drag_frame_scheduled:
+                _renforge_editor_flush_drag_frame()
+                raise renpy.IgnoreEvent()
+            return None
+        pointer_x, pointer_y = _renforge_editor_event_pos(event, x, y)
         key = getattr(event, "key", None)
         shift = _renforge_editor_event_shift(event)
         state.pointer = [int(pointer_x), int(pointer_y)]
@@ -1712,10 +1836,15 @@ init 1100 python:
                     _renforge_editor_apply_drag_from_pointer(pointer_x, pointer_y, shift)
                 raise renpy.IgnoreEvent()
             if event_type == getattr(pygame, "MOUSEMOTION", None) and state.drag_active:
-                _renforge_editor_apply_drag_from_pointer(pointer_x, pointer_y, shift)
+                _renforge_editor_queue_drag_frame(pointer_x, pointer_y, shift)
                 raise renpy.IgnoreEvent()
             if event_type == getattr(pygame, "MOUSEBUTTONUP", None) and getattr(event, "button", 0) == 1:
-                if state.drag_active: _renforge_editor_apply_drag_from_pointer(pointer_x, pointer_y, shift)
+                if state.drag_active:
+                    state.pending_drag_pointer = None
+                    state.pending_drag_shift = False
+                    state.drag_frame_scheduled = False
+                    _renforge_editor_clear_drag_timer()
+                    _renforge_editor_apply_drag_from_pointer(pointer_x, pointer_y, shift)
                 _renforge_editor_end_drag()
                 raise renpy.IgnoreEvent()
             if event_type == getattr(pygame, "KEYDOWN", None):
@@ -2040,6 +2169,13 @@ init 1100 python:
         state.selected_target_key = None
         state.selected_lock_reason = None
         state.preview_position = None
+        state.drag_active = False
+        state.drag_offset = [0, 0]
+        state.drag_start_position = None
+        state.pending_drag_pointer = None
+        state.pending_drag_shift = False
+        state.drag_frame_scheduled = False
+        _renforge_editor_clear_drag_timer()
         state.selected_original_position = None
         state.selected_source_position = None
         state.selected_rect = None
@@ -2541,6 +2677,58 @@ init 1100 python:
             "delta_y": delta_y,
             "text_x": "dx %s%d px" % ("+" if delta_x >= 0 else "", delta_x),
             "text_y": "dy %s%d px" % ("+" if delta_y >= 0 else "", delta_y),
+        }
+
+    def _renforge_editor_measure_snapshot():
+        """Track raw pointer displacement throughout an active drag.
+
+        Snap guides intentionally hold the preview at an anchor. Measurement
+        lines still follow the pointer so a small or directional movement is
+        visible instead of flashing only after snap release.
+        """
+        state = _renforge_editor_state()
+        if not state.drag_active:
+            return None
+        pointer = state.pointer
+        drag_start = state.drag_start_position
+        drag_offset = state.drag_offset
+        preview = state.preview_position
+        original = state.selected_original_position
+        rect = state.selected_rect
+        if (
+            not isinstance(pointer, (builtins.list, builtins.tuple))
+            or len(pointer) != 2
+            or not isinstance(rect, (builtins.list, builtins.tuple))
+            or len(rect) != 4
+        ):
+            return None
+        if (
+            isinstance(drag_start, (builtins.list, builtins.tuple))
+            and len(drag_start) == 2
+            and isinstance(drag_offset, (builtins.list, builtins.tuple))
+            and len(drag_offset) == 2
+        ):
+            origin_x, origin_y = int(drag_start[0]), int(drag_start[1])
+            current_x = int(pointer[0]) - int(drag_offset[0])
+            current_y = int(pointer[1]) - int(drag_offset[1])
+        elif (
+            isinstance(preview, (builtins.list, builtins.tuple))
+            and len(preview) == 2
+            and isinstance(original, (builtins.list, builtins.tuple))
+            and len(original) == 2
+        ):
+            origin_x, origin_y = int(original[0]), int(original[1])
+            current_x, current_y = int(preview[0]), int(preview[1])
+        else:
+            return None
+        width, height = int(rect[2]), int(rect[3])
+        dx = current_x - origin_x
+        dy = current_y - origin_y
+        return {
+            "dx": dx,
+            "dy": dy,
+            "line_x": [min(origin_x, current_x), current_y + height // 2, abs(dx)] if dx else None,
+            "line_y": [current_x + width // 2, min(origin_y, current_y), abs(dy)] if dy else None,
         }
 
     def _renforge_editor_label_snapshot():

--- a/src/renforge/bridge/editor.rpy
+++ b/src/renforge/bridge/editor.rpy
@@ -7,7 +7,7 @@ screen _renforge_editor_launcher():
             id "rf_launcher"
             xalign 0.985
             yalign 0.025
-            action Function(_renforge_editor_activate)
+            action Function(_renforge_editor_consume, _renforge_editor_activate)
             background Solid("#7c3aed")
             hover_background Solid("#8b5cf6")
             text_color "#ffffff"
@@ -123,35 +123,35 @@ screen _renforge_editor_overlay():
                     spacing 6
                     textbutton "Exit":
                         id "rf_exit"
-                        action Function(_renforge_editor_exit)
+                        action Function(_renforge_editor_consume, _renforge_editor_exit)
                         text_color "#f4f4f5"
                     textbutton "Undo":
                         id "rf_undo"
-                        action Function(_renforge_editor_undo)
+                        action Function(_renforge_editor_consume, _renforge_editor_undo)
                         sensitive _renforge_editor_can_undo()
                         text_color "#f4f4f5"
                     textbutton "Redo":
                         id "rf_redo"
-                        action Function(_renforge_editor_redo)
+                        action Function(_renforge_editor_consume, _renforge_editor_redo)
                         sensitive _renforge_editor_can_redo()
                         text_color "#f4f4f5"
                     textbutton "Reset":
                         id "rf_reset"
-                        action Function(_renforge_editor_reset_selected)
+                        action Function(_renforge_editor_consume, _renforge_editor_reset_selected)
                         sensitive _renforge_editor_has_selection()
                         text_color "#f4f4f5"
                     textbutton ("Tools On" if _rf_tools_visible else "Tools Off"):
                         id "rf_tools"
-                        action Function(_renforge_editor_toggle_tools)
+                        action Function(_renforge_editor_consume, _renforge_editor_toggle_tools)
                         background Solid("#7c3aed" if _rf_tools_visible else "#3f3f46")
                         text_color "#ffffff"
                     textbutton "-":
                         id "rf_opacity_down"
-                        action Function(_renforge_editor_adjust_opacity, -0.1)
+                        action Function(_renforge_editor_consume, _renforge_editor_adjust_opacity, -0.1)
                         text_color "#f4f4f5"
                     textbutton "+":
                         id "rf_opacity_up"
-                        action Function(_renforge_editor_adjust_opacity, 0.1)
+                        action Function(_renforge_editor_consume, _renforge_editor_adjust_opacity, 0.1)
                         text_color "#f4f4f5"
                     text _renforge_editor_status_text():
                         color "#a1a1aa"
@@ -160,7 +160,7 @@ screen _renforge_editor_overlay():
                         xminimum 120
                     textbutton _renforge_editor_save_label():
                         id "rf_save"
-                        action Function(_renforge_editor_save)
+                        action Function(_renforge_editor_consume, _renforge_editor_save)
                         sensitive _renforge_editor_save_enabled()
                         background Solid("#7c3aed")
                         hover_background Solid("#8b5cf6")
@@ -336,6 +336,18 @@ init 1100 python:
 
     def _renforge_editor_is_editor_injected():
         return bool(_renforge_editor_state().editor_injected)
+
+
+    def _renforge_editor_consume(callback, *args):
+        """Run an editor control's action and report nothing back to Ren'Py.
+
+        `Function` ends the interaction as soon as its callable returns a
+        non-None value (behavior.py, Button.handle_click), and every editor
+        callback returns a status dict. That ended the interaction and
+        dismissed the dialogue underneath, so pressing Exit or Tools also
+        advanced the story. Returning None lets Ren'Py consume the click.
+        """
+        callback(*args)
 
 
     def _renforge_editor_activate():
@@ -1688,39 +1700,40 @@ init 1100 python:
         if not state.active:
             return None
         pointer_x, pointer_y = _renforge_editor_event_pos(event, x, y)
-        state.pointer = [int(pointer_x), int(pointer_y)]
-        _renforge_editor_set_label(pointer_x, pointer_y)
         event_type = getattr(event, "type", None)
         key = getattr(event, "key", None)
         shift = _renforge_editor_event_shift(event)
+        state.pointer = [int(pointer_x), int(pointer_y)]
+        _renforge_editor_set_label(pointer_x, pointer_y)
         if pygame is not None:
             if event_type == getattr(pygame, "MOUSEBUTTONDOWN", None) and getattr(event, "button", 0) == 1:
                 _renforge_editor_select(pointer_x, pointer_y)
                 if not state.selected_lock_reason:
                     _renforge_editor_apply_drag_from_pointer(pointer_x, pointer_y, shift)
-                return None
+                raise renpy.IgnoreEvent()
             if event_type == getattr(pygame, "MOUSEMOTION", None) and state.drag_active:
                 _renforge_editor_apply_drag_from_pointer(pointer_x, pointer_y, shift)
-                return None
+                raise renpy.IgnoreEvent()
             if event_type == getattr(pygame, "MOUSEBUTTONUP", None) and getattr(event, "button", 0) == 1:
+                if state.drag_active: _renforge_editor_apply_drag_from_pointer(pointer_x, pointer_y, shift)
                 _renforge_editor_end_drag()
-                return None
+                raise renpy.IgnoreEvent()
             if event_type == getattr(pygame, "KEYDOWN", None):
                 if key == getattr(pygame, "K_ESCAPE", None):
                     _renforge_editor_exit()
-                    return None
+                    raise renpy.IgnoreEvent()
                 if key == getattr(pygame, "K_LEFT", None):
                     _renforge_editor_nudge(-1, 0, shift)
-                    return None
+                    raise renpy.IgnoreEvent()
                 if key == getattr(pygame, "K_RIGHT", None):
                     _renforge_editor_nudge(1, 0, shift)
-                    return None
+                    raise renpy.IgnoreEvent()
                 if key == getattr(pygame, "K_UP", None):
                     _renforge_editor_nudge(0, -1, shift)
-                    return None
+                    raise renpy.IgnoreEvent()
                 if key == getattr(pygame, "K_DOWN", None):
                     _renforge_editor_nudge(0, 1, shift)
-                    return None
+                    raise renpy.IgnoreEvent()
         return None
 
 
@@ -2196,13 +2209,17 @@ init 1100 python:
                 nudge_reply = _renforge_editor_nudge(dx, dy, shift)
                 if not nudge_reply.get("ok", False):
                     return nudge_reply
+                continue
             else:
                 event = _renforge_editor_fake_event(
                     pygame.KEYDOWN,
                     key=key_value,
                     mod=getattr(pygame, "KMOD_SHIFT", 0) if shift else 0,
                 )
-                _renforge_editor_handle_event(event, state.pointer[0], state.pointer[1], 0.0)
+                try:
+                    _renforge_editor_handle_event(event, state.pointer[0], state.pointer[1], 0.0)
+                except renpy.IgnoreEvent:
+                    pass
             traces.append({"key": key_name, "shift": shift})
         state.last_event_trace = traces
         return {"ok": True, "repeat": repeat, "shift": shift, "active": state.active}
@@ -2483,6 +2500,8 @@ init 1100 python:
 
     def _renforge_editor_is_active():
         return bool(_renforge_editor_state().active)
+
+
 
 
     def _renforge_editor_opacity():

--- a/src/renforge/bridge/editor.rpy
+++ b/src/renforge/bridge/editor.rpy
@@ -28,6 +28,7 @@ screen _renforge_editor_overlay():
         $ _rf_label = _renforge_editor_label_snapshot()
         $ _rf_distance = _renforge_editor_distance_snapshot()
         $ _rf_measure = _renforge_editor_measure_snapshot()
+        $ _rf_guide = _renforge_editor_guide_snapshot()
         $ _rf_tools_visible = _renforge_editor_tools_visible()
 
         fixed:
@@ -35,28 +36,17 @@ screen _renforge_editor_overlay():
             yfill True
             at Transform(alpha=_renforge_editor_opacity())
 
-            if _rf_tools_visible and _renforge_editor_guide_x() is not None:
-                add Solid("#ff3b30", xysize=(1, config.screen_height)):
+            if _rf_tools_visible and _rf_guide["line_x"] is not None:
+                add Solid("#ff3b30", xysize=(1, max(1, int(_rf_guide["line_x"][2])))):
                     id "rf_guide_x"
-                    xpos int(_renforge_editor_guide_x())
-                    ypos 0
+                    xpos int(_rf_guide["line_x"][0])
+                    ypos int(_rf_guide["line_x"][1])
 
-            if _rf_tools_visible and _renforge_editor_guide_y() is not None:
-                add Solid("#ff3b30", xysize=(config.screen_width, 1)):
+            if _rf_tools_visible and _rf_guide["line_y"] is not None:
+                add Solid("#ff3b30", xysize=(max(1, int(_rf_guide["line_y"][2])), 1)):
                     id "rf_guide_y"
-                    xpos 0
-                    ypos int(_renforge_editor_guide_y())
-            if _rf_tools_visible and _rf_measure is not None and _rf_measure["line_x"] is not None:
-                add Solid("#ff3b30", xysize=(max(2, int(_rf_measure["line_x"][2])), 2)):
-                    id "rf_measure_x"
-                    xpos int(_rf_measure["line_x"][0])
-                    ypos int(_rf_measure["line_x"][1])
-
-            if _rf_tools_visible and _rf_measure is not None and _rf_measure["line_y"] is not None:
-                add Solid("#ff3b30", xysize=(2, max(2, int(_rf_measure["line_y"][2])))):
-                    id "rf_measure_y"
-                    xpos int(_rf_measure["line_y"][0])
-                    ypos int(_rf_measure["line_y"][1])
+                    xpos int(_rf_guide["line_y"][0])
+                    ypos int(_rf_guide["line_y"][1])
 
             $ _rf_guide_x_val = _renforge_editor_guide_x()
             $ _rf_guide_y_val = _renforge_editor_guide_y()
@@ -71,7 +61,7 @@ screen _renforge_editor_overlay():
                     id "rf_distance_x"
                     xpos _rf_distance_x
                     ypos _rf_distance_y
-                    background Solid("#b91c1c")
+                    background Solid("#27272a")
                     padding (6, 3)
                     text _rf_distance["text_x"]:
                         id "rf_distance_x_text"
@@ -86,7 +76,7 @@ screen _renforge_editor_overlay():
                     id "rf_distance_y"
                     xpos _rf_distance_x
                     ypos _rf_distance_y
-                    background Solid("#b91c1c")
+                    background Solid("#27272a")
                     padding (6, 3)
                     text _rf_distance["text_y"]:
                         id "rf_distance_y_text"
@@ -283,10 +273,14 @@ init 1100 python:
             state.snap_anchor_y = None
             state.snap_offset_x = None
             state.snap_offset_y = None
-            state.snap_anchors_x = None
-            state.snap_anchors_y = None
+            state.snap_candidates_x = None
+            state.snap_candidates_y = None
+            state.snap_target_x_rect = None
+            state.snap_target_y_rect = None
             state.guide_x = None
             state.guide_y = None
+            state.guide_x_span = None
+            state.guide_y_span = None
             state.opacity = 0.86
             state.tools_visible = True
             state.label_rect = [20, 20, 260, 32]
@@ -333,10 +327,18 @@ init 1100 python:
             state.snap_offset_x = None
         if not hasattr(state, "snap_offset_y"):
             state.snap_offset_y = None
-        if not hasattr(state, "snap_anchors_x"):
-            state.snap_anchors_x = None
-        if not hasattr(state, "snap_anchors_y"):
-            state.snap_anchors_y = None
+        if not hasattr(state, "snap_candidates_x"):
+            state.snap_candidates_x = None
+        if not hasattr(state, "snap_candidates_y"):
+            state.snap_candidates_y = None
+        if not hasattr(state, "snap_target_x_rect"):
+            state.snap_target_x_rect = None
+        if not hasattr(state, "snap_target_y_rect"):
+            state.snap_target_y_rect = None
+        if not hasattr(state, "guide_x_span"):
+            state.guide_x_span = None
+        if not hasattr(state, "guide_y_span"):
+            state.guide_y_span = None
         if not hasattr(state, "tools_visible"):
             state.tools_visible = True
         if not hasattr(state, "selected_source_position"):
@@ -1321,9 +1323,9 @@ init 1100 python:
         return first_key == second_key
 
 
-    def _renforge_editor_anchor_lines(selected_key):
-        anchors_x = []
-        anchors_y = []
+    def _renforge_editor_anchor_candidates(selected_key):
+        candidates_x = []
+        candidates_y = []
         for candidate in _renforge_editor_focus_candidates():
             if candidate.get("editor_owned"):
                 continue
@@ -1335,13 +1337,13 @@ init 1100 python:
             rect = candidate.get("rect") or []
             if len(rect) != 4:
                 continue
-            left = int(rect[0])
-            top = int(rect[1])
-            width = int(rect[2])
-            height = int(rect[3])
-            anchors_x.extend([left, left + width // 2, left + width])
-            anchors_y.extend([top, top + height // 2, top + height])
-        return anchors_x, anchors_y
+            target_rect = [int(value) for value in rect]
+            left, top, width, height = target_rect
+            for anchor in (left, left + width // 2, left + width):
+                candidates_x.append({"anchor": anchor, "rect": target_rect})
+            for anchor in (top, top + height // 2, top + height):
+                candidates_y.append({"anchor": anchor, "rect": target_rect})
+        return candidates_x, candidates_y
 
 
     def _renforge_editor_apply_snap(desired_x, desired_y, shift):
@@ -1351,15 +1353,25 @@ init 1100 python:
             state.snap_anchor_y = None
             state.snap_offset_x = None
             state.snap_offset_y = None
+            state.snap_target_x_rect = None
+            state.snap_target_y_rect = None
             state.guide_x = None
             state.guide_y = None
+            state.guide_x_span = None
+            state.guide_y_span = None
             return int(desired_x), int(desired_y), {"snapped_x": False, "snapped_y": False}
 
-        if state.drag_active and state.snap_anchors_x is not None and state.snap_anchors_y is not None:
-            anchors_x = state.snap_anchors_x
-            anchors_y = state.snap_anchors_y
+        if (
+            state.drag_active
+            and state.snap_candidates_x is not None
+            and state.snap_candidates_y is not None
+        ):
+            candidates_x = state.snap_candidates_x
+            candidates_y = state.snap_candidates_y
         else:
-            anchors_x, anchors_y = _renforge_editor_anchor_lines(state.selected_runtime_key)
+            candidates_x, candidates_y = _renforge_editor_anchor_candidates(
+                state.selected_runtime_key
+            )
         selected_rect = state.selected_rect or [desired_x, desired_y, 0, 0]
         width = max(0, int(selected_rect[2]))
         height = max(0, int(selected_rect[3]))
@@ -1373,21 +1385,30 @@ init 1100 python:
         if (
             anchor_x is not None
             and offset_x is not None
+            and state.snap_target_x_rect is not None
             and abs((int(desired_x) + int(offset_x)) - int(anchor_x)) <= _SNAP_RELEASE
         ):
             snapped_x = int(anchor_x) - int(offset_x)
         else:
             state.snap_anchor_x = None
             state.snap_offset_x = None
+            state.snap_target_x_rect = None
             closest_x = None
-            for anchor in anchors_x:
+            for candidate in candidates_x:
+                anchor = int(candidate["anchor"])
                 for offset in offsets_x:
-                    distance = abs((int(desired_x) + int(offset)) - int(anchor))
+                    distance = abs((int(desired_x) + int(offset)) - anchor)
                     if closest_x is None or distance < closest_x[0]:
-                        closest_x = (distance, int(anchor), int(offset))
+                        closest_x = (
+                            distance,
+                            anchor,
+                            int(offset),
+                            list(candidate["rect"]),
+                        )
             if closest_x is not None and closest_x[0] <= _SNAP_ACQUIRE:
                 state.snap_anchor_x = closest_x[1]
                 state.snap_offset_x = closest_x[2]
+                state.snap_target_x_rect = closest_x[3]
                 snapped_x = closest_x[1] - closest_x[2]
 
         anchor_y = state.snap_anchor_y
@@ -1395,25 +1416,50 @@ init 1100 python:
         if (
             anchor_y is not None
             and offset_y is not None
+            and state.snap_target_y_rect is not None
             and abs((int(desired_y) + int(offset_y)) - int(anchor_y)) <= _SNAP_RELEASE
         ):
             snapped_y = int(anchor_y) - int(offset_y)
         else:
             state.snap_anchor_y = None
             state.snap_offset_y = None
+            state.snap_target_y_rect = None
             closest_y = None
-            for anchor in anchors_y:
+            for candidate in candidates_y:
+                anchor = int(candidate["anchor"])
                 for offset in offsets_y:
-                    distance = abs((int(desired_y) + int(offset)) - int(anchor))
+                    distance = abs((int(desired_y) + int(offset)) - anchor)
                     if closest_y is None or distance < closest_y[0]:
-                        closest_y = (distance, int(anchor), int(offset))
+                        closest_y = (
+                            distance,
+                            anchor,
+                            int(offset),
+                            list(candidate["rect"]),
+                        )
             if closest_y is not None and closest_y[0] <= _SNAP_ACQUIRE:
                 state.snap_anchor_y = closest_y[1]
                 state.snap_offset_y = closest_y[2]
+                state.snap_target_y_rect = closest_y[3]
                 snapped_y = closest_y[1] - closest_y[2]
 
         state.guide_x = state.snap_anchor_x
         state.guide_y = state.snap_anchor_y
+        if state.guide_x is not None and state.snap_target_x_rect is not None:
+            target = state.snap_target_x_rect
+            state.guide_x_span = [
+                min(snapped_y, int(target[1])),
+                max(snapped_y + height, int(target[1]) + int(target[3])),
+            ]
+        else:
+            state.guide_x_span = None
+        if state.guide_y is not None and state.snap_target_y_rect is not None:
+            target = state.snap_target_y_rect
+            state.guide_y_span = [
+                min(snapped_x, int(target[0])),
+                max(snapped_x + width, int(target[0]) + int(target[2])),
+            ]
+        else:
+            state.guide_y_span = None
         return snapped_x, snapped_y, {
             "snapped_x": state.snap_anchor_x is not None,
             "snapped_y": state.snap_anchor_y is not None,
@@ -1700,9 +1746,11 @@ init 1100 python:
                 if len(rect) != 4:
                     return {"ok": False, "error": "UNMEASURED"}
                 base = [int(rect[0]), int(rect[1])]
-            anchors_x, anchors_y = _renforge_editor_anchor_lines(state.selected_runtime_key)
-            state.snap_anchors_x = anchors_x
-            state.snap_anchors_y = anchors_y
+            candidates_x, candidates_y = _renforge_editor_anchor_candidates(
+                state.selected_runtime_key
+            )
+            state.snap_candidates_x = candidates_x
+            state.snap_candidates_y = candidates_y
             state.drag_active = True
             state.drag_offset = [int(pointer_x) - int(base[0]), int(pointer_y) - int(base[1])]
             state.drag_start_position = list(base)
@@ -1715,8 +1763,18 @@ init 1100 python:
         state = _renforge_editor_state()
         state.drag_active = False
         state.drag_offset = [0, 0]
-        state.snap_anchors_x = None
-        state.snap_anchors_y = None
+        state.snap_candidates_x = None
+        state.snap_candidates_y = None
+        state.snap_anchor_x = None
+        state.snap_anchor_y = None
+        state.snap_offset_x = None
+        state.snap_offset_y = None
+        state.snap_target_x_rect = None
+        state.snap_target_y_rect = None
+        state.guide_x = None
+        state.guide_y = None
+        state.guide_x_span = None
+        state.guide_y_span = None
         if state.preview_position is not None and state.drag_start_position is not None:
             _renforge_editor_push_history(state.preview_position, before=state.drag_start_position)
         state.drag_start_position = None
@@ -1732,10 +1790,14 @@ init 1100 python:
         state.snap_anchor_y = None
         state.snap_offset_x = None
         state.snap_offset_y = None
-        state.snap_anchors_x = None
-        state.snap_anchors_y = None
+        state.snap_candidates_x = None
+        state.snap_candidates_y = None
+        state.snap_target_x_rect = None
+        state.snap_target_y_rect = None
         state.guide_x = None
         state.guide_y = None
+        state.guide_x_span = None
+        state.guide_y_span = None
         renpy.hide_screen(_EDITOR_SCREEN, layer="screens")
         renpy.restart_interaction()
         return {"ok": True, "active": False}
@@ -2610,6 +2672,19 @@ init 1100 python:
         return _renforge_editor_state().guide_y
 
 
+    def _renforge_editor_guide_snapshot():
+        state = _renforge_editor_state()
+        line_x = None
+        line_y = None
+        if state.guide_x is not None and state.guide_x_span is not None:
+            start, end = state.guide_x_span
+            line_x = [int(state.guide_x), int(start), max(1, int(end) - int(start))]
+        if state.guide_y is not None and state.guide_y_span is not None:
+            start, end = state.guide_y_span
+            line_y = [int(start), int(state.guide_y), max(1, int(end) - int(start))]
+        return {"line_x": line_x, "line_y": line_y}
+
+
     def _renforge_editor_distance_snapshot():
         state = _renforge_editor_state()
         preview = state.preview_position
@@ -2685,8 +2760,6 @@ init 1100 python:
         return {
             "dx": dx,
             "dy": dy,
-            "line_x": [min(origin_x, current_x), current_y + height // 2, abs(dx)] if dx else None,
-            "line_y": [current_x + width // 2, min(origin_y, current_y), abs(dy)] if dy else None,
         }
 
     def _renforge_editor_label_snapshot():

--- a/src/renforge/editor_demo_runner.py
+++ b/src/renforge/editor_demo_runner.py
@@ -378,12 +378,19 @@ def run_demo_v1_scenario(client: Any) -> dict[str, Any]:
     if not isinstance(samples, list) or not samples:
         raise AssertionError(f"snap samples missing: {snap!r}")
     final_sample = samples[-1]
-    guide_y = snap.get("guide_y")
+    guide_y = final_sample.get("guide_y")
     preview = final_sample.get("preview_position")
     if not isinstance(guide_y, int) or not isinstance(preview, list) or len(preview) != 2:
         raise AssertionError(f"snap did not produce a measurable guide/preview: {snap!r}")
     if abs(int(preview[1]) - decline_top) > 1 or guide_y != decline_top:
         raise AssertionError(f"snap missed decline top: {snap!r}; decline_top={decline_top}")
+    _ed_require_ok(
+        client.eval_expr(
+            "_renforge_editor_apply_drag_from_pointer(%d, %d, False)"
+            % (int(preview[0]), int(preview[1]))
+        ),
+        "visual snap guide",
+    )
 
     opacity_before_low = client.screenshot()
     _ed_require_ok(client.request("editor_task0_set_opacity", {"opacity": 0.2}), "opacity low")
@@ -393,37 +400,53 @@ def run_demo_v1_scenario(client: Any) -> dict[str, Any]:
     high_image = _open_png(high_png)
     low_image = _open_png(low_png)
     scale = _scale(client, high_image)
-    # Sample a clear span of the guide: the selection border is painted over the
-    # widget and the distance badge sits beside it, so sampling the widget's own
-    # columns would measure those instead of the line.
-    free_x0 = 4
-    free_x1 = max(free_x0 + 16, take_rect[0] - 8)
-
-    def guide_excess(image: Image.Image, y: int) -> float:
-        return _red_excess(image, y, free_x0, free_x1, scale)
-
-    red_high = guide_excess(high_image, guide_y)
-    settle_deadline = time.monotonic() + 2.0
-    while time.monotonic() < settle_deadline:
-        time.sleep(0.1)
-        settled_png = client.screenshot()
-        settled_image = _open_png(settled_png)
-        settled_red_high = guide_excess(settled_image, guide_y)
-        high_png = settled_png
-        high_image = settled_image
-        if abs(settled_red_high - red_high) < 2:
-            red_high = settled_red_high
-            break
-        red_high = settled_red_high
-    red_low = guide_excess(low_image, guide_y)
-    # Relative criteria only: the guide's own row must out-red the rows just
-    # above and below it, and must fade when the overlay opacity drops.
-    neighbour_high = max(
-        guide_excess(high_image, guide_y - 3),
-        guide_excess(high_image, guide_y + 3),
+    guide_snapshot = client.eval_expr("_renforge_editor_guide_snapshot()")
+    guide_line_y = guide_snapshot.get("line_y")
+    if (
+        not isinstance(guide_line_y, list)
+        or len(guide_line_y) != 3
+        or int(guide_line_y[1]) != guide_y
+        or int(guide_line_y[2]) <= 0
+        or int(guide_line_y[2]) >= high_image.size[0]
+    ):
+        raise AssertionError(f"bounded horizontal guide missing: {guide_snapshot!r}")
+    guide_start_x = int(guide_line_y[0])
+    guide_length = int(guide_line_y[2])
+    guide_end_x = guide_start_x + guide_length
+    sample_step = max(4, guide_length // 24)
+    sample_centers = list(
+        range(guide_start_x + 4, max(guide_start_x + 5, guide_end_x - 3), sample_step)
     )
-    guide_row_delta = red_high - red_low
-    guide_over_neighbour = red_high - neighbour_high
+    if not sample_centers:
+        sample_centers = [guide_start_x + guide_length // 2]
+    guide_contrasts = []
+    guide_fades = []
+    for center_x in sample_centers:
+        sample_x0 = max(guide_start_x, center_x - 2)
+        sample_x1 = min(guide_end_x, center_x + 3)
+        high_row = _red_excess(
+            high_image, guide_y, sample_x0, sample_x1, scale
+        )
+        high_neighbour = max(
+            _red_excess(
+                high_image, guide_y - 3, sample_x0, sample_x1, scale
+            ),
+            _red_excess(
+                high_image, guide_y + 3, sample_x0, sample_x1, scale
+            ),
+        )
+        low_row = _red_excess(
+            low_image, guide_y, sample_x0, sample_x1, scale
+        )
+        guide_contrasts.append(high_row - high_neighbour)
+        guide_fades.append(high_row - low_row)
+    guide_over_neighbour = max(guide_contrasts)
+    guide_opacity_delta = max(guide_fades)
+    if guide_over_neighbour <= 2.0 or guide_opacity_delta <= 0.0:
+        raise AssertionError(
+            "bounded guide pixels missing: contrast=%.1f opacity_delta=%.1f guide=%r"
+            % (guide_over_neighbour, guide_opacity_delta, guide_snapshot)
+        )
     guide_widget = bool(
         client.eval_expr("renpy.get_widget('_renforge_editor_overlay','rf_guide_y') is not None")
     )
@@ -435,28 +458,22 @@ def run_demo_v1_scenario(client: Any) -> dict[str, Any]:
         not guide_widget
         or not isinstance(distance_y_text, str)
         or not distance_y_text.strip()
-        or guide_over_neighbour <= 2.0
-        or guide_row_delta <= 0.0
     ):
         raise AssertionError(
-            "snap visual proof missing: widget=%r, text=%r, row=%.1f neighbour=%.1f "
-            "low=%.1f over_neighbour=%.1f opacity_delta=%.1f"
-            % (
-                guide_widget,
-                distance_y_text,
-                red_high,
-                neighbour_high,
-                red_low,
-                guide_over_neighbour,
-                guide_row_delta,
-            )
+            "snap visual proof missing: widget=%r, text=%r, guide=%r"
+            % (guide_widget, distance_y_text, guide_snapshot)
         )
+    _ed_require_ok(client.eval_expr("_renforge_editor_end_drag()"), "visual snap end")
 
     shift_drag = _ed_require_ok(
         client.request("editor_task0_drag", {"points": snap_points, "shift": True}),
         "shift drag",
     )
-    if shift_drag.get("guide_x") is not None or shift_drag.get("guide_y") is not None:
+    shift_samples = shift_drag.get("samples") or []
+    if any(
+        sample.get("guide_x") is not None or sample.get("guide_y") is not None
+        for sample in shift_samples
+    ):
         raise AssertionError(f"shift drag unexpectedly snapped: {shift_drag!r}")
 
     _ed_require_ok(_ed_select(client, _TAKE_ID), "take reselect for shift nudge")
@@ -667,9 +684,12 @@ def run_demo_v1_scenario(client: Any) -> dict[str, Any]:
             "preview_on_anchor": abs(int(preview[1]) - decline_top) <= 1,
             "guide_widget": guide_widget,
             "distance_y_text": distance_y_text,
-            "guide_row_delta": guide_row_delta,
+            "guide_snapshot": guide_snapshot,
+            "guide_length": int(guide_line_y[2]),
             "guide_over_neighbour": guide_over_neighbour,
+            "guide_opacity_delta": guide_opacity_delta,
             "low_png_bytes": len(low_png),
+            "high_png_bytes": len(high_png),
         },
         "shift_drag": shift_drag,
         "shift_nudge": {

--- a/src/renforge/editor_demo_runner.py
+++ b/src/renforge/editor_demo_runner.py
@@ -1,0 +1,710 @@
+"""Live V1 acceptance scenario for the editor in the demo game."""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import time
+from typing import Any
+
+from PIL import Image
+
+
+_EDITOR_LAUNCHER = "_renforge_editor_launcher"
+_EDITOR_OVERLAY = "_renforge_editor_overlay"
+_DEMO_SCREEN = "village_gate_choices"
+_TAKE_ID = "demo_lantern_take"
+_DECLINE_ID = "demo_lantern_decline"
+_LOCKED_ID = "demo_locked_expr"
+
+
+def _ed_require_ok(reply: dict[str, Any], name: str) -> dict[str, Any]:
+    if not isinstance(reply, dict) or reply.get("ok") is not True:
+        raise AssertionError(f"{name} failed: {reply!r}")
+    return reply
+
+
+def _ed_boot(client: Any) -> dict[str, dict[str, Any]]:
+    """Reach the demo choice screen, then open RF over it.
+
+    The story is advanced *before* the editor opens: an active editor owns every
+    click, so it deliberately no longer lets `advance` play the game underneath.
+    """
+    launcher: dict[str, Any] = {}
+    for _ in range(40):
+        launcher = client.inspect_screen(_EDITOR_LAUNCHER)
+        if launcher.get("active") is True:
+            break
+        time.sleep(0.1)
+    if launcher.get("active") is not True:
+        raise AssertionError(f"editor launcher never became active: {launcher!r}")
+
+    controls: list[dict[str, Any]] = []
+    for _ in range(12):
+        controls = [
+            control
+            for control in client.list_ui_elements()
+            if control.get("screen") == _DEMO_SCREEN
+        ]
+        found = {str(control.get("id")) for control in controls}
+        if {_TAKE_ID, _DECLINE_ID, _LOCKED_ID}.issubset(found):
+            break
+        client.advance()
+        time.sleep(0.4)
+    found_by_id = {str(control.get("id")): control for control in controls}
+    missing = {_TAKE_ID, _DECLINE_ID, _LOCKED_ID} - set(found_by_id)
+    if missing:
+        raise AssertionError(f"demo choice controls missing: {missing!r}; controls={controls!r}")
+
+    _ed_require_ok(
+        client.click_element(text="RF", exact=True, screen=_EDITOR_LAUNCHER),
+        "RF launcher click",
+    )
+    overlay: dict[str, Any] = {}
+    for _ in range(40):
+        overlay = client.inspect_screen(_EDITOR_OVERLAY)
+        if overlay.get("active") is True:
+            break
+        time.sleep(0.05)
+    if overlay.get("active") is not True:
+        raise AssertionError(f"editor overlay never became active: {overlay!r}")
+
+    _ed_require_ok(
+        client.request("editor_task0_start", {"screen": _DEMO_SCREEN}),
+        "editor_task0_start",
+    )
+    return {control_id: found_by_id[control_id] for control_id in (_TAKE_ID, _DECLINE_ID, _LOCKED_ID)}
+
+
+def _ed_focus_rect(client: Any, widget_id: str) -> list[int]:
+    """Read one focus rectangle from the current UI frame."""
+    controls = client.list_ui_elements()
+    for control in controls:
+        if control.get("id") != widget_id:
+            continue
+        bounds = control.get("bounds")
+        if not isinstance(bounds, dict):
+            break
+        return [
+            int(bounds["x"]),
+            int(bounds["y"]),
+            int(bounds["width"]),
+            int(bounds["height"]),
+        ]
+    raise AssertionError(f"missing measurable focus control {widget_id!r}: {controls!r}")
+
+
+def _ed_anchors(rect: list[int]) -> dict[str, list[int]]:
+    """Return the left/center/right and top/center/bottom anchor lines."""
+    if len(rect) != 4:
+        raise AssertionError(f"focus rect must have four values: {rect!r}")
+    x, y, width, height = (int(value) for value in rect)
+    return {
+        "x": [x, x + width // 2, x + width],
+        "y": [y, y + height // 2, y + height],
+    }
+
+
+def _ed_select(client: Any, widget_id: str) -> dict[str, Any]:
+    """Select a control at a point calculated from its observed bounds."""
+    rect = _ed_focus_rect(client, widget_id)
+    reply = client.request(
+        "editor_task0_select",
+        {"x": rect[0] + rect[2] // 2, "y": rect[1] + rect[3] // 2},
+    )
+    if reply.get("ok") is not True and not reply.get("lock_reason"):
+        _ed_require_ok(reply, f"select {widget_id}")
+    return reply
+
+
+def _ed_wait_analysis(client: Any, locked: bool, *, timeout: float = 20.0) -> dict[str, Any]:
+    """Wait until selected-target analysis settles, locked or editable."""
+    deadline = time.monotonic() + timeout
+    last: dict[str, Any] = {}
+    while time.monotonic() < deadline:
+        last = _ed_require_ok(client.request("editor_task0_status"), "analysis status")
+        reason = last.get("selected_lock_reason")
+        if locked:
+            if reason not in (None, "", "ANALYZING") and last.get("save_enabled") is False:
+                return last
+        elif last.get("current_analysis_id") and reason in (None, ""):
+            return last
+        time.sleep(0.1)
+    raise AssertionError(f"analysis did not settle (locked={locked}): {last!r}")
+
+
+def _ed_wait_original(client: Any, *, timeout: float = 10.0) -> list[int]:
+    deadline = time.monotonic() + timeout
+    last: dict[str, Any] = {}
+    while time.monotonic() < deadline:
+        last = _ed_require_ok(client.request("editor_task0_status"), "original status")
+        orig = last.get("selected_original_position")
+        if isinstance(orig, (list, tuple)) and len(orig) == 2 and all(isinstance(v, int) and not isinstance(v, bool) for v in orig):
+            return [int(orig[0]), int(orig[1])]
+        time.sleep(0.05)
+    raise AssertionError(f"selected_original_position did not settle: {last!r}")
+
+
+def _ed_wait_preview(
+    client: Any,
+    expect: list[int] | tuple[int, int] | None = None,
+    *,
+    timeout: float = 10.0,
+) -> list[int]:
+    """Poll until the selected widget has a concrete two-int preview."""
+    deadline = time.monotonic() + timeout
+    last: dict[str, Any] = {}
+    while time.monotonic() < deadline:
+        last = _ed_require_ok(client.request("editor_task0_status"), "preview status")
+        preview = last.get("preview_position")
+        if (
+            isinstance(preview, (list, tuple))
+            and len(preview) == 2
+            and all(isinstance(value, int) and not isinstance(value, bool) for value in preview)
+        ):
+            position = [int(preview[0]), int(preview[1])]
+            if expect is None or position == [int(expect[0]), int(expect[1])]:
+                return position
+        time.sleep(0.05)
+    raise AssertionError(f"preview did not settle: {last!r}")
+
+
+def _ed_do_save(client: Any, *, timeout: float = 60.0) -> dict[str, Any]:
+    """Commit the current dirty targets and wait for the reload handshake."""
+    deadline = time.monotonic() + timeout
+    last: dict[str, Any] = {}
+    while time.monotonic() < deadline:
+        last = _ed_require_ok(client.request("editor_task0_status"), "save readiness")
+        if last.get("save_enabled") is True:
+            break
+        time.sleep(0.1)
+    else:
+        raise AssertionError(f"save never became enabled: {last!r}")
+    _ed_require_ok(
+        client.click_element(id="rf_save", screen=_EDITOR_OVERLAY),
+        "editor save click",
+    )
+    while time.monotonic() < deadline:
+        last = _ed_require_ok(client.request("editor_task0_status"), "save status")
+        if not last.get("save_in_progress") and last.get("status_text") == "Reload committed":
+            return last
+        time.sleep(0.2)
+    raise AssertionError(f"save did not commit: {last!r}")
+
+
+def _open_png(png: bytes) -> Image.Image:
+    image = Image.open(io.BytesIO(png))
+    image.load()
+    return image.convert("RGB")
+
+
+def _wait_for_screenshot_change(client: Any, previous: bytes, *, timeout: float = 3.0) -> bytes:
+    previous_digest = hashlib.sha256(previous).digest()
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        current = client.screenshot()
+        if hashlib.sha256(current).digest() != previous_digest:
+            return current
+        time.sleep(0.05)
+    raise AssertionError("screenshot did not change before timeout")
+
+
+
+
+def _scale(client: Any, image: Image.Image) -> float:
+    """Physical-pixel / logical-unit ratio (guide coords are logical)."""
+    virtual = client.eval_expr("[config.screen_width, config.screen_height]")
+    if isinstance(virtual, list) and len(virtual) == 2 and virtual[0] and virtual[1]:
+        return float(image.size[0]) / float(virtual[0])
+    return float(image.size[0]) / 1280.0
+
+
+def _red_excess(
+    image: Image.Image,
+    y_logical: int,
+    x0_logical: int,
+    x1_logical: int,
+    scale: float,
+) -> float:
+    """Mean red excess ``R - (G + B) / 2`` on one exact pixel row.
+
+    The guide is a 1 px ``#ff3b30`` line: averaging neighbouring rows dilutes it
+    below the noise floor, and a plain red average would also score the warm
+    demo art. Red excess isolates the line's hue.
+    """
+    width, height = image.size
+    pixels = image.load()
+    assert pixels is not None
+    yy = int(round(y_logical * scale))
+    x0 = max(0, int(round(x0_logical * scale)))
+    x1 = min(width, int(round(x1_logical * scale)))
+    if not (0 <= yy < height) or x0 >= x1:
+        return 0.0
+    total = 0.0
+    for xx in range(x0, x1):
+        red, green, blue = pixels[xx, yy][:3]
+        total += float(red) - (float(green) + float(blue)) / 2.0
+    return total / (x1 - x0)
+
+
+def run_demo_v1_scenario(client: Any) -> dict[str, Any]:
+    """Run the complete V1 acceptance flow in one sequential Ren'Py session."""
+    controls = _ed_boot(client)
+    take_rect = _ed_focus_rect(client, _TAKE_ID)
+    decline_rect = _ed_focus_rect(client, _DECLINE_ID)
+    locked_rect = _ed_focus_rect(client, _LOCKED_ID)
+    decline_anchors = _ed_anchors(decline_rect)
+    decline_top = decline_anchors["y"][0]
+    history_screen_before = client.inspect_screen(_DEMO_SCREEN)
+    history_controls_before = [
+        control
+        for control in client.list_ui_elements()
+        if control.get("screen") == _DEMO_SCREEN
+    ]
+    history_control_ids = {str(control.get("id")) for control in history_controls_before}
+    history_label_before = client.get_state(state_profile="interaction").get("current_label")
+    history_choice_before = client.get_var("renforge_choice")
+    if (
+        history_screen_before.get("active") is not True
+        or not history_label_before
+        or not {_TAKE_ID, _DECLINE_ID}.issubset(history_control_ids)
+    ):
+        raise AssertionError(
+            "history screen was not ready before real drag: screen=%r label=%r controls=%r"
+            % (history_screen_before, history_label_before, history_controls_before)
+        )
+
+    take_selection = _ed_require_ok(_ed_select(client, _TAKE_ID), "take selection")
+    take_analysis = _ed_wait_analysis(client, locked=False)
+    if take_analysis.get("selected_lock_reason") not in (None, ""):
+        raise AssertionError(f"take unexpectedly locked: {take_analysis!r}")
+    if not take_analysis.get("current_analysis_id"):
+        raise AssertionError(f"take analysis id missing: {take_analysis!r}")
+    baseline = _ed_wait_original(client)
+    bx = take_rect[0] + take_rect[2] // 2
+    by = take_rect[1] + take_rect[3] // 2
+    real_drag_reply = _ed_require_ok(
+        client.send_input(
+            drag={
+                "points": [[bx, by], [bx + 30, by], [bx + 60, by]],
+                "button": 1,
+                "coordinate_space": "logical",
+            }
+        ),
+        "real mouse drag",
+    )
+    real_preview = None
+    real_drag_status: dict[str, Any] = {}
+    real_drag_deadline = time.monotonic() + 3.0
+    while time.monotonic() < real_drag_deadline:
+        real_drag_status = _ed_require_ok(
+            client.request("editor_task0_status"), "real drag status"
+        )
+        candidate = real_drag_status.get("preview_position")
+        if (
+            isinstance(candidate, (list, tuple))
+            and len(candidate) == 2
+            and all(isinstance(value, int) and not isinstance(value, bool) for value in candidate)
+            and list(candidate) != baseline
+        ):
+            real_preview = [int(candidate[0]), int(candidate[1])]
+            break
+        time.sleep(0.05)
+    if real_preview is None:
+        raise AssertionError(
+            f"real mouse drag did not move preview: baseline={baseline!r}, status={real_drag_status!r}"
+        )
+    real_drag_delta = [
+        real_preview[0] - baseline[0],
+        real_preview[1] - baseline[1],
+    ]
+    real_moved = max(abs(real_drag_delta[0]), abs(real_drag_delta[1])) >= 20
+    if not real_moved:
+        raise AssertionError(
+            f"real mouse drag moved less than 20px: {real_drag_delta!r}"
+        )
+    history_screen_after = client.inspect_screen(_DEMO_SCREEN)
+    history_label_after = client.get_state(state_profile="interaction").get("current_label")
+    history_choice_after = client.get_var("renforge_choice")
+    screen_still_visible = history_screen_after.get("active") is True
+    choice_not_activated = (
+        history_label_after == history_label_before
+        and history_choice_after == history_choice_before
+    )
+    if not screen_still_visible or not choice_not_activated:
+        raise AssertionError(
+            "real mouse drag propagated to story: before=(%r,%r), after=(%r,%r), screen=%r"
+            % (
+                history_label_before,
+                history_choice_before,
+                history_label_after,
+                history_choice_after,
+                history_screen_after,
+            )
+        )
+
+    move_points = [
+        [baseline[0], baseline[1]],
+        [baseline[0] + 30, baseline[1]],
+        [baseline[0] + 60, baseline[1]],
+    ]
+    drag_move = _ed_require_ok(
+        client.request("editor_task0_drag", {"points": move_points, "shift": False}),
+        "move drag",
+    )
+    moved = _ed_wait_preview(client)
+    drag_delta = [moved[0] - baseline[0], moved[1] - baseline[1]]
+    if abs(drag_delta[0]) < 20 or abs(drag_delta[1]) > 1:
+        raise AssertionError(f"move drag did not move horizontally: {drag_delta!r}")
+
+    cur = _ed_wait_preview(client)
+    snap_points = [[cur[0], cur[1]], [cur[0], decline_top]]
+    snap = _ed_require_ok(
+        client.request("editor_task0_drag", {"points": snap_points, "shift": False}),
+        "snap drag",
+    )
+    samples = snap.get("samples")
+    if not isinstance(samples, list) or not samples:
+        raise AssertionError(f"snap samples missing: {snap!r}")
+    final_sample = samples[-1]
+    guide_y = snap.get("guide_y")
+    preview = final_sample.get("preview_position")
+    if not isinstance(guide_y, int) or not isinstance(preview, list) or len(preview) != 2:
+        raise AssertionError(f"snap did not produce a measurable guide/preview: {snap!r}")
+    if abs(int(preview[1]) - decline_top) > 1 or guide_y != decline_top:
+        raise AssertionError(f"snap missed decline top: {snap!r}; decline_top={decline_top}")
+
+    opacity_before_low = client.screenshot()
+    _ed_require_ok(client.request("editor_task0_set_opacity", {"opacity": 0.2}), "opacity low")
+    low_png = _wait_for_screenshot_change(client, opacity_before_low)
+    _ed_require_ok(client.request("editor_task0_set_opacity", {"opacity": 1.0}), "opacity high")
+    high_png = _wait_for_screenshot_change(client, low_png)
+    high_image = _open_png(high_png)
+    low_image = _open_png(low_png)
+    scale = _scale(client, high_image)
+    # Sample a clear span of the guide: the selection border is painted over the
+    # widget and the distance badge sits beside it, so sampling the widget's own
+    # columns would measure those instead of the line.
+    free_x0 = 4
+    free_x1 = max(free_x0 + 16, take_rect[0] - 8)
+
+    def guide_excess(image: Image.Image, y: int) -> float:
+        return _red_excess(image, y, free_x0, free_x1, scale)
+
+    red_high = guide_excess(high_image, guide_y)
+    settle_deadline = time.monotonic() + 2.0
+    while time.monotonic() < settle_deadline:
+        time.sleep(0.1)
+        settled_png = client.screenshot()
+        settled_image = _open_png(settled_png)
+        settled_red_high = guide_excess(settled_image, guide_y)
+        high_png = settled_png
+        high_image = settled_image
+        if abs(settled_red_high - red_high) < 2:
+            red_high = settled_red_high
+            break
+        red_high = settled_red_high
+    red_low = guide_excess(low_image, guide_y)
+    # Relative criteria only: the guide's own row must out-red the rows just
+    # above and below it, and must fade when the overlay opacity drops.
+    neighbour_high = max(
+        guide_excess(high_image, guide_y - 3),
+        guide_excess(high_image, guide_y + 3),
+    )
+    guide_row_delta = red_high - red_low
+    guide_over_neighbour = red_high - neighbour_high
+    guide_widget = bool(
+        client.eval_expr("renpy.get_widget('_renforge_editor_overlay','rf_guide_y') is not None")
+    )
+    distance_y_text = client.eval_expr(
+        "str(getattr(renpy.get_widget('_renforge_editor_overlay','rf_distance_y_text'), 'text', '')) "
+        "if renpy.get_widget('_renforge_editor_overlay','rf_distance_y_text') is not None else ''"
+    )
+    if (
+        not guide_widget
+        or not isinstance(distance_y_text, str)
+        or not distance_y_text.strip()
+        or guide_over_neighbour <= 2.0
+        or guide_row_delta <= 0.0
+    ):
+        raise AssertionError(
+            "snap visual proof missing: widget=%r, text=%r, row=%.1f neighbour=%.1f "
+            "low=%.1f over_neighbour=%.1f opacity_delta=%.1f"
+            % (
+                guide_widget,
+                distance_y_text,
+                red_high,
+                neighbour_high,
+                red_low,
+                guide_over_neighbour,
+                guide_row_delta,
+            )
+        )
+
+    shift_drag = _ed_require_ok(
+        client.request("editor_task0_drag", {"points": snap_points, "shift": True}),
+        "shift drag",
+    )
+    if shift_drag.get("guide_x") is not None or shift_drag.get("guide_y") is not None:
+        raise AssertionError(f"shift drag unexpectedly snapped: {shift_drag!r}")
+
+    _ed_require_ok(_ed_select(client, _TAKE_ID), "take reselect for shift nudge")
+    _ed_wait_analysis(client, locked=False)
+    pre_shift_nudge = _ed_wait_preview(client)
+    _ed_require_ok(
+        client.request("editor_task0_key", {"key": "right", "repeat": 1, "shift": True}),
+        "shift nudge",
+    )
+    post_shift_nudge = _ed_wait_preview(client)
+    shift_nudge_delta = [
+        post_shift_nudge[0] - pre_shift_nudge[0],
+        post_shift_nudge[1] - pre_shift_nudge[1],
+    ]
+    if shift_nudge_delta != [10, 0]:
+        raise AssertionError(f"shift nudge was not ten pixels: {shift_nudge_delta!r}")
+
+    _ed_require_ok(_ed_select(client, _TAKE_ID), "take reselect for history")
+    _ed_wait_analysis(client, locked=False)
+    # The target is dirty from the drags/shift-nudge above. Reset it to its runtime
+    # baseline so the history sub-scenario starts clean: Reset returns a target to
+    # that same runtime baseline, so history_baseline below must equal it for the
+    # reset assertion to hold in one coherent frame of reference.
+    _pre_reset = client.request("editor_task0_reset", {})
+    if _pre_reset.get("ok") is True:
+        _ed_wait_preview(client)
+        _ed_require_ok(_ed_select(client, _TAKE_ID), "take reselect after pre-reset")
+        _ed_wait_analysis(client, locked=False)
+    history_baseline = _ed_wait_original(client)
+    before_nudge_status = _ed_require_ok(client.request("editor_task0_status"), "history before")
+    before_nudge = int(before_nudge_status.get("history_length", 0))
+    _ed_require_ok(
+        client.request("editor_task0_key", {"key": "right", "repeat": 1}),
+        "history nudge",
+    )
+    nudge_preview = _ed_wait_preview(client)
+    after_nudge_status = _ed_require_ok(client.request("editor_task0_status"), "history after nudge")
+    after_nudge = int(after_nudge_status.get("history_length", 0))
+    expected_nudge_preview = [history_baseline[0] + 1, history_baseline[1]]
+    if any(abs(nudge_preview[index] - expected_nudge_preview[index]) > 1 for index in range(2)):
+        raise AssertionError(
+            f"nudge preview mismatch: {nudge_preview!r}; expected {expected_nudge_preview!r}"
+        )
+    undo_reply = _ed_require_ok(client.request("editor_task0_undo"), "history undo")
+    undo_preview = _ed_wait_preview(client)
+    after_undo_status = _ed_require_ok(client.request("editor_task0_status"), "history after undo")
+    after_undo = int(after_undo_status.get("history_length", 0))
+    redo_reply = _ed_require_ok(client.request("editor_task0_redo"), "history redo")
+    redo_preview = _ed_wait_preview(client)
+    after_redo_status = _ed_require_ok(client.request("editor_task0_status"), "history after redo")
+    after_redo = int(after_redo_status.get("history_length", 0))
+    reset_reply = _ed_require_ok(client.request("editor_task0_reset"), "history reset")
+    reset_preview = _ed_wait_preview(client)
+    reset_status = _ed_require_ok(client.request("editor_task0_status"), "history after reset")
+    after_reset = int(reset_status.get("history_length", 0))
+    _ed_require_ok(
+        client.request("editor_task0_key", {"key": "right", "repeat": 1}),
+        "overlay history seed nudge",
+    )
+    overlay_seed_preview = _ed_wait_preview(client)
+    if any(
+        abs(overlay_seed_preview[index] - expected_nudge_preview[index]) > 1
+        for index in range(2)
+    ):
+        raise AssertionError(
+            f"overlay history seed mismatch: {overlay_seed_preview!r} vs {expected_nudge_preview!r}"
+        )
+    overlay_undo_reply = _ed_require_ok(
+        client.click_element(id="rf_undo", screen=_EDITOR_OVERLAY),
+        "overlay undo click",
+    )
+    overlay_undo_preview = _ed_wait_preview(client, expect=history_baseline)
+    overlay_redo_reply = _ed_require_ok(
+        client.click_element(id="rf_redo", screen=_EDITOR_OVERLAY),
+        "overlay redo click",
+    )
+    overlay_redo_preview = _ed_wait_preview(client, expect=expected_nudge_preview)
+    _ed_require_ok(
+        client.request("editor_task0_key", {"key": "right", "repeat": 1}),
+        "overlay reset seed nudge",
+    )
+    _ed_wait_preview(client)
+    overlay_reset_reply = _ed_require_ok(
+        client.click_element(id="rf_reset", screen=_EDITOR_OVERLAY),
+        "overlay reset click",
+    )
+    overlay_reset_preview = _ed_wait_preview(client, expect=history_baseline)
+    overlay_undo_ok = overlay_undo_reply.get("ok") is True
+    overlay_redo_ok = overlay_redo_reply.get("ok") is True
+    overlay_reset_ok = overlay_reset_reply.get("ok") is True
+    if any(abs(undo_preview[index] - history_baseline[index]) > 1 for index in range(2)):
+        raise AssertionError(f"undo did not restore baseline: {undo_preview!r} vs {history_baseline!r}")
+    if any(abs(redo_preview[index] - expected_nudge_preview[index]) > 1 for index in range(2)):
+        raise AssertionError(f"redo did not restore nudge: {redo_preview!r} vs {expected_nudge_preview!r}")
+    if any(abs(reset_preview[index] - history_baseline[index]) > 1 for index in range(2)):
+        raise AssertionError(f"reset did not restore baseline: {reset_preview!r} vs {history_baseline!r}")
+
+    locked_selection = _ed_select(client, _LOCKED_ID)
+    locked_status = _ed_wait_analysis(client, locked=True)
+    locked_reason = locked_status.get("selected_lock_reason")
+    if locked_reason in (None, "", "ANALYZING") or locked_status.get("save_enabled") is not False:
+        raise AssertionError(f"locked demo control was editable: {locked_status!r}")
+    lock_label_text = client.eval_expr(
+        "str(_renforge_editor_label_snapshot()['text']) "
+        "if _renforge_editor_label_snapshot() is not None else ''"
+    )
+    lock_code_in_label = (
+        isinstance(lock_label_text, str)
+        and bool(lock_label_text.strip())
+        and str(locked_reason) in lock_label_text
+    )
+    if not lock_code_in_label:
+        raise AssertionError(
+            f"locked code missing from rendered editor label: reason={locked_reason!r}, "
+            f"label={lock_label_text!r}"
+        )
+    locked_observation = locked_selection.get("observation")
+    locked_observation_rect = (
+        locked_observation.get("rect") if isinstance(locked_observation, dict) else None
+    )
+    if not isinstance(locked_observation_rect, list) or len(locked_observation_rect) != 4:
+        raise AssertionError(f"locked observation is not measurable: {locked_selection!r}")
+
+    _ed_require_ok(_ed_select(client, _TAKE_ID), "take reselect for multi")
+    _ed_wait_analysis(client, locked=False)
+    _ed_wait_original(client)
+    _ed_require_ok(
+        client.request("editor_task0_key", {"key": "right", "repeat": 1}),
+        "multi take nudge",
+    )
+    _ed_require_ok(_ed_select(client, _DECLINE_ID), "decline selection for multi")
+    _ed_wait_analysis(client, locked=False)
+    _ed_wait_original(client)
+    _ed_require_ok(
+        client.request("editor_task0_key", {"key": "right", "repeat": 1}),
+        "multi decline nudge",
+    )
+    multi_before_undo = _ed_require_ok(client.request("editor_task0_status"), "multi dirty status")
+    dirty_before_undo = int(multi_before_undo.get("dirty_target_count", 0))
+    if dirty_before_undo < 2:
+        raise AssertionError(f"multi-target dirty count did not reach two: {multi_before_undo!r}")
+    _ed_require_ok(client.request("editor_task0_undo"), "multi undo")
+    deadline = time.monotonic() + 10.0
+    multi_after_undo: dict[str, Any] = {}
+    while time.monotonic() < deadline:
+        multi_after_undo = _ed_require_ok(client.request("editor_task0_status"), "multi undo status")
+        if int(multi_after_undo.get("dirty_target_count", 0)) <= 1:
+            break
+        time.sleep(0.05)
+    dirty_after_undo = int(multi_after_undo.get("dirty_target_count", 0))
+    if dirty_after_undo > 1:
+        raise AssertionError(f"multi-target undo left too many dirty targets: {multi_after_undo!r}")
+
+    save1 = _ed_do_save(client)
+    gen1 = int(save1.get("script_generation", 0))
+    reset_after_save = client.request("editor_task0_reset")
+    if reset_after_save.get("error") != "RESET_UNAVAILABLE":
+        raise AssertionError(f"reset after save was unexpectedly available: {reset_after_save!r}")
+
+    _ed_require_ok(_ed_select(client, _TAKE_ID), "take reselect for second save")
+    _ed_wait_analysis(client, locked=False)
+    _ed_wait_original(client)
+    _ed_require_ok(
+        client.request("editor_task0_key", {"key": "right", "repeat": 1}),
+        "second save nudge",
+    )
+    _ed_wait_analysis(client, locked=False)
+    save2 = _ed_do_save(client)
+    gen2 = int(save2.get("script_generation", 0))
+    if gen2 <= gen1:
+        raise AssertionError(f"script generation did not advance: {gen1}->{gen2}")
+
+    return {
+        "controls": controls,
+        "take_rect": take_rect,
+        "decline_rect": decline_rect,
+        "locked_rect": locked_rect,
+        "decline_top": decline_top,
+        "take_selection": take_selection,
+        "take_analysis": take_analysis,
+        "baseline": baseline,
+        "undo_preview": undo_preview,
+        "redo_preview": redo_preview,
+        "reset_preview": reset_preview,
+        "reset_ok": reset_reply.get("ok") is True,
+        "drag_move": drag_move,
+        "real_mouse_drag": {
+            "reply": real_drag_reply,
+            "baseline": baseline,
+            "preview": real_preview,
+            "delta": real_drag_delta,
+            "moved": real_moved,
+            "screen_before": history_screen_before,
+            "controls_before": history_controls_before,
+            "screen_after": history_screen_after,
+            "screen_still_visible": screen_still_visible,
+            "choice_before": history_choice_before,
+            "choice_after": history_choice_after,
+            "choice_not_activated": choice_not_activated,
+            "label_before": history_label_before,
+            "label_after": history_label_after,
+        },
+        "drag_delta": drag_delta,
+        "snap": {
+            "reply": snap,
+            "guide_y": guide_y,
+            "preview": preview,
+            "preview_on_anchor": abs(int(preview[1]) - decline_top) <= 1,
+            "guide_widget": guide_widget,
+            "distance_y_text": distance_y_text,
+            "guide_row_delta": guide_row_delta,
+            "guide_over_neighbour": guide_over_neighbour,
+            "low_png_bytes": len(low_png),
+        },
+        "shift_drag": shift_drag,
+        "shift_nudge": {
+            "before": pre_shift_nudge,
+            "after": post_shift_nudge,
+            "delta": shift_nudge_delta,
+        },
+        "history": {
+            "baseline": history_baseline,
+            "before_nudge": before_nudge,
+            "after_nudge": after_nudge,
+            "nudge_preview": nudge_preview,
+            "undo": undo_reply,
+            "undo_preview": undo_preview,
+            "after_undo": after_undo,
+            "redo": redo_reply,
+            "redo_preview": redo_preview,
+            "after_redo": after_redo,
+            "reset": reset_reply,
+            "reset_ok": reset_reply.get("ok") is True,
+            "reset_preview": reset_preview,
+            "after_reset": after_reset,
+        },
+        "overlay_undo_ok": overlay_undo_ok,
+        "overlay_redo_ok": overlay_redo_ok,
+        "overlay_reset_ok": overlay_reset_ok,
+        "locked": {
+            "selection": locked_selection,
+            "selected_lock_reason": locked_reason,
+            "save_enabled": locked_status.get("save_enabled"),
+            "rect": locked_rect,
+            "observation_rect": locked_observation_rect,
+            "observation": locked_observation,
+            "lock_label_text": lock_label_text,
+            "lock_code_in_label": lock_code_in_label,
+        },
+        "multi": {
+            "dirty_before_undo": dirty_before_undo,
+            "dirty_after_undo": dirty_after_undo,
+            "status_before_undo": multi_before_undo,
+            "status_after_undo": multi_after_undo,
+        },
+        "save1": save1,
+        "gen1": gen1,
+        "reset_after_save_error": reset_after_save.get("error"),
+        "reset_after_save": reset_after_save,
+        "save2": save2,
+        "gen2": gen2,
+    }

--- a/src/renforge/editor_demo_runner.py
+++ b/src/renforge/editor_demo_runner.py
@@ -9,6 +9,8 @@ from typing import Any
 
 from PIL import Image
 
+from .bridge.client import BridgeError
+
 
 _EDITOR_LAUNCHER = "_renforge_editor_launcher"
 _EDITOR_OVERLAY = "_renforge_editor_overlay"
@@ -185,8 +187,17 @@ def _ed_do_save(client: Any, *, timeout: float = 60.0) -> dict[str, Any]:
         "editor save click",
     )
     while time.monotonic() < deadline:
-        last = _ed_require_ok(client.request("editor_task0_status"), "save status")
-        if not last.get("save_in_progress") and last.get("status_text") == "Reload committed":
+        try:
+            last = _ed_require_ok(
+                client.request("editor_task0_status"), "save status"
+            )
+        except BridgeError:
+            time.sleep(0.2)
+            continue
+        if (
+            not last.get("save_in_progress")
+            and last.get("status_text") == "Reload committed"
+        ):
             return last
         time.sleep(0.2)
     raise AssertionError(f"save did not commit: {last!r}")

--- a/src/renforge/editor_task0_runner.py
+++ b/src/renforge/editor_task0_runner.py
@@ -368,66 +368,58 @@ def run_editor_task0_live_scenario(
         "_renforge_editor_label_snapshot()"
     )
     report["no_op_save"] = client.request("editor_task0_save")
-    timer_base = client.eval_expr(
+    motion_base = client.eval_expr(
         "list(_renforge_editor_state().preview_position or [])"
     )
-    if len(timer_base) != 2:
-        raise AssertionError(f"timer drag needs a selected preview: {timer_base!r}")
-    timer_start = _require_ok(
+    if len(motion_base) != 2:
+        raise AssertionError(f"motion drag needs a selected preview: {motion_base!r}")
+    motion_start = _require_ok(
         client.eval_expr(
             f"_renforge_editor_apply_drag_from_pointer("
             f"{target_center[0]}, {target_center[1]}, True)"
         ),
-        "timer drag start",
+        "motion drag start",
     )
-    timer_queue = _require_ok(
+    motion_move = _require_ok(
         client.eval_expr(
-            f"_renforge_editor_queue_drag_frame("
+            f"_renforge_editor_apply_drag_from_pointer("
             f"{target_center[0] + 20}, {target_center[1]}, True)"
         ),
-        "timer drag queue",
+        "motion drag move",
     )
-    timer_deadline = time.monotonic() + 1.0
-    timer_after: dict[str, Any] = {}
-    while time.monotonic() < timer_deadline:
-        timer_after = client.eval_expr(
-            "{"
-            "'preview': list(_renforge_editor_state().preview_position or []),"
-            "'pending': _renforge_editor_state().pending_drag_pointer,"
-            "'scheduled': bool(_renforge_editor_state().drag_frame_scheduled),"
-            "'measure': _renforge_editor_measure_snapshot(),"
-            "'measure_x': renpy.get_widget('_renforge_editor_overlay', 'rf_measure_x') is not None,"
-            "'measure_y': renpy.get_widget('_renforge_editor_overlay', 'rf_measure_y') is not None"
-            "}"
+    motion_after = client.eval_expr(
+        "{"
+        "'preview': list(_renforge_editor_state().preview_position or []),"
+        "'drag_active': bool(_renforge_editor_state().drag_active),"
+        "'measure': _renforge_editor_measure_snapshot(),"
+        "'measure_x': renpy.get_widget('_renforge_editor_overlay', 'rf_measure_x') is not None,"
+        "'measure_y': renpy.get_widget('_renforge_editor_overlay', 'rf_measure_y') is not None"
+        "}"
+    )
+    if motion_after.get("preview") == motion_base:
+        raise AssertionError(f"direct motion did not move preview: {motion_after!r}")
+    if not isinstance(motion_after.get("measure"), dict):
+        raise AssertionError(f"direct motion lost measurement: {motion_after!r}")
+    if not (motion_after.get("measure_x") or motion_after.get("measure_y")):
+        raise AssertionError(
+            f"direct motion rendered no measurement line: {motion_after!r}"
         )
-        if (
-            timer_after.get("preview") != timer_base
-            and timer_after.get("pending") is None
-            and timer_after.get("scheduled") is False
-        ):
-            break
-        time.sleep(0.03)
-    else:
-        raise AssertionError(f"private drag timer did not flush: {timer_after!r}")
-    if not isinstance(timer_after.get("measure"), dict):
-        raise AssertionError(f"private drag timer lost measurement: {timer_after!r}")
-    if not (timer_after.get("measure_x") or timer_after.get("measure_y")):
-        raise AssertionError(f"private drag timer rendered no measurement line: {timer_after!r}")
-    report["timer_drag"] = {
-        "base": timer_base,
-        "start": timer_start,
-        "queue": timer_queue,
-        "after": timer_after,
+    report["motion_drag"] = {
+        "base": motion_base,
+        "start": motion_start,
+        "move": motion_move,
+        "after": motion_after,
     }
-    _require_ok(client.eval_expr("_renforge_editor_end_drag()"), "timer drag end")
+    _require_ok(client.eval_expr("_renforge_editor_end_drag()"), "motion drag end")
     _require_ok(
         client.eval_expr(
             f"_renforge_editor_apply_preview("
-            f"{int(timer_base[0])}, {int(timer_base[1])}, allow_snap=False, record=False)"
+            f"{int(motion_base[0])}, {int(motion_base[1])}, allow_snap=False, record=False)"
         ),
-        "timer drag restore",
+        "motion drag restore",
     )
     client.eval_expr("_renforge_editor_reset_history()")
+
 
     anchor_x = int(anchor["bounds"]["x"])
     target_y = int(target["bounds"]["y"])

--- a/src/renforge/editor_task0_runner.py
+++ b/src/renforge/editor_task0_runner.py
@@ -392,18 +392,19 @@ def run_editor_task0_live_scenario(
         "'preview': list(_renforge_editor_state().preview_position or []),"
         "'drag_active': bool(_renforge_editor_state().drag_active),"
         "'measure': _renforge_editor_measure_snapshot(),"
+        "'guide': _renforge_editor_guide_snapshot(),"
         "'measure_x': renpy.get_widget('_renforge_editor_overlay', 'rf_measure_x') is not None,"
         "'measure_y': renpy.get_widget('_renforge_editor_overlay', 'rf_measure_y') is not None"
         "}"
     )
     if motion_after.get("preview") == motion_base:
         raise AssertionError(f"direct motion did not move preview: {motion_after!r}")
-    if not isinstance(motion_after.get("measure"), dict):
-        raise AssertionError(f"direct motion lost measurement: {motion_after!r}")
-    if not (motion_after.get("measure_x") or motion_after.get("measure_y")):
-        raise AssertionError(
-            f"direct motion rendered no measurement line: {motion_after!r}"
-        )
+    if set((motion_after.get("measure") or {}).keys()) != {"dx", "dy"}:
+        raise AssertionError(f"direct motion mixed measurements with guides: {motion_after!r}")
+    if motion_after.get("measure_x") or motion_after.get("measure_y"):
+        raise AssertionError(f"direct motion rendered a competing measurement line: {motion_after!r}")
+    if motion_after.get("guide") != {"line_x": None, "line_y": None}:
+        raise AssertionError(f"shift drag rendered a snap guide: {motion_after!r}")
     report["motion_drag"] = {
         "base": motion_base,
         "start": motion_start,
@@ -443,25 +444,34 @@ def run_editor_task0_live_scenario(
 
     visual_bounds = _bounds_for(client, "task0_target", wanted_text="MOVE ME")
     visual_center = _center(visual_bounds)
-    _require_ok(
-        client.request(
-            "editor_task0_drag",
-            {
-                "points": [
-                    [visual_center[0], visual_center[1]],
-                    [anchor_x + 5, visual_center[1]],
-                ],
-                "shift": False,
-            },
+    visual_start = _require_ok(
+        client.eval_expr(
+            f"_renforge_editor_apply_drag_from_pointer("
+            f"{visual_center[0]}, {visual_center[1]}, False)"
+        ),
+        "visual guide drag start",
+    )
+    visual_snap = _require_ok(
+        client.eval_expr(
+            f"_renforge_editor_apply_drag_from_pointer("
+            f"{anchor_x + 5}, {visual_center[1]}, False)"
         ),
         "visual guide snap",
     )
+    report["visual_guide_drag"] = {
+        "start": visual_start,
+        "snap": visual_snap,
+    }
     guide_status = _require_ok(client.request("editor_task0_status"), "guide status")
     guide_x = guide_status.get("guide_x")
     guide_y = guide_status.get("guide_y")
     if not isinstance(guide_x, int) and not isinstance(guide_y, int):
         raise AssertionError(f"snap did not render a guide: {guide_status!r}")
     report["distance_badge"] = client.eval_expr("_renforge_editor_distance_snapshot()")
+    guide_snapshot = client.eval_expr("_renforge_editor_guide_snapshot()")
+    if guide_snapshot.get("line_x") is None and guide_snapshot.get("line_y") is None:
+        raise AssertionError(f"snap guide was not bounded: {guide_snapshot!r}")
+    report["guide_snapshot"] = guide_snapshot
 
     opacity_before = client.screenshot()
     _require_ok(client.request("editor_task0_set_opacity", {"opacity": 1.0}), "opacity 1.0")
@@ -522,8 +532,12 @@ def run_editor_task0_live_scenario(
             >= 60
         ),
     )
-    sample_x = int(guide_x) if isinstance(guide_x, int) else 10
-    sample_y = int(guide_y) if isinstance(guide_y, int) else int(guide_high.size[1] - 10)
+    if guide_snapshot.get("line_x") is not None:
+        sample_x = int(guide_snapshot["line_x"][0])
+        sample_y = int(guide_snapshot["line_x"][1]) + int(guide_snapshot["line_x"][2]) // 2
+    else:
+        sample_x = int(guide_snapshot["line_y"][0]) + int(guide_snapshot["line_y"][2]) // 2
+        sample_y = int(guide_snapshot["line_y"][1])
     guide_pixel_high = _sample_rgb(guide_high, sample_x, sample_y)
     guide_pixel_low = _sample_rgb(guide_low, sample_x, sample_y)
     report["guide_red"] = {
@@ -543,6 +557,10 @@ def run_editor_task0_live_scenario(
     _wait_for_image(
         client,
         lambda image: _sample_rgb(image, exit_border_x, exit_border_y)[2] < 220,
+    )
+    _require_ok(client.eval_expr("_renforge_editor_end_drag()"), "visual guide drag end")
+    report["guide_after_mouse_up"] = client.eval_expr(
+        "_renforge_editor_guide_snapshot()"
     )
 
 

--- a/src/renforge/editor_task0_runner.py
+++ b/src/renforge/editor_task0_runner.py
@@ -368,6 +368,67 @@ def run_editor_task0_live_scenario(
         "_renforge_editor_label_snapshot()"
     )
     report["no_op_save"] = client.request("editor_task0_save")
+    timer_base = client.eval_expr(
+        "list(_renforge_editor_state().preview_position or [])"
+    )
+    if len(timer_base) != 2:
+        raise AssertionError(f"timer drag needs a selected preview: {timer_base!r}")
+    timer_start = _require_ok(
+        client.eval_expr(
+            f"_renforge_editor_apply_drag_from_pointer("
+            f"{target_center[0]}, {target_center[1]}, True)"
+        ),
+        "timer drag start",
+    )
+    timer_queue = _require_ok(
+        client.eval_expr(
+            f"_renforge_editor_queue_drag_frame("
+            f"{target_center[0] + 20}, {target_center[1]}, True)"
+        ),
+        "timer drag queue",
+    )
+    timer_deadline = time.monotonic() + 1.0
+    timer_after: dict[str, Any] = {}
+    while time.monotonic() < timer_deadline:
+        timer_after = client.eval_expr(
+            "{"
+            "'preview': list(_renforge_editor_state().preview_position or []),"
+            "'pending': _renforge_editor_state().pending_drag_pointer,"
+            "'scheduled': bool(_renforge_editor_state().drag_frame_scheduled),"
+            "'measure': _renforge_editor_measure_snapshot(),"
+            "'measure_x': renpy.get_widget('_renforge_editor_overlay', 'rf_measure_x') is not None,"
+            "'measure_y': renpy.get_widget('_renforge_editor_overlay', 'rf_measure_y') is not None"
+            "}"
+        )
+        if (
+            timer_after.get("preview") != timer_base
+            and timer_after.get("pending") is None
+            and timer_after.get("scheduled") is False
+        ):
+            break
+        time.sleep(0.03)
+    else:
+        raise AssertionError(f"private drag timer did not flush: {timer_after!r}")
+    if not isinstance(timer_after.get("measure"), dict):
+        raise AssertionError(f"private drag timer lost measurement: {timer_after!r}")
+    if not (timer_after.get("measure_x") or timer_after.get("measure_y")):
+        raise AssertionError(f"private drag timer rendered no measurement line: {timer_after!r}")
+    report["timer_drag"] = {
+        "base": timer_base,
+        "start": timer_start,
+        "queue": timer_queue,
+        "after": timer_after,
+    }
+    _require_ok(client.eval_expr("_renforge_editor_end_drag()"), "timer drag end")
+    _require_ok(
+        client.eval_expr(
+            f"_renforge_editor_apply_preview("
+            f"{int(timer_base[0])}, {int(timer_base[1])}, allow_snap=False, record=False)"
+        ),
+        "timer drag restore",
+    )
+    client.eval_expr("_renforge_editor_reset_history()")
+
     anchor_x = int(anchor["bounds"]["x"])
     target_y = int(target["bounds"]["y"])
 

--- a/tests/test_bridge_runtime.py
+++ b/tests/test_bridge_runtime.py
@@ -848,7 +848,7 @@ def test_editor_mouse_up_applies_final_drag_position_without_motion(
         globs["_renforge_editor_stop_coordinator"]()
 
 
-def test_editor_measurement_tracks_raw_pointer_while_snap_is_pinned(
+def test_editor_drag_feedback_separates_distance_from_bounded_snap_guide(
     running_bridge, monkeypatch
 ):
     renpy = running_bridge.renpy
@@ -879,13 +879,49 @@ def test_editor_measurement_tracks_raw_pointer_while_snap_is_pinned(
         state.selected_original_position = [100, 200]
         state.preview_position = [100, 200]
         state.selected_rect = [100, 200, 40, 20]
+        state.snap_candidates_x = [
+            {"anchor": 120, "rect": [120, 260, 40, 40]}
+        ]
+        state.snap_candidates_y = []
 
         measurement = globs["_renforge_editor_measure_snapshot"]()
+        snapped_x, snapped_y, detail = globs["_renforge_editor_apply_snap"](
+            81, 200, False
+        )
+        guide = globs["_renforge_editor_guide_snapshot"]()
+        held_x, held_y, held_detail = globs["_renforge_editor_apply_snap"](
+            84, 210, False
+        )
+        held_guide = globs["_renforge_editor_guide_snapshot"]()
+        globs["_renforge_editor_apply_snap"](84, 210, True)
+        state.snap_candidates_x = []
+        state.snap_candidates_y = [
+            {"anchor": 230, "rect": [300, 230, 50, 40]}
+        ]
+        y_snapped_x, y_snapped_y, y_detail = globs[
+            "_renforge_editor_apply_snap"
+        ](100, 211, False)
+        horizontal_guide = globs["_renforge_editor_guide_snapshot"]()
 
-        assert measurement["dx"] == 1
-        assert measurement["dy"] == 1
-        assert measurement["line_x"] == [100, 211, 1]
-        assert measurement["line_y"] == [121, 200, 1]
+        assert measurement == {"dx": 1, "dy": 1}
+        assert (snapped_x, snapped_y) == (80, 200)
+        assert detail == {"snapped_x": True, "snapped_y": False}
+        assert guide == {
+            "line_x": [120, 200, 100],
+            "line_y": None,
+        }
+        assert (held_x, held_y) == (80, 210)
+        assert held_detail == {"snapped_x": True, "snapped_y": False}
+        assert held_guide == {
+            "line_x": [120, 210, 90],
+            "line_y": None,
+        }
+        assert (y_snapped_x, y_snapped_y) == (100, 210)
+        assert y_detail == {"snapped_x": False, "snapped_y": True}
+        assert horizontal_guide == {
+            "line_x": None,
+            "line_y": [100, 230, 250],
+        }
     finally:
         globs["_renforge_editor_stop_coordinator"]()
 
@@ -988,8 +1024,8 @@ def test_editor_motion_applies_preview_immediately(running_bridge, monkeypatch):
         state.selected_source_position = [100, 200]
         state.selected_rect = [100, 200, 40, 20]
         state.preview_position = [100, 200]
-        state.snap_anchors_x = []
-        state.snap_anchors_y = []
+        state.snap_candidates_x = []
+        state.snap_candidates_y = []
         state.targets["target"] = {
             "screen": "drag_target_screen",
             "widget_id": "drag_target",

--- a/tests/test_bridge_runtime.py
+++ b/tests/test_bridge_runtime.py
@@ -595,21 +595,21 @@ def test_send_input_scroll_posts_logical_wheel_event(running_bridge):
 def test_send_input_drag_posts_real_mouse_event_sequence(running_bridge):
     points = [[100, 200], [150, 200], [150, 240]]
     reply = running_bridge.client.send_input(
-        drag={"points": points, "button": 1, "coordinate_space": "logical"}
+        drag={"points": points, "button": 3, "coordinate_space": "logical"}
     )
 
-    assert reply == {"ok": True, "mode": "drag", "points": points, "button": 1}
+    assert reply == {"ok": True, "mode": "drag", "points": points, "button": 3}
     events = running_bridge.renpy._pygame_events
     assert [event.type for event in events] == [4, 6, 6, 5]
-    assert events[0].button == 1
+    assert events[0].button == 3
     assert events[0].pos == (100, 200)
     assert events[1].pos == (150, 200)
-    assert events[1].rel == (0, 0)
-    assert events[1].buttons == (1, 0, 0)
+    assert events[1].rel == (50, 0)
+    assert events[1].buttons == (0, 0, 1)
     assert events[2].pos == (150, 240)
-    assert events[2].rel == (0, 0)
-    assert events[2].buttons == (1, 0, 0)
-    assert events[3].button == 1
+    assert events[2].rel == (0, 40)
+    assert events[2].buttons == (0, 0, 1)
+    assert events[3].button == 3
     assert events[3].pos == (150, 240)
     assert running_bridge.renpy.display.interface.mouse_focused is True
 

--- a/tests/test_bridge_runtime.py
+++ b/tests/test_bridge_runtime.py
@@ -848,6 +848,206 @@ def test_editor_mouse_up_applies_final_drag_position_without_motion(
         globs["_renforge_editor_stop_coordinator"]()
 
 
+def test_editor_measurement_tracks_raw_pointer_while_snap_is_pinned(
+    running_bridge, monkeypatch
+):
+    renpy = running_bridge.renpy
+    globs = running_bridge.globs
+    for name in (
+        "RENFORGE_EDITOR_HOST",
+        "RENFORGE_EDITOR_PORT",
+        "RENFORGE_EDITOR_TOKEN",
+        "RENFORGE_EDITOR_PROTOCOL",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+    renpy.config.after_load_callbacks = []
+    renpy.Displayable = object
+    renpy.Render = lambda width, height: types.SimpleNamespace(
+        width=width, height=height
+    )
+    renpy.IgnoreEvent = type("IgnoreEvent", (Exception,), {})
+    renpy.show_screen = lambda *args, **kwargs: None
+    exec(compile(_load_editor_body(), "editor.rpy", "exec"), globs)
+    try:
+        state = globs["_renforge_editor_state"]()
+        state.active = True
+        state.drag_active = True
+        state.drag_start_position = [100, 200]
+        state.drag_offset = [10, 10]
+        state.pointer = [111, 211]
+        state.selected_original_position = [100, 200]
+        state.preview_position = [100, 200]
+        state.selected_rect = [100, 200, 40, 20]
+
+        measurement = globs["_renforge_editor_measure_snapshot"]()
+
+        assert measurement["dx"] == 1
+        assert measurement["dy"] == 1
+        assert measurement["line_x"] == [100, 211, 1]
+        assert measurement["line_y"] == [121, 200, 1]
+    finally:
+        globs["_renforge_editor_stop_coordinator"]()
+
+
+def test_editor_drag_deduplicates_target_rebuild_but_refreshes_measurement(
+    running_bridge, monkeypatch
+):
+    renpy = running_bridge.renpy
+    globs = running_bridge.globs
+    for name in (
+        "RENFORGE_EDITOR_HOST",
+        "RENFORGE_EDITOR_PORT",
+        "RENFORGE_EDITOR_TOKEN",
+        "RENFORGE_EDITOR_PROTOCOL",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+    renpy.config.after_load_callbacks = []
+    renpy.Displayable = object
+    renpy.Render = lambda width, height: types.SimpleNamespace(
+        width=width, height=height
+    )
+    renpy.IgnoreEvent = type("IgnoreEvent", (Exception,), {})
+    show_calls = []
+    renpy.show_screen = lambda *args, **kwargs: show_calls.append((args, kwargs))
+    exec(compile(_load_editor_body(), "editor.rpy", "exec"), globs)
+    try:
+        state = globs["_renforge_editor_state"]()
+        state.active = True
+        state.drag_active = True
+        state.selected_screen = "drag_target_screen"
+        state.selected_widget_id = "drag_target"
+        state.selected_target_key = "target"
+        state.selected_lock_reason = None
+        state.selected_original_position = [100, 200]
+        state.selected_source_position = [100, 200]
+        state.selected_rect = [100, 200, 40, 20]
+        state.preview_position = [100, 200]
+        state.targets["target"] = {
+            "screen": "drag_target_screen",
+            "widget_id": "drag_target",
+            "runtime_baseline": [100, 200],
+            "source_position": [100, 200],
+            "position": [100, 200],
+            "dirty": False,
+        }
+
+        first = globs["_renforge_editor_apply_preview"](
+            101, 200, allow_snap=False
+        )
+        restart_count = len(
+            [item for item in renpy._invoked if item == ("restart_interaction",)]
+        )
+        second = globs["_renforge_editor_apply_preview"](
+            101, 200, allow_snap=False
+        )
+
+        assert first["ok"] is True
+        assert second["ok"] is True
+        assert len(show_calls) == 1
+        assert len(
+            [item for item in renpy._invoked if item == ("restart_interaction",)]
+        ) == restart_count + 1
+    finally:
+        globs["_renforge_editor_stop_coordinator"]()
+
+
+def test_editor_drag_coalesces_motion_until_frame_tick(running_bridge, monkeypatch):
+    renpy = running_bridge.renpy
+    globs = running_bridge.globs
+    pygame = globs["pygame"]
+    for name in (
+        "RENFORGE_EDITOR_HOST",
+        "RENFORGE_EDITOR_PORT",
+        "RENFORGE_EDITOR_TOKEN",
+        "RENFORGE_EDITOR_PROTOCOL",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+    renpy.config.after_load_callbacks = []
+    renpy.Displayable = object
+    renpy.Render = lambda width, height: types.SimpleNamespace(
+        width=width, height=height
+    )
+    renpy.IgnoreEvent = type("IgnoreEvent", (Exception,), {})
+    timer_calls = []
+    pygame.event.register = lambda name: 9001
+    pygame.time = types.SimpleNamespace(
+        set_timer=lambda *args, **kwargs: timer_calls.append((args, kwargs))
+    )
+    show_calls = []
+    renpy.show_screen = lambda *args, **kwargs: show_calls.append((args, kwargs))
+    exec(compile(_load_editor_body(), "editor.rpy", "exec"), globs)
+    try:
+        state = globs["_renforge_editor_state"]()
+        state.active = True
+        state.drag_active = True
+        state.drag_offset = [10, 10]
+        state.drag_start_position = [100, 200]
+        state.selected_screen = "drag_target_screen"
+        state.selected_widget_id = "drag_target"
+        state.selected_target_key = "target"
+        state.selected_lock_reason = None
+        state.selected_original_position = [100, 200]
+        state.selected_source_position = [100, 200]
+        state.selected_rect = [100, 200, 40, 20]
+        state.preview_position = [100, 200]
+        state.snap_anchors_x = []
+        state.snap_anchors_y = []
+        state.targets["target"] = {
+            "screen": "drag_target_screen",
+            "widget_id": "drag_target",
+            "runtime_baseline": [100, 200],
+            "source_position": [100, 200],
+            "position": [100, 200],
+            "dirty": False,
+        }
+
+        motion = pygame.event.Event(
+            pygame.MOUSEMOTION,
+            {"pos": (111, 210), "rel": (1, 0), "buttons": (1, 0, 0)},
+        )
+        with pytest.raises(renpy.IgnoreEvent):
+            globs["_renforge_editor_handle_event"](motion, 111, 210, 0.0)
+
+        assert state.preview_position == [100, 200]
+        assert state.pending_drag_pointer == [111, 210]
+        assert timer_calls == [((9001, 16), {"once": True})]
+
+        tick = pygame.event.Event(9001, {"modal": False})
+        with pytest.raises(renpy.IgnoreEvent):
+            globs["_renforge_editor_handle_event"](tick, 111, 210, 0.0)
+        assert timer_calls[-1][0] == (9001, 0)
+        assert state.preview_position == [101, 200]
+        assert len(show_calls) == 1
+
+        motion_again = pygame.event.Event(
+            pygame.MOUSEMOTION,
+            {"pos": (112, 212), "rel": (1, 0), "buttons": (1, 0, 0)},
+        )
+        with pytest.raises(renpy.IgnoreEvent):
+            globs["_renforge_editor_handle_event"](motion_again, 112, 212, 0.0)
+        up = pygame.event.Event(
+            pygame.MOUSEBUTTONUP,
+            {
+                "button": 1,
+                "pos": (113, 213),
+                "x": 113,
+                "y": 213,
+                "touch": False,
+                "test": True,
+                "mod": 0,
+            },
+        )
+        with pytest.raises(renpy.IgnoreEvent):
+            globs["_renforge_editor_handle_event"](up, 113, 213, 0.0)
+        assert state.drag_active is False
+        assert state.preview_position == [103, 203]
+    finally:
+        globs["_renforge_editor_stop_coordinator"]()
+
+
 def test_dispatch_mouse_click_delivers_up_after_down_is_ignored(running_bridge):
     globs = running_bridge.globs
     renpy = running_bridge.renpy

--- a/tests/test_bridge_runtime.py
+++ b/tests/test_bridge_runtime.py
@@ -953,7 +953,7 @@ def test_editor_drag_deduplicates_target_rebuild_but_refreshes_measurement(
         globs["_renforge_editor_stop_coordinator"]()
 
 
-def test_editor_drag_coalesces_motion_until_frame_tick(running_bridge, monkeypatch):
+def test_editor_motion_applies_preview_immediately(running_bridge, monkeypatch):
     renpy = running_bridge.renpy
     globs = running_bridge.globs
     pygame = globs["pygame"]
@@ -971,11 +971,6 @@ def test_editor_drag_coalesces_motion_until_frame_tick(running_bridge, monkeypat
         width=width, height=height
     )
     renpy.IgnoreEvent = type("IgnoreEvent", (Exception,), {})
-    timer_calls = []
-    pygame.event.register = lambda name: 9001
-    pygame.time = types.SimpleNamespace(
-        set_timer=lambda *args, **kwargs: timer_calls.append((args, kwargs))
-    )
     show_calls = []
     renpy.show_screen = lambda *args, **kwargs: show_calls.append((args, kwargs))
     exec(compile(_load_editor_body(), "editor.rpy", "exec"), globs)
@@ -1011,23 +1006,9 @@ def test_editor_drag_coalesces_motion_until_frame_tick(running_bridge, monkeypat
         with pytest.raises(renpy.IgnoreEvent):
             globs["_renforge_editor_handle_event"](motion, 111, 210, 0.0)
 
-        assert state.preview_position == [100, 200]
-        assert state.pending_drag_pointer == [111, 210]
-        assert timer_calls == [((9001, 16), {"once": True})]
-
-        tick = pygame.event.Event(9001, {"modal": False})
-        with pytest.raises(renpy.IgnoreEvent):
-            globs["_renforge_editor_handle_event"](tick, 111, 210, 0.0)
-        assert timer_calls[-1][0] == (9001, 0)
         assert state.preview_position == [101, 200]
         assert len(show_calls) == 1
 
-        motion_again = pygame.event.Event(
-            pygame.MOUSEMOTION,
-            {"pos": (112, 212), "rel": (1, 0), "buttons": (1, 0, 0)},
-        )
-        with pytest.raises(renpy.IgnoreEvent):
-            globs["_renforge_editor_handle_event"](motion_again, 112, 212, 0.0)
         up = pygame.event.Event(
             pygame.MOUSEBUTTONUP,
             {
@@ -1046,6 +1027,113 @@ def test_editor_drag_coalesces_motion_until_frame_tick(running_bridge, monkeypat
         assert state.preview_position == [103, 203]
     finally:
         globs["_renforge_editor_stop_coordinator"]()
+
+
+def test_editor_task0_drag_uses_displayable_event_path(running_bridge, monkeypatch):
+    renpy = running_bridge.renpy
+    globs = running_bridge.globs
+    pygame = globs["pygame"]
+    for name in (
+        "RENFORGE_EDITOR_HOST",
+        "RENFORGE_EDITOR_PORT",
+        "RENFORGE_EDITOR_TOKEN",
+        "RENFORGE_EDITOR_PROTOCOL",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+    renpy.config.after_load_callbacks = []
+    renpy.Displayable = object
+    renpy.Render = lambda width, height: types.SimpleNamespace(
+        width=width, height=height
+    )
+    renpy.IgnoreEvent = type("IgnoreEvent", (Exception,), {})
+    renpy.show_screen = lambda *args, **kwargs: None
+    exec(compile(_load_editor_body(), "editor.rpy", "exec"), globs)
+    try:
+        state = globs["_renforge_editor_state"]()
+        state.active = True
+        state.preview_position = [100, 200]
+        event_types = []
+
+        def handle_event(event, x, y, st):
+            event_types.append(event.type)
+            if event.type == pygame.MOUSEBUTTONDOWN:
+                state.drag_active = True
+            elif event.type == pygame.MOUSEMOTION:
+                state.preview_position = [int(x), int(y)]
+            elif event.type == pygame.MOUSEBUTTONUP:
+                state.drag_active = False
+            raise renpy.IgnoreEvent()
+
+        globs["_renforge_editor_handle_event"] = handle_event
+        globs["_renforge_editor_apply_drag_from_pointer"] = (
+            lambda x, y, shift: {
+                "ok": True,
+                "preview_position": [int(x), int(y)],
+            }
+        )
+
+        reply = globs["_renforge_editor_h_drag"](
+            {"points": [[100, 200], [120, 200], [130, 210]]}
+        )
+
+        assert reply["ok"] is True
+        assert event_types == [
+            pygame.MOUSEBUTTONDOWN,
+            pygame.MOUSEMOTION,
+            pygame.MOUSEMOTION,
+            pygame.MOUSEBUTTONUP,
+        ]
+        assert reply["preview_before_mouse_up"] == [130, 210]
+        assert reply["drag_active_before_mouse_up"] is True
+        assert state.drag_active is False
+    finally:
+        globs["_renforge_editor_stop_coordinator"]()
+
+
+def test_editor_coordinator_survives_missing_global_queue(running_bridge, monkeypatch):
+    renpy = running_bridge.renpy
+    globs = dict(running_bridge.globs)
+    for name in (
+        "RENFORGE_EDITOR_HOST",
+        "RENFORGE_EDITOR_PORT",
+        "RENFORGE_EDITOR_TOKEN",
+        "RENFORGE_EDITOR_PROTOCOL",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+    renpy.config.after_load_callbacks = []
+    renpy.Displayable = object
+    renpy.Render = lambda width, height: types.SimpleNamespace(
+        width=width, height=height
+    )
+    renpy.IgnoreEvent = type("IgnoreEvent", (Exception,), {})
+    renpy.show_screen = lambda *args, **kwargs: None
+    exec(compile(_load_editor_body(), "editor.rpy", "exec"), globs)
+    try:
+        coordinator = globs["_renforge_editor_ensure_coordinator"]()
+        saved_queue = globs.get("queue")
+        globs.pop("queue", None)
+        try:
+            # Force the Empty path that crashed after reload before any submit.
+            time.sleep(0.15)
+            assert coordinator.thread.is_alive()
+        finally:
+            if saved_queue is not None:
+                globs["queue"] = saved_queue
+        request_id = coordinator.submit({"probe": True})
+        deadline = time.time() + 1.0
+        collected = []
+        while time.time() < deadline:
+            collected = coordinator.collect_nowait()
+            if collected:
+                break
+            time.sleep(0.02)
+        assert coordinator.thread.is_alive()
+        assert any(item.get("request_id") == request_id for item in collected)
+    finally:
+        globs["_renforge_editor_stop_coordinator"]()
+
 
 
 def test_dispatch_mouse_click_delivers_up_after_down_is_ignored(running_bridge):

--- a/tests/test_bridge_runtime.py
+++ b/tests/test_bridge_runtime.py
@@ -26,6 +26,15 @@ def _load_bridge_body():
     return "\n".join(line[4:] if line.startswith("    ") else line for line in lines[1:])
 
 
+def _load_editor_body():
+    raw = Path(__file__).resolve().parents[1] / "src/renforge/bridge/editor.rpy"
+    lines = raw.read_text(encoding="utf-8").splitlines()
+    start = lines.index("init 1100 python:")
+    return "\n".join(
+        line[4:] if line.startswith("    ") else line for line in lines[start + 1 :]
+    )
+
+
 class _FakeWidget:
     def __init__(self, text):
         self._text = text
@@ -583,6 +592,42 @@ def test_send_input_scroll_posts_logical_wheel_event(running_bridge):
     assert event.pos == (123, 456)
 
 
+def test_send_input_drag_posts_real_mouse_event_sequence(running_bridge):
+    points = [[100, 200], [150, 200], [150, 240]]
+    reply = running_bridge.client.send_input(
+        drag={"points": points, "button": 1, "coordinate_space": "logical"}
+    )
+
+    assert reply == {"ok": True, "mode": "drag", "points": points, "button": 1}
+    events = running_bridge.renpy._pygame_events
+    assert [event.type for event in events] == [4, 6, 6, 5]
+    assert events[0].button == 1
+    assert events[0].pos == (100, 200)
+    assert events[1].pos == (150, 200)
+    assert events[1].rel == (0, 0)
+    assert events[1].buttons == (1, 0, 0)
+    assert events[2].pos == (150, 240)
+    assert events[2].rel == (0, 0)
+    assert events[2].buttons == (1, 0, 0)
+    assert events[3].button == 1
+    assert events[3].pos == (150, 240)
+    assert running_bridge.renpy.display.interface.mouse_focused is True
+
+
+def test_send_input_drag_validates_exclusive_and_non_empty_points(running_bridge):
+    mixed = running_bridge.client.send_input(
+        text="nope",
+        drag={"points": [[1, 2], [3, 4]]},
+    )
+    empty = running_bridge.client.send_input(drag={"points": []})
+
+    assert mixed["ok"] is False
+    assert "exactly one" in mixed["error"]
+    assert empty["ok"] is False
+    assert "non-empty" in empty["error"]
+    assert running_bridge.renpy._pygame_events == []
+
+
 def test_poll_events_captures_labels_and_say_lines(running_bridge):
     config = running_bridge.renpy.config
     # Fire Ren'Py's registered callbacks the way the engine would.
@@ -713,6 +758,94 @@ def test_dispatch_mouse_click_uses_focused_displayable_local_coordinates(running
             focus_module.mouse_handler = original_mouse_handler
 
     assert seen == [(30, 50, 0), (30, 50, 0)]
+
+
+def test_editor_mouse_up_applies_final_drag_position_without_motion(
+    running_bridge, monkeypatch
+):
+    renpy = running_bridge.renpy
+    globs = running_bridge.globs
+    pygame = globs["pygame"]
+    screen_name = "drag_target_screen"
+    baseline = [320, 220]
+
+    for name in (
+        "RENFORGE_EDITOR_HOST",
+        "RENFORGE_EDITOR_PORT",
+        "RENFORGE_EDITOR_TOKEN",
+        "RENFORGE_EDITOR_PROTOCOL",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+    ScreenDisplayable = type("ScreenDisplayable", (), {})
+    Text = type("Text", (), {})
+    screen = ScreenDisplayable()
+    widget = Text()
+    widget._location = ("game/screens.rpy", 12)
+    screen.children = [widget]
+    screen.widgets = {"drag_target": widget}
+    focus = _FakeFocus("Drag target", baseline[0], baseline[1], 120, 60, widget=widget)
+    focus.screen_name = screen_name
+    renpy.display.focus.focus_list[:] = [focus]
+    renpy.display.screen = types.SimpleNamespace(
+        get_screen=lambda name: screen if name == screen_name else None
+    )
+    renpy.config.after_load_callbacks = []
+    renpy.Displayable = object
+    renpy.Render = lambda width, height: types.SimpleNamespace(
+        width=width, height=height
+    )
+    renpy.IgnoreEvent = type("IgnoreEvent", (Exception,), {})
+    renpy.show_screen = lambda *args, **kwargs: None
+
+    exec(compile(_load_editor_body(), "editor.rpy", "exec"), globs)
+    try:
+        state = globs["_renforge_editor_state"]()
+        state.active = True
+        center = [baseline[0] + focus.w // 2, baseline[1] + focus.h // 2]
+        selected = globs["_renforge_editor_h_select"]({"x": center[0], "y": center[1]})
+        runtime_key = selected["observation"]["runtime_key"]
+        target_key = globs["_renforge_editor_target_key"](runtime_key)
+        state.targets[target_key] = {
+            "analysis_id": "analysis-drag-target",
+            "source_key": {"relative_path": "screens.rpy", "line": 12},
+            "screen": screen_name,
+            "widget_id": "drag_target",
+            "runtime_baseline": list(baseline),
+            "source_position": list(baseline),
+            "position": list(baseline),
+            "dirty": False,
+        }
+        analyzed = globs["_renforge_editor_h_select"](
+            {"x": center[0], "y": center[1]}
+        )
+        assert analyzed["ok"] is True
+        assert state.preview_position == baseline
+
+        down = pygame.event.Event(
+            pygame.MOUSEBUTTONDOWN,
+            {"button": 1, "pos": tuple(center), "mod": pygame.KMOD_NONE},
+        )
+        up = pygame.event.Event(
+            pygame.MOUSEBUTTONUP,
+            {
+                "button": 1,
+                "pos": (center[0] + 40, center[1] + 30),
+                "mod": pygame.KMOD_NONE,
+            },
+        )
+        with pytest.raises(renpy.IgnoreEvent):
+            globs["_renforge_editor_handle_event"](down, center[0], center[1], 0.0)
+        with pytest.raises(renpy.IgnoreEvent):
+            globs["_renforge_editor_handle_event"](
+                up, center[0] + 40, center[1] + 30, 0.0
+            )
+
+        assert state.preview_position[0] == pytest.approx(baseline[0] + 40, abs=1)
+        assert state.preview_position[1] == pytest.approx(baseline[1] + 30, abs=1)
+        assert state.targets[state.selected_target_key]["dirty"] is True
+    finally:
+        globs["_renforge_editor_stop_coordinator"]()
 
 
 def test_dispatch_mouse_click_delivers_up_after_down_is_ignored(running_bridge):

--- a/tests/test_editor_task0_live.py
+++ b/tests/test_editor_task0_live.py
@@ -98,6 +98,12 @@ def test_task0_live_editor_prerequisite(demo_copy: Path) -> None:
     assert snap_samples[2]["guide_x"] == 360
     assert snap_samples[1]["preview_position"][0] == snap_samples[2]["preview_position"][0]
     assert snap_samples[3]["guide_x"] is None
+    timer_drag = report["timer_drag"]
+    assert timer_drag["after"]["preview"] != timer_drag["base"]
+    assert timer_drag["after"]["pending"] is None
+    assert timer_drag["after"]["scheduled"] is False
+    assert isinstance(timer_drag["after"]["measure"], dict)
+    assert timer_drag["after"]["measure_x"] or timer_drag["after"]["measure_y"]
     distance_badge = report["distance_badge"]
     assert isinstance(distance_badge, dict)
     assert int(distance_badge["delta_x"]) != 0

--- a/tests/test_editor_task0_live.py
+++ b/tests/test_editor_task0_live.py
@@ -98,12 +98,15 @@ def test_task0_live_editor_prerequisite(demo_copy: Path) -> None:
     assert snap_samples[2]["guide_x"] == 360
     assert snap_samples[1]["preview_position"][0] == snap_samples[2]["preview_position"][0]
     assert snap_samples[3]["guide_x"] is None
-    timer_drag = report["timer_drag"]
-    assert timer_drag["after"]["preview"] != timer_drag["base"]
-    assert timer_drag["after"]["pending"] is None
-    assert timer_drag["after"]["scheduled"] is False
-    assert isinstance(timer_drag["after"]["measure"], dict)
-    assert timer_drag["after"]["measure_x"] or timer_drag["after"]["measure_y"]
+    assert report["drag_snap"]["event_method"] == "_renforge_editor_handle_event"
+    assert report["drag_snap"]["drag_active_before_mouse_up"] is True
+    assert report["drag_snap"]["preview_before_mouse_up"] == snap_samples[-1]["preview_position"]
+    assert report["drag_snap"]["preview_before_mouse_up"] != snap_samples[0]["preview_position"]
+    motion_drag = report["motion_drag"]
+    assert motion_drag["after"]["preview"] != motion_drag["base"]
+    assert motion_drag["after"]["drag_active"] is True
+    assert isinstance(motion_drag["after"]["measure"], dict)
+    assert motion_drag["after"]["measure_x"] or motion_drag["after"]["measure_y"]
     distance_badge = report["distance_badge"]
     assert isinstance(distance_badge, dict)
     assert int(distance_badge["delta_x"]) != 0

--- a/tests/test_editor_task0_live.py
+++ b/tests/test_editor_task0_live.py
@@ -105,8 +105,10 @@ def test_task0_live_editor_prerequisite(demo_copy: Path) -> None:
     motion_drag = report["motion_drag"]
     assert motion_drag["after"]["preview"] != motion_drag["base"]
     assert motion_drag["after"]["drag_active"] is True
-    assert isinstance(motion_drag["after"]["measure"], dict)
-    assert motion_drag["after"]["measure_x"] or motion_drag["after"]["measure_y"]
+    assert set(motion_drag["after"]["measure"]) == {"dx", "dy"}
+    assert motion_drag["after"]["measure_x"] is False
+    assert motion_drag["after"]["measure_y"] is False
+    assert motion_drag["after"]["guide"] == {"line_x": None, "line_y": None}
     distance_badge = report["distance_badge"]
     assert isinstance(distance_badge, dict)
     assert int(distance_badge["delta_x"]) != 0
@@ -114,6 +116,12 @@ def test_task0_live_editor_prerequisite(demo_copy: Path) -> None:
     rendered_distance = report["distance_badge_rendered_text"]
     assert isinstance(rendered_distance, str)
     assert distance_badge["text_x"] in rendered_distance
+    guide_snapshot = report["guide_snapshot"]
+    assert guide_snapshot["line_x"] is not None
+    assert guide_snapshot["line_y"] is not None
+    assert 0 < guide_snapshot["line_x"][2] < 720
+    assert 0 < guide_snapshot["line_y"][2] < 1280
+    assert report["guide_after_mouse_up"] == {"line_x": None, "line_y": None}
     tools_visibility = report["tools_visibility"]
     assert tools_visibility["hide_click"]["ok"] is True
     assert tools_visibility["hidden_state"] == [False, True, False, False, False, True]

--- a/tests/test_editor_task0_runner.py
+++ b/tests/test_editor_task0_runner.py
@@ -2,6 +2,9 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from renforge.bridge.client import BridgeProtocolError
+from renforge.editor_demo_runner import _ed_do_save
+
 from renforge.editor_task0_runner import (
     EDITOR_RESOURCE,
     FIXTURE_RESOURCE,
@@ -39,3 +42,30 @@ def test_task0_runner_accepts_custom_fixture_path(tmp_path: Path) -> None:
 
     copied = inject_editor_task0_resources(project, fixture_path=custom_fixture)
     assert Path(copied["fixture"]).is_file()
+
+
+def test_demo_save_tolerates_bridge_reload_disconnect() -> None:
+    class ReloadingClient:
+        def __init__(self) -> None:
+            self.status_calls = 0
+
+        def request(self, command: str) -> dict:
+            assert command == "editor_task0_status"
+            self.status_calls += 1
+            if self.status_calls == 1:
+                return {"ok": True, "save_enabled": True}
+            if self.status_calls == 2:
+                raise BridgeProtocolError("bridge response was empty")
+            return {
+                "ok": True,
+                "save_in_progress": False,
+                "status_text": "Reload committed",
+            }
+
+        def click_element(self, **kwargs) -> dict:
+            assert kwargs == {"id": "rf_save", "screen": "_renforge_editor_overlay"}
+            return {"ok": True}
+
+    reply = _ed_do_save(ReloadingClient(), timeout=1.0)
+
+    assert reply["status_text"] == "Reload committed"

--- a/tests/test_integration_sdk_live_demo_acceptance.py
+++ b/tests/test_integration_sdk_live_demo_acceptance.py
@@ -60,8 +60,10 @@ def test_live_demo_editor_v1_acceptance(sdk, demo_copy: Path) -> None:
     assert snap["preview_on_anchor"] is True
     assert snap["guide_widget"] is True
     assert snap["distance_y_text"]
+    assert snap["guide_snapshot"]["line_y"][1] == snap["guide_y"]
+    assert 0 < snap["guide_length"] < 1280
     assert snap["guide_over_neighbour"] > 2.0
-    assert snap["guide_row_delta"] > 0.0
+    assert snap["guide_opacity_delta"] > 0.0
 
     assert report["shift_drag"]["guide_x"] is None
     assert report["shift_drag"]["guide_y"] is None

--- a/tests/test_integration_sdk_live_demo_acceptance.py
+++ b/tests/test_integration_sdk_live_demo_acceptance.py
@@ -1,0 +1,177 @@
+"""Single-session live acceptance for the demo editor workflow."""
+
+from __future__ import annotations
+
+import os
+import shutil
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("RENFORGE_SDK_TESTS"),
+    reason="set RENFORGE_SDK_TESTS=1 to run live Ren'Py SDK integration tests",
+)
+
+_DEMO = Path(__file__).resolve().parents[1] / "examples" / "demo_game"
+
+
+@pytest.fixture(scope="module")
+def sdk():
+    from renforge.sdk import DEFAULT_RENPY_VERSION, get_or_install_sdk
+
+    return get_or_install_sdk(os.environ.get("RENFORGE_SDK_VERSION", DEFAULT_RENPY_VERSION))
+
+
+@pytest.fixture
+def demo_copy(tmp_path: Path) -> Path:
+    destination = tmp_path / "demo"
+    shutil.copytree(_DEMO, destination, ignore=shutil.ignore_patterns("*.rpyc", "cache"))
+    return destination
+
+
+@pytest.mark.skipif(
+    not os.environ.get("DISPLAY"),
+    reason="live bridge needs a display (set DISPLAY, or run under xvfb)",
+)
+def test_live_demo_editor_v1_acceptance(sdk, demo_copy: Path) -> None:
+    pytest.importorskip("PIL.Image")
+
+    from renforge.bridge.launcher import launch_with_bridge
+    from renforge.editor_demo_runner import run_demo_v1_scenario
+    from renforge.project import RenpyProject
+
+    with launch_with_bridge(sdk, RenpyProject(demo_copy), startup_timeout=90, editor=True) as session:
+        report = run_demo_v1_scenario(session.client)
+
+    assert report["take_analysis"]["selected_lock_reason"] is None
+    assert report["take_analysis"]["current_analysis_id"]
+    assert abs(report["drag_delta"][0]) >= 20
+    assert abs(report["drag_delta"][1]) <= 1
+    real_drag = report["real_mouse_drag"]
+    assert real_drag["moved"] is True
+    assert max(abs(real_drag["delta"][0]), abs(real_drag["delta"][1])) >= 20
+    assert real_drag["screen_still_visible"] is True
+    assert real_drag["choice_not_activated"] is True
+
+    snap = report["snap"]
+    assert isinstance(snap["guide_y"], int)
+    assert snap["guide_y"] == report["decline_top"]
+    assert snap["preview_on_anchor"] is True
+    assert snap["guide_widget"] is True
+    assert snap["distance_y_text"]
+    assert snap["guide_over_neighbour"] > 2.0
+    assert snap["guide_row_delta"] > 0.0
+
+    assert report["shift_drag"]["guide_x"] is None
+    assert report["shift_drag"]["guide_y"] is None
+    assert report["shift_nudge"]["delta"] == [10, 0]
+
+    history = report["history"]
+    h_base = report["history"]["baseline"]
+    assert history["reset_ok"] is True
+    assert history["nudge_preview"] == [h_base[0] + 1, h_base[1]]
+    assert all(
+        abs(history["undo_preview"][index] - h_base[index]) <= 1
+        for index in range(2)
+    )
+    assert all(
+        abs(history["redo_preview"][index] - history["nudge_preview"][index]) <= 1
+        for index in range(2)
+    )
+    assert report["overlay_undo_ok"] is True
+    assert report["overlay_redo_ok"] is True
+    assert report["overlay_reset_ok"] is True
+    assert all(
+        abs(history["reset_preview"][index] - h_base[index]) <= 1
+        for index in range(2)
+    )
+
+    locked = report["locked"]
+    assert locked["selected_lock_reason"] not in (None, "", "ANALYZING")
+    assert locked["save_enabled"] is False
+    assert len(locked["observation_rect"]) == 4
+    assert locked["lock_label_text"]
+    assert locked["lock_code_in_label"] is True
+    assert report["reset_after_save_error"] == "RESET_UNAVAILABLE"
+
+    assert report["multi"]["dirty_before_undo"] >= 2
+    assert report["multi"]["dirty_after_undo"] <= 1
+
+    assert report["save1"]["status_text"] == "Reload committed"
+    assert report["save2"]["status_text"] == "Reload committed"
+    assert report["save2"]["script_generation"] > report["save1"]["script_generation"]
+
+
+@pytest.mark.skipif(
+    not os.environ.get("DISPLAY"),
+    reason="live bridge needs a display (set DISPLAY, or run under xvfb)",
+)
+def test_live_editor_controls_do_not_advance_the_story(sdk, demo_copy: Path) -> None:
+    """An editor click must edit, never play the game underneath.
+
+    `Function` ends the interaction as soon as its callable returns a non-None
+    value, so every editor button used to dismiss the dialogue while doing its
+    own job: pressing Exit also played several statements of the story.
+    """
+    import time
+
+    from renforge.bridge.launcher import launch_with_bridge
+    from renforge.project import RenpyProject
+
+    def position(client) -> str:
+        return client.eval_expr("str(renpy.get_filename_line())")
+
+    def settle(client, *, stable_reads: int = 5, gap: float = 0.25, timeout: float = 30.0) -> str:
+        """A script position that held still: transitions advance on their own."""
+        deadline = time.monotonic() + timeout
+        last = position(client)
+        same = 1
+        while time.monotonic() < deadline:
+            time.sleep(gap)
+            current = position(client)
+            same = same + 1 if current == last else 1
+            last = current
+            if same >= stable_reads:
+                return last
+        raise AssertionError(f"script position never settled: {last}")
+
+    def center(client, element_id: str) -> tuple[int, int]:
+        for element in client.request("list_ui_elements", {}).get("elements", []):
+            if element.get("id") == element_id:
+                box = element["bounds"]
+                return box["x"] + box["width"] // 2, box["y"] + box["height"] // 2
+        raise AssertionError(f"control not on screen: {element_id}")
+
+    def advanced(client, x: int, y: int) -> bool:
+        before = settle(client)
+        client.send_input(
+            drag={"points": [[x, y], [x, y]], "button": 1, "coordinate_space": "logical"}
+        )
+        return settle(client) != before
+
+    def wait_screen(client, name: str) -> bool:
+        for _ in range(80):
+            if client.inspect_screen(name).get("active") is True:
+                return True
+            time.sleep(0.1)
+        return False
+
+    with launch_with_bridge(sdk, RenpyProject(demo_copy), startup_timeout=90, editor=True) as session:
+        client = session.client
+        assert wait_screen(client, "_renforge_editor_launcher")
+
+        # Control: with the editor closed, a posted click dismisses the say.
+        # Without this, every "did not move" below would prove nothing.
+        assert advanced(client, 600, 400) is True
+
+        assert advanced(client, *center(client, "rf_launcher")) is False
+        assert wait_screen(client, "_renforge_editor_overlay")
+
+        assert advanced(client, 600, 400) is False
+        assert advanced(client, *center(client, "rf_tools")) is False
+        assert advanced(client, *center(client, "rf_exit")) is False
+
+        # Leaving the editor must hand input back, not leave the game deaf.
+        assert wait_screen(client, "_renforge_editor_launcher")
+        assert advanced(client, 600, 400) is True


### PR DESCRIPTION
## Summary

Completes the in-game RenForge editor drag workflow and its live acceptance coverage. The editor now owns pointer input while active, applies drag motion continuously, survives save/reload handshakes, and renders professional snap feedback without duplicate parallel guides.

## Motivation and related issue

The editor overlay could leak clicks into the underlying Ren'Py story, drag feedback could stall or render competing red measurement lines, and the demo acceptance did not exercise the complete real-input/save/reload path.

## Changes

- Prevent editor controls and drag gestures from activating the game underneath the overlay.
- Apply real SDL mouse motion immediately and keep the coordinator alive across Ren'Py reloads.
- Render no alignment guide outside a snap; render at most one bounded red guide per snapped axis.
- Retain the snapped target rectangle through hysteresis, clear guides on mouse-up, and keep `dx`/`dy` badges visually neutral.
- Add the editor playground, complete demo runner, real `send_input(drag=...)` coverage, save/reload acceptance, and focused regressions for both guide axes.
- Retry transient bridge disconnects during the intentional reload handshake.

## Validation

- `uv run python -m compileall -q src tests`: passed.
- `uv run pytest -q`: 487 passed, 22 skipped; one pre-existing `BrokenPipeError` thread warning in `test_close_fails_closed_while_a_handler_is_still_running`.
- `RENFORGE_TASK0_LIVE=1 uv run pytest -q tests/test_editor_task0_live.py`: 1 passed; two Pillow deprecation warnings.
- `RENFORGE_SDK_TESTS=1 DISPLAY=:0 uv run pytest -q tests/test_integration_sdk_live_demo_acceptance.py::test_live_demo_editor_v1_acceptance`: 1 passed.
- `npm --prefix ui run build`: not applicable; no dashboard frontend files changed.
- Manual verification: exercised a real SDL down → motion → up drag in Ren'Py, observed one bounded snap guide, confirmed competing measurement widgets were absent, and confirmed guides disappeared on mouse-up.

## User-facing changes

- Dragging responds continuously without activating underlying story choices.
- Red smart guides appear only for detected snaps, are bounded to the aligned objects, and never duplicate on the same axis.
- Distance badges remain available with neutral styling.

## Internationalization

- [x] This PR adds no dashboard user-visible copy requiring i18n keys.
- [x] i18n checking is not applicable because the dashboard frontend is unchanged.

## Breaking changes

None.

## Documentation

No documentation change is required; the behavior is covered by unit and live acceptance tests.

## Reviewer notes

The snap cache now keeps the selected candidate rectangle, not only flattened anchor coordinates, so bounded guide segments remain correct throughout snap-release hysteresis. The live visual assertion scans pixel windows inside the bounded guide span rather than assuming a full-canvas guide.

## Final checklist

- [x] The PR is focused on one coherent change.
- [x] Tests were added or updated for behavior changes.
- [x] Generated frontend assets are not applicable.
- [x] No credentials, tokens, personal paths, or other secrets are included.
- [x] I understand the submitted code and can explain how it works.

## Summary by Sourcery

Compléter le workflow de glisser-déposer de l’éditeur RenForge en jeu ainsi que sa couverture d’acceptation en temps réel.

Nouvelles fonctionnalités :
- Ajout de la prise en charge des événements d’entrée de type glisser-déposer dans le client bridge et le runtime, y compris la gestion des coordonnées logiques et de capture d’écran, ainsi que l’émission de véritables événements souris SDL.
- Introduction d’un exécuteur d’acceptation de l’éditeur en démo live qui pilote le workflow complet de l’éditeur en jeu dans le projet de démo Ren’Py d’exemple.
- Exposition d’un écran de terrain de jeu (playground) de l’éditeur dans le jeu de démo pour les tests manuels des interactions de l’éditeur et du comportement d’aimantation (snapping).

Corrections de bugs :
- Garantir que les boutons de l’UI de l’éditeur et les gestes de glisser-déposer consomment l’entrée sans faire avancer l’histoire Ren’Py sous-jacente ni fermer les dialogues.
- Corriger le coordinateur de glisser-déposer de l’éditeur pour qu’il survive à l’absence de files d’attente globales et aux déconnexions transitoires du bridge durant les handshakes de rechargement.
- Corriger le rendu des guides d’aimantation pour n’afficher au maximum qu’un seul guide rouge borné par axe aimanté et effacer les guides au relâchement de la souris tout en gardant les badges de distance neutres.
- Appliquer les positions finales de glisser-déposer au relâchement de la souris même en l’absence d’événements de mouvement intermédiaires, et s’assurer que le mouvement de glisser-déposer est appliqué immédiatement à partir des véritables événements souris SDL.

Améliorations :
- Affiner la logique d’aimantation de l’éditeur pour suivre les rectangles candidats et calculer des étendues de guides bornées, en séparant la mesure brute de distance des guides d’aimantation.
- Étendre la gestion du glisser-déposer de l’éditeur pour utiliser le chemin d’événements des « displayables », en coalescant les mouvements de souris et en conservant les cibles aimantées via l’hystérésis.
- Améliorer la gestion des entrées clavier et de glisser-déposer dans l’éditeur afin de toujours lever `IgnoreEvent` pour que les événements pointeur et clavier soient entièrement possédés tant que l’éditeur est actif.

Tests :
- Ajouter des tests au niveau du bridge pour la validation des entrées de glisser-déposer et des séquences d’événements souris SDL.
- Étendre les tests unitaires de l’éditeur pour couvrir les mises à jour de prévisualisation de glisser-déposer, la mesure des guides d’aimantation, la robustesse du coordinateur et le comportement du cycle de vie du glisser-déposer.
- Ajouter un test d’intégration live avec le SDK Ren’Py qui exécute le scénario complet d’acceptation de l’éditeur de démo V1, incluant les entrées de glisser-déposer réelles et le comportement de sauvegarde/rechargement.
- Étendre les tests live pour vérifier que les contrôles de l’éditeur ne font pas avancer l’histoire lorsqu’ils sont actifs et que les guides disparaissent après le relâchement de la souris avec des étendues bornées correctes.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Complete the in-game RenForge editor drag workflow and its live acceptance coverage.

New Features:
- Add support for drag input events to the bridge client and runtime, including logical and screenshot coordinate handling and real SDL mouse event posting.
- Introduce a live demo editor acceptance runner that drives the full in-game editor workflow in the example Ren'Py demo project.
- Expose an editor playground screen in the demo game for manual testing of editor interactions and snapping behavior.

Bug Fixes:
- Ensure editor UI buttons and drag gestures consume input without advancing the underlying Ren'Py story or dismissing dialogues.
- Fix the editor drag coordinator to survive missing global queues and transient bridge disconnects during reload handshakes.
- Correct snap guide rendering to show at most one bounded red guide per snapped axis and clear guides on mouse-up while keeping distance badges neutral.
- Apply final drag positions on mouse-up even without intermediate motion events and ensure drag motion is applied immediately from real SDL mouse events.

Enhancements:
- Refine editor snapping logic to track candidate rectangles and compute bounded guide spans, separating raw distance measurement from snap guides.
- Extend editor drag handling to use the displayable event path, coalescing mouse motion and retaining snapped targets through hysteresis.
- Improve keyboard and drag input handling in the editor to always raise IgnoreEvent so pointer and key events are fully owned while the editor is active.

Tests:
- Add bridge-level tests for drag input validation and SDL mouse event sequences.
- Expand editor unit tests to cover drag preview updates, snap guide measurement, coordinator robustness, and drag lifecycle behavior.
- Add a live Ren'Py SDK integration test that runs the full demo editor V1 acceptance scenario including real drag input and save/reload behavior.
- Extend live tests to verify editor controls do not advance the story while active and that guides disappear after mouse-up with correct bounded spans.

</details>