### PR TITLE
fix: stop Windows editor commit tests timing out

### DIFF
--- a/src/renforge/editor/coordinator.py
+++ b/src/renforge/editor/coordinator.py
@@ -315,7 +315,12 @@ class EditorCoordinator:
         return data[:-1], None
 
     def _send_json(self, conn: socket.socket, payload: dict[str, Any]) -> None:
-        conn.sendall((json.dumps(payload, separators=(",", ":")) + "\n").encode("utf-8"))
+        try:
+            conn.sendall((json.dumps(payload, separators=(",", ":")) + "\n").encode("utf-8"))
+        except OSError:
+            # Client may have timed out or closed while a long command (e.g. shadow
+            # lint) was still running. Teardown is handled by the connection finally.
+            return
 
     def _error_reply(self, *, request_id: str | None, code: str, message: str, details: dict[str, Any] | None = None) -> dict[str, Any]:
         error_payload: dict[str, Any] = {"code": code, "message": message}

--- a/tests/test_editor_coordinator.py
+++ b/tests/test_editor_coordinator.py
@@ -220,28 +220,37 @@ def _commit(
     y: int,
     request_id: str = "co-1",
 ) -> dict[str, Any]:
-    _send_json(
-        sock,
-        {
-            "protocol": "renforge-editor",
-            "version": 1,
-            "connection_id": auth["connection_id"],
-            "request_id": request_id,
-            "command": "commit",
-            "payload": {
-                "session_id": auth["session_id"],
-                "intents": [
-                    {
-                        "analysis_id": analysis["result"]["analysis_id"],
-                        "source_key": analysis["result"]["source_key"],
-                        "x": x,
-                        "y": y,
-                    }
-                ],
+    # Commit runs a shadow-project lint subprocess under the coordinator request
+    # lock. On loaded Windows CI hosts that can exceed the 2s create_connection
+    # default used by most tests; keep recv budget above the lint timeout floor
+    # (max(1.0, attestation_timeout * 3)) without changing non-commit paths.
+    previous_timeout = sock.gettimeout()
+    sock.settimeout(max(float(previous_timeout or 0.0), 10.0))
+    try:
+        _send_json(
+            sock,
+            {
+                "protocol": "renforge-editor",
+                "version": 1,
+                "connection_id": auth["connection_id"],
+                "request_id": request_id,
+                "command": "commit",
+                "payload": {
+                    "session_id": auth["session_id"],
+                    "intents": [
+                        {
+                            "analysis_id": analysis["result"]["analysis_id"],
+                            "source_key": analysis["result"]["source_key"],
+                            "x": x,
+                            "y": y,
+                        }
+                    ],
+                },
             },
-        },
-    )
-    return _recv_json(sock)
+        )
+        return _recv_json(sock)
+    finally:
+        sock.settimeout(previous_timeout)
 
 
 def _commit_status(sock: socket.socket, auth: dict[str, Any], transaction_id: str, request_id: str = "st-1") -> dict[str, Any]:


### PR DESCRIPTION
## Summary
- Windows CI failed on `test_reload_handshake_marks_committed_after_independent_attestation` with a 2s client socket timeout during `commit`.
- Root cause: `commit` runs a shadow lint subprocess under the coordinator request lock; under loaded Windows runners that can exceed the test socket timeout. The server then hits `BrokenPipeError` when replying after the client has already closed.
- Raise the `_commit` helper socket recv budget to ≥10s for every commit call site, and make `_send_json` tolerate a peer that closed mid-command.

## Test plan
- [x] Reproduced timeout by delaying shadow lint past 2s; confirmed `_commit` now succeeds and restores the prior socket timeout
- [x] `python -m pip install -e .[test] && python -m pytest -q` → 487 passed, 22 skipped
- [ ] CI green on `windows-latest` (the previously failing job)

## Résumé par Sourcery

Prolonger les délais d’expiration des sockets des requêtes de commit dans les tests du coordinateur de l’éditeur et rendre l’envoi de JSON par le serveur plus robuste face aux clients qui expirent ou se déconnectent pendant les commandes de longue durée.

Corrections de bugs :
- Empêcher les tests de commit du coordinateur de l’éditeur sous Windows d’expirer lorsque l’exécution du lint « shadow » dépasse l’ancien délai d’expiration `socket recv`.
- Éviter les erreurs `BrokenPipeError` lors de l’envoi de réponses JSON à des clients qui ont déjà fermé la connexion pendant des opérations de longue durée.

Tests :
- Ajuster la gestion du délai d’expiration du socket de commit dans les helpers de test afin de mieux refléter la durée réaliste des commits sur des environnements plus lents.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Extend commit request socket timeouts in editor coordinator tests and make server JSON sending robust to clients that time out or disconnect during long-running commands.

Bug Fixes:
- Prevent Windows editor coordinator commit tests from timing out due to shadow lint execution exceeding the previous socket recv timeout.
- Avoid BrokenPipeError when sending JSON replies to clients that have already closed the connection during long-running operations.

Tests:
- Adjust test helper commit socket timeout handling to better reflect realistic commit durations on slower environments.

</details>