### PR TITLE
feat(editor): dedicated imagebutton adapter (#32)

### DIFF
--- a/docs/superpowers/plans/2026-08-01-imagebutton-adapter.md
+++ b/docs/superpowers/plans/2026-08-01-imagebutton-adapter.md
@@ -1,0 +1,688 @@
+# Imagebutton Adapter Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a dedicated single-line `imagebutton` visual-editor adapter with analyzer, patch path, coordinator dispatch, unit/coordinator coverage, and an opt-in seven-step live proof (issue #32).
+
+**Architecture:** Twin of the existing textbutton source adapter (separate kind check and error messages). Coordinator peeks the source-line keyword and dispatches to the matching analyzer/patcher. Runtime selection/preview seams stay unchanged. Live proof is a **focused** seven-step scenario with its own fixture and test. The harness reuses task0 bridge handlers and small pure helpers; it does **not** clone the full task0 UI suite and does **not** widen the analyzer by allowlist/analogy.
+
+**Tech Stack:** Python 3.11+, pytest, Ren'Py 8.5.3 SDK (live only), existing `EditorCoordinator` / bridge editor handlers.
+
+**Spec:** `docs/superpowers/specs/2026-08-01-imagebutton-adapter-design.md`  
+**Issue:** https://github.com/alex-jordan547/renforge-mcp/issues/32  
+**Branch:** `feat/imagebutton-adapter-32`
+
+## Global Constraints
+
+1. Dedicated adapter path — do **not** change `analyze_textbutton_statement` to accept `imagebutton`.
+2. Single-line statements only; multi-line `imagebutton:` blocks stay locked (`MULTILINE_STATEMENT_REJECTED`).
+3. Every verdict-bearing position must use `measurement_method == "focus_list"`.
+4. textbutton behavior and existing tests must remain green unchanged.
+5. Live proof is opt-in via `RENFORGE_IMAGEBUTTON_LIVE=1`; default CI runs unit/coordinator only.
+6. Scope doc honesty: say **“implemented; live proof opt-in”** unless live proof is in default CI.
+7. Proof harness decision (locked): dedicated fixture + dedicated test + **slim focused runner**. Reuse `_require_ok`, `_wait_for_status`, `_extract_widget_position`, inject pattern, and `editor_task0_*` bridge commands. Do **not** fork the 800-line task0 UI matrix. Do **not** parameterize task0 into a multi-adapter mega-suite in this PR.
+8. Roadmap “no widening by analogy” applies to the **analyzer kind check**, not to shared proof helpers.
+
+## File map
+
+| File | Role |
+|---|---|
+| `src/renforge/editor/source.py` | `ImagebuttonStatement`, analyze/patch twin, peek + dispatch routers |
+| `src/renforge/editor/coordinator.py` | analyze/commit use dispatch; `statement_kind` from parsed kind |
+| `tests/test_editor_source.py` | unit tests for imagebutton analyzer/patch |
+| `tests/test_editor_coordinator.py` | analyze+commit imagebutton; unsupported kind lock |
+| `tests/live_fixtures/renforge_editor_imagebutton_fixture.rpy` | single-line editable imagebutton + anchor |
+| `src/renforge/editor_imagebutton_runner.py` | slim seven-step live scenario |
+| `tests/test_editor_imagebutton_live.py` | opt-in live test |
+| `docs/superpowers/specs/2026-07-30-renforge-visual-editor-v1-scope.md` | gate 3 + adapter table honesty |
+| `docs/superpowers/specs/2026-07-30-renforge-visual-editor-vfull-roadmap.md` | Stage 1 note |
+| `docs/superpowers/specs/2026-08-01-imagebutton-adapter-design.md` | design (already written) |
+| `docs/superpowers/plans/2026-08-01-imagebutton-adapter.md` | this plan |
+
+## Public interfaces (contract)
+
+```python
+@dataclass(frozen=True)
+class ImagebuttonStatement:
+    widget_id: str
+    xpos: int
+    ypos: int
+    xpos_span: tuple[int, int]
+    ypos_span: tuple[int, int]
+
+def peek_statement_kind(line: str) -> str | None:
+    """First top-level WORD on a single line, or None."""
+
+def analyze_imagebutton_statement(line: str, *, expected_widget_id: str) -> ImagebuttonStatement: ...
+
+def apply_imagebutton_patch(
+    source_bytes: bytes, statement: ImagebuttonStatement, *, x: int, y: int
+) -> bytes: ...
+
+def analyze_editable_statement(
+    line: str, *, expected_widget_id: str
+) -> tuple[str, TextbuttonStatement | ImagebuttonStatement]:
+    """Router only. Kind checks stay inside each dedicated analyzer."""
+
+def apply_editable_statement_patch(
+    source_bytes: bytes, kind: str, statement: Any, *, x: int, y: int
+) -> bytes: ...
+```
+
+`source_key.statement_kind` values after this work: `"textbutton"` | `"imagebutton"`.
+
+Live report minimum keys:
+
+```text
+resolve, preview, patch, reload, pixel_agreement, rebinding, byte_identical_undo
+```
+
+---
+
+### Task 1: Imagebutton source analyzer + unit tests
+
+**Files:**
+- Modify: `src/renforge/editor/source.py`
+- Modify: `tests/test_editor_source.py`
+
+**Verify:** `python -m pytest tests/test_editor_source.py -q` → PASS
+
+- [ ] **Step 1: Write failing unit tests**
+
+Append to `tests/test_editor_source.py`:
+
+```python
+from renforge.editor.source import (
+    EditorSourceError,
+    analyze_editable_statement,
+    analyze_imagebutton_statement,
+    analyze_textbutton_statement,
+    apply_editable_statement_patch,
+    apply_imagebutton_patch,
+    apply_textbutton_patch,
+    peek_statement_kind,
+)
+
+
+def test_peek_statement_kind_reads_first_top_level_word() -> None:
+    assert peek_statement_kind(
+        '    imagebutton id "icon" idle Solid("#0f0") xpos 1 ypos 2 action NullAction()\n'
+    ) == "imagebutton"
+    assert peek_statement_kind(
+        '    textbutton "Play" id "start" xpos 1 ypos 2 action NullAction()\n'
+    ) == "textbutton"
+    assert peek_statement_kind("    # comment only\n") is None
+
+
+def test_analyze_imagebutton_statement_accepts_single_line_and_patches_spans() -> None:
+    line = (
+        '    imagebutton id "icon" idle Solid("#4c6ef5", xysize=(80, 48)) '
+        "xpos 200 ypos 180 action NullAction()\n"
+    )
+    parsed = analyze_imagebutton_statement(line, expected_widget_id="icon")
+    assert parsed.widget_id == "icon"
+    assert parsed.xpos == 200
+    assert parsed.ypos == 180
+    patched = apply_imagebutton_patch(line.encode("utf-8"), parsed, x=240, y=196).decode("utf-8")
+    assert patched == (
+        '    imagebutton id "icon" idle Solid("#4c6ef5", xysize=(80, 48)) '
+        "xpos 240 ypos 196 action NullAction()\n"
+    )
+
+
+def test_analyze_imagebutton_statement_rejects_textbutton_kind() -> None:
+    with pytest.raises(EditorSourceError, match="imagebutton") as excinfo:
+        analyze_imagebutton_statement(
+            '    textbutton "Play" id "start" xpos 12 ypos 10 action NullAction()\n',
+            expected_widget_id="start",
+        )
+    assert excinfo.value.code == "STATEMENT_KIND_MISMATCH"
+
+
+def test_analyze_imagebutton_statement_rejects_expressions_duplicates_and_multiline() -> None:
+    with pytest.raises(EditorSourceError) as excinfo:
+        analyze_imagebutton_statement(
+            '    imagebutton id "icon" idle Solid("#0f0") xpos xpos_base ypos 10 action NullAction()\n',
+            expected_widget_id="icon",
+        )
+    assert excinfo.value.code == "XPOS_LITERAL_REQUIRED"
+
+    with pytest.raises(EditorSourceError) as excinfo:
+        analyze_imagebutton_statement(
+            '    imagebutton id "icon" idle Solid("#0f0") xpos 1 xpos 2 ypos 10 action NullAction()\n',
+            expected_widget_id="icon",
+        )
+    assert excinfo.value.code == "XPOS_DUPLICATE"
+
+    with pytest.raises(EditorSourceError) as excinfo:
+        analyze_imagebutton_statement(
+            '    imagebutton:\n        id "icon"\n        xpos 1\n        ypos 2\n',
+            expected_widget_id="icon",
+        )
+    assert excinfo.value.code == "MULTILINE_STATEMENT_REJECTED"
+
+
+def test_analyze_imagebutton_ignores_keywords_inside_nested_calls() -> None:
+    line = (
+        '    imagebutton id "icon" idle Transform("x", xpos=9) '
+        "xpos 12 ypos 34 action NullAction() # xpos 99\n"
+    )
+    parsed = analyze_imagebutton_statement(line, expected_widget_id="icon")
+    assert (parsed.xpos, parsed.ypos) == (12, 34)
+
+
+def test_analyze_editable_statement_routes_kinds() -> None:
+    kind, stmt = analyze_editable_statement(
+        '    imagebutton id "icon" idle Solid("#0f0") xpos 3 ypos 4 action NullAction()\n',
+        expected_widget_id="icon",
+    )
+    assert kind == "imagebutton"
+    assert stmt.xpos == 3
+    kind_tb, stmt_tb = analyze_editable_statement(
+        '    textbutton "Play" id "start" xpos 8 ypos 9 action NullAction()\n',
+        expected_widget_id="start",
+    )
+    assert kind_tb == "textbutton"
+    assert stmt_tb.ypos == 9
+    with pytest.raises(EditorSourceError) as excinfo:
+        analyze_editable_statement(
+            '    bar id "b" value 1 range 2 xpos 1 ypos 2\n',
+            expected_widget_id="b",
+        )
+    assert excinfo.value.code == "STATEMENT_KIND_MISMATCH"
+```
+
+- [ ] **Step 2: Run tests — expect FAIL**
+
+```bash
+python -m pytest tests/test_editor_source.py -q -k "imagebutton or editable_statement or peek_statement"
+```
+
+Expected: import/attribute failures for missing symbols.
+
+- [ ] **Step 3: Implement in `source.py`**
+
+1. Add `ImagebuttonStatement` (same fields as `TextbuttonStatement`).
+2. Factor span rewrite into a private `_apply_integer_span_patch(source_bytes, xpos_span, ypos_span, *, x, y)` used by both patchers (optional but preferred).
+3. Implement `analyze_imagebutton_statement` as a twin of textbutton:
+   - multi-line reject
+   - first top-level WORD must be `"imagebutton"`
+   - messages name `imagebutton`
+   - same id/xpos/ypos literal rules and nested-depth ignore
+4. Implement `apply_imagebutton_patch`.
+5. Implement `peek_statement_kind(line)` via `_lex_single_line`.
+6. Implement router helpers:
+
+```python
+def analyze_editable_statement(line: str, *, expected_widget_id: str):
+    kind = peek_statement_kind(line)
+    if kind == "textbutton":
+        return kind, analyze_textbutton_statement(line, expected_widget_id=expected_widget_id)
+    if kind == "imagebutton":
+        return kind, analyze_imagebutton_statement(line, expected_widget_id=expected_widget_id)
+    raise EditorSourceError(
+        "STATEMENT_KIND_MISMATCH",
+        f"unsupported statement kind: {kind!r}",
+    )
+
+
+def apply_editable_statement_patch(source_bytes, kind, statement, *, x, y):
+    if kind == "textbutton":
+        return apply_textbutton_patch(source_bytes, statement, x=x, y=y)
+    if kind == "imagebutton":
+        return apply_imagebutton_patch(source_bytes, statement, x=x, y=y)
+    raise EditorSourceError("STATEMENT_KIND_MISMATCH", f"unsupported statement kind: {kind!r}")
+```
+
+**Anti-pattern:** do not implement one analyzer with `if kind in {...}`. Each analyzer owns its kind check; routers only dispatch.
+
+- [ ] **Step 4: Run full source tests — expect PASS**
+
+```bash
+python -m pytest tests/test_editor_source.py -q
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/renforge/editor/source.py tests/test_editor_source.py
+git commit -m "$(cat <<'EOF'
+feat(editor): add dedicated imagebutton source analyzer
+
+Issue #32 — Stage 1 adapter twin for single-line imagebutton
+with literal id/xpos/ypos; no textbutton allowlist widen.
+EOF
+)"
+```
+
+---
+
+### Task 2: Coordinator dispatch + tests
+
+**Files:**
+- Modify: `src/renforge/editor/coordinator.py`
+- Modify: `tests/test_editor_coordinator.py`
+
+**Verify:** `python -m pytest tests/test_editor_source.py tests/test_editor_coordinator.py -q` → PASS
+
+- [ ] **Step 1: Write failing coordinator tests**
+
+Add to `tests/test_editor_coordinator.py`:
+
+```python
+def _make_imagebutton_project(tmp_path: Path) -> tuple[RenpyProject, Path]:
+    root = tmp_path / "project_img"
+    game_dir = root / "game"
+    game_dir.mkdir(parents=True)
+    source = game_dir / "script.rpy"
+    source.write_text(
+        "screen test_screen:\n"
+        '    imagebutton id "start_btn" idle Solid("#4c6ef5", xysize=(80, 48)) '
+        "xpos 12 ypos 10 action NullAction()\n",
+        encoding="utf-8",
+    )
+    return RenpyProject(root), source
+
+
+def test_analyze_and_commit_imagebutton_statement(tmp_path: Path) -> None:
+    project, source = _make_imagebutton_project(tmp_path)
+    observation = _base_observation()
+    observation["runtime_key"]["ancestry"][1]["type"] = "ImageButton"
+    probe = _Probe(
+        observe_reply={
+            **json.loads(json.dumps(observation)),
+            "frame_id": "independent-frame-img",
+            "object_id": "obj-independent-img",
+        }
+    )
+    coordinator = EditorCoordinator(project, _make_sdk(tmp_path))
+    coordinator.attach_runtime_probe(probe)
+    endpoint = coordinator.start()
+    try:
+        with socket.create_connection((endpoint.host, endpoint.port), timeout=2.0) as sock:
+            auth = _auth(sock, endpoint)
+            analyzed = _analyze(sock, auth, observation, request_id="an-img")
+            assert analyzed["ok"] is True
+            result = analyzed["result"]
+            assert result["lock_reason"] is None
+            assert result["capabilities"] == {"move": True}
+            assert result["source_key"]["statement_kind"] == "imagebutton"
+            assert result["original_position"] == [12, 10]
+
+            committed = _commit(sock, auth, analyzed, x=40, y=50, request_id="co-img")
+            assert committed["ok"] is True
+            assert committed["result"]["state"] == "published"
+    finally:
+        coordinator.close()
+
+    text = source.read_text(encoding="utf-8")
+    assert "xpos 40 ypos 50" in text
+    assert 'imagebutton id "start_btn"' in text
+
+
+def test_analyze_rejects_unsupported_statement_kind(tmp_path: Path) -> None:
+    project, source = _make_project(tmp_path)
+    source.write_text(
+        "screen test_screen:\n"
+        '    bar id "start_btn" value 1 range 10 xpos 12 ypos 10 xysize (40, 10)\n',
+        encoding="utf-8",
+    )
+    observation = _base_observation()
+    probe = _Probe(
+        observe_reply={
+            **json.loads(json.dumps(observation)),
+            "frame_id": "independent-frame-bar",
+            "object_id": "obj-independent-bar",
+        }
+    )
+    coordinator = EditorCoordinator(project, _make_sdk(tmp_path))
+    coordinator.attach_runtime_probe(probe)
+    endpoint = coordinator.start()
+    try:
+        with socket.create_connection((endpoint.host, endpoint.port), timeout=2.0) as sock:
+            auth = _auth(sock, endpoint)
+            reply = _analyze(sock, auth, observation, request_id="an-bar")
+            assert reply["ok"] is True
+            assert reply["result"]["capabilities"] == {"move": False}
+            assert reply["result"]["lock_reason"]["code"] == "STATEMENT_KIND_MISMATCH"
+    finally:
+        coordinator.close()
+```
+
+- [ ] **Step 2: Run — expect FAIL**
+
+```bash
+python -m pytest tests/test_editor_coordinator.py -q -k "imagebutton or unsupported_statement"
+```
+
+Expected: imagebutton still analyzed as textbutton / kind mismatch.
+
+- [ ] **Step 3: Wire coordinator**
+
+In `coordinator.py`:
+
+1. Replace import of only `analyze_textbutton_statement` with:
+
+```python
+from .source import (
+    EditorSourceError,
+    analyze_editable_statement,
+    apply_editable_statement_patch,
+)
+```
+
+2. In `_command_analyze_target`, replace:
+
+```python
+statement = analyze_textbutton_statement(...)
+...
+"statement_kind": "textbutton",
+```
+
+with:
+
+```python
+kind, statement = analyze_editable_statement(lines[source_line - 1], expected_widget_id=widget_id)
+...
+"statement_kind": kind,
+```
+
+3. In `_apply_same_file_intents`, replace direct textbutton analyze + manual span append with:
+
+```python
+kind, statement = analyze_editable_statement(line_text, expected_widget_id=widget_id)
+# Prefer source_key statement_kind when present; must agree with peeked kind.
+recorded_kind = source_key.get("statement_kind")
+if isinstance(recorded_kind, str) and recorded_kind != kind:
+    raise EditorError("STATEMENT_KIND_MISMATCH", "source_key statement_kind does not match source line")
+# Collect replacements from statement spans (same as today) OR:
+# rebuild whole file via apply_editable_statement_patch per intent carefully.
+```
+
+Keep the existing multi-intent global offset replacement approach: after analyzing, append xpos/ypos span replacements exactly as today (statement exposes spans on both dataclasses).
+
+4. Do not special-case runtime locks for imagebutton; `ImageButton` is already in ancestry allowlist.
+
+- [ ] **Step 4: Run coordinator + source — expect PASS**
+
+```bash
+python -m pytest tests/test_editor_source.py tests/test_editor_coordinator.py -q
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/renforge/editor/coordinator.py tests/test_editor_coordinator.py
+git commit -m "$(cat <<'EOF'
+feat(editor): dispatch imagebutton analyze and commit paths
+
+Wire dedicated imagebutton adapter through EditorCoordinator
+while keeping textbutton behavior intact.
+EOF
+)"
+```
+
+---
+
+### Task 3: Focused seven-step live proof
+
+**Files:**
+- Create: `tests/live_fixtures/renforge_editor_imagebutton_fixture.rpy`
+- Create: `src/renforge/editor_imagebutton_runner.py`
+- Create: `tests/test_editor_imagebutton_live.py`
+
+**Verify (non-live):**  
+`python -m pytest tests/test_editor_imagebutton_live.py -q` → SKIP  
+
+**Verify (live, when SDK+display available):**  
+`RENFORGE_IMAGEBUTTON_LIVE=1 python -m pytest tests/test_editor_imagebutton_live.py -q` → PASS
+
+#### Harness decision (do not reopen)
+
+- Dedicated fixture file.
+- Dedicated test file gated by `RENFORGE_IMAGEBUTTON_LIVE`.
+- Slim runner (~150–250 lines) that only exercises the seven steps.
+- Reuse from `editor_task0_runner`: `_require_ok`, `_wait_for_status`, `_extract_widget_position`, `_source_generation`, inject copy pattern, and the `editor_task0_*` bridge API already registered by injected `editor.rpy`.
+- Do **not** call `run_editor_task0_live_scenario` (it asserts task0-only widgets and the full UI matrix).
+
+- [ ] **Step 1: Fixture**
+
+`tests/live_fixtures/renforge_editor_imagebutton_fixture.rpy`:
+
+```renpy
+default renforge_editor_imagebutton_clicks = 0
+
+screen renforge_editor_imagebutton_fixture():
+    layer "screens"
+    zorder 640
+
+    fixed:
+        id "imgbtn_root"
+        xfill True
+        yfill True
+
+        textbutton "ANCHOR" id "imgbtn_anchor" xpos 360 ypos 210 action NullAction()
+
+        imagebutton id "imgbtn_target" idle Solid("#4c6ef5", xysize=(96, 56)) xpos 200 ypos 180 action SetVariable("renforge_editor_imagebutton_clicks", renforge_editor_imagebutton_clicks + 1)
+```
+
+- [ ] **Step 2: Slim runner**
+
+`src/renforge/editor_imagebutton_runner.py` outline:
+
+```python
+FIXTURE_SCREEN = "renforge_editor_imagebutton_fixture"
+TARGET_ID = "imgbtn_target"
+FIXTURE_RESOURCE = Path(__file__).resolve().parents[2] / "tests" / "live_fixtures" / "renforge_editor_imagebutton_fixture.rpy"
+EDITOR_RESOURCE = Path(__file__).resolve().parent / "bridge" / "editor.rpy"
+
+def inject_editor_imagebutton_resources(project_root: Path) -> dict[str, str]:
+    # copy editor.rpy + fixture into game/zz_renforge_editor_imagebutton*.rpy
+
+def run_editor_imagebutton_live_scenario(client, *, fixture_path: Path) -> dict:
+    report = {}
+    baseline_bytes = fixture_path.read_bytes()
+    baseline_sha = hashlib.sha256(baseline_bytes).hexdigest()
+    report["fixture_before"] = {
+        "sha256": baseline_sha,
+        "position": _extract_widget_position(baseline_bytes.decode(), TARGET_ID),
+    }
+
+    # 1 resolve
+    _require_ok(client.request("editor_task0_start", {"screen": FIXTURE_SCREEN}), "start")
+    # list UI / focus candidates; select target center
+    # wait analysis: lock_reason None, current_analysis_id set
+    status = _wait_for_status(...)
+    source_key = status.get("current_source_key") or {}
+    report["resolve"] = {
+        "statement_kind": source_key.get("statement_kind"),
+        "lock_reason": status.get("selected_lock_reason"),
+        "move": status.get("save_enabled") is False and status.get("selected_lock_reason") in (None, ""),
+        "analysis_id": status.get("current_analysis_id"),
+        "measurement_method": "focus_list",  # from observation on select
+    }
+    assert source_key.get("statement_kind") == "imagebutton"
+
+    # 2 preview — nudge right 24 / down 16 via editor_task0_key or apply_preview
+    before = status focus/original position from focus_list observation
+    # nudge
+    after_preview_status = ...
+    report["preview"] = {
+        "before": before,
+        "after": after,
+        "measurement_method": "focus_list",
+    }
+
+    # 3 patch + 4 reload — click rf_save, wait Reload committed
+    pre_sha = hashlib.sha256(fixture_path.read_bytes()).hexdigest()
+    # save ...
+    post_bytes = fixture_path.read_bytes()
+    post_sha = hashlib.sha256(post_bytes).hexdigest()
+    report["patch"] = {
+        "before_sha256": pre_sha,
+        "after_sha256": post_sha,
+        "source_position_after": _extract_widget_position(post_bytes.decode(), TARGET_ID),
+    }
+    report["reload"] = {"ok": True, "script_generation": ..., "status_text": "Reload committed"}
+
+    # 5 pixel agreement — bounds/focus within 1px of expected source-driven runtime pos
+    report["pixel_agreement"] = {"expected": [...], "observed": [...], "delta": [...]}
+
+    # 6 rebinding — post-save selected widget_id still TARGET_ID; analysis id refreshed
+    report["rebinding"] = {"ok": True, "widget_id": TARGET_ID, "analysis_id": ...}
+
+    # 7 byte-identical undo — write baseline_bytes back, compare sha
+    fixture_path.write_bytes(baseline_bytes)
+    restored = hashlib.sha256(fixture_path.read_bytes()).hexdigest()
+    report["byte_identical_undo"] = {
+        "baseline_sha256": baseline_sha,
+        "restored_sha256": restored,
+        "matches_baseline": restored == baseline_sha,
+    }
+    return report
+```
+
+Notes:
+
+- Prefer selecting via `editor_task0_select` with coordinates from `list_ui_elements` / focus candidates for `imgbtn_target`.
+- All geometry used in assertions must come from observations with `measurement_method == "focus_list"` or from post-reload focus bounds that the editor itself measured that way.
+- For step 7, restoring baseline bytes in the harness is explicit proof of byte identity of the pre-patch file; also assert `patch.after_sha256 != patch.before_sha256` and that only xpos/ypos integers changed (re-parse with `analyze_imagebutton_statement`).
+
+- [ ] **Step 3: Opt-in test**
+
+`tests/test_editor_imagebutton_live.py`:
+
+```python
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("RENFORGE_IMAGEBUTTON_LIVE"),
+    reason="set RENFORGE_IMAGEBUTTON_LIVE=1 to run imagebutton seven-step live proof",
+)
+
+def test_imagebutton_seven_step_live_proof(demo_copy: Path) -> None:
+    # inject resources, launch_with_bridge(editor=True), activate RF if needed,
+    # run_editor_imagebutton_live_scenario, assert each of the seven keys.
+```
+
+Assertions (explicit per step):
+
+```python
+assert report["resolve"]["statement_kind"] == "imagebutton"
+assert report["resolve"]["lock_reason"] in (None, "")
+assert report["preview"]["after"] != report["preview"]["before"]
+assert report["preview"]["measurement_method"] == "focus_list"
+assert report["patch"]["after_sha256"] != report["patch"]["before_sha256"]
+assert report["reload"]["ok"] is True
+assert abs(report["pixel_agreement"]["delta"][0]) <= 1
+assert abs(report["pixel_agreement"]["delta"][1]) <= 1
+assert report["rebinding"]["ok"] is True
+assert report["byte_identical_undo"]["matches_baseline"] is True
+```
+
+- [ ] **Step 4: Non-live verification**
+
+```bash
+python -m pytest tests/test_editor_imagebutton_live.py -q
+# expected: 1 skipped
+python -m pytest tests/test_editor_source.py tests/test_editor_coordinator.py -q
+# expected: pass
+```
+
+- [ ] **Step 5: Live verification (when possible)**
+
+```bash
+RENFORGE_IMAGEBUTTON_LIVE=1 python -m pytest tests/test_editor_imagebutton_live.py -q
+```
+
+If display/SDK unavailable, document SKIP in PR body; do not fake a pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tests/live_fixtures/renforge_editor_imagebutton_fixture.rpy \
+  src/renforge/editor_imagebutton_runner.py \
+  tests/test_editor_imagebutton_live.py
+git commit -m "$(cat <<'EOF'
+test(editor): add imagebutton seven-step live proof harness
+
+Opt-in live scenario covers resolve → preview → patch → reload →
+pixel agreement → rebinding → byte-identical undo for issue #32.
+EOF
+)"
+```
+
+---
+
+### Task 4: Scope docs + PR
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-07-30-renforge-visual-editor-v1-scope.md`
+- Modify: `docs/superpowers/specs/2026-07-30-renforge-visual-editor-vfull-roadmap.md`
+- Include design + this plan in the PR
+
+**Verify:**  
+`python -m pytest tests/test_editor_source.py tests/test_editor_coordinator.py tests/test_editor_protocol.py tests/test_editor_runtime.py tests/test_editor_imagebutton_live.py -q`
+
+- [ ] **Step 1: V1 scope edits**
+
+Gate 3 wording → proven single-line adapters (`textbutton`, `imagebutton`) with literal integer `xpos`/`ypos`.
+
+Adapter table row:
+
+| Adapter | Selection | Write chain | Status |
+|---|---|---|---|
+| `imagebutton` | focusable (Spike C) | dedicated analyzer + coordinator path | **Implemented; live proof opt-in (`RENFORGE_IMAGEBUTTON_LIVE=1`)** |
+
+- [ ] **Step 2: Roadmap Stage 1 note**
+
+On the `imagebutton` row, note implementation + live harness pointer. Do not mark Stage 1 complete.
+
+- [ ] **Step 3: Final test run** (command above)
+
+- [ ] **Step 4: Commit docs and open PR**
+
+```bash
+git add docs/superpowers/specs/2026-08-01-imagebutton-adapter-design.md \
+  docs/superpowers/plans/2026-08-01-imagebutton-adapter.md \
+  docs/superpowers/specs/2026-07-30-renforge-visual-editor-v1-scope.md \
+  docs/superpowers/specs/2026-07-30-renforge-visual-editor-vfull-roadmap.md
+git commit -m "$(cat <<'EOF'
+docs: imagebutton adapter design, plan, and scope update
+
+Issue #32 Stage 1 allowlist widening — evidence-gated.
+EOF
+)"
+
+git push -u origin HEAD
+gh pr create --title "feat(editor): dedicated imagebutton adapter (#32)" --body "$(cat <<'EOF'
+## Summary
+- Dedicated single-line `imagebutton` analyzer/patcher (not a textbutton allowlist widen)
+- Coordinator analyze/commit dispatch by statement kind
+- Focused opt-in seven-step live proof (`RENFORGE_IMAGEBUTTON_LIVE=1`)
+- Scope/roadmap honesty notes
+
+## Test plan
+- [x] `pytest tests/test_editor_source.py tests/test_editor_coordinator.py -q`
+- [ ] `RENFORGE_IMAGEBUTTON_LIVE=1 pytest tests/test_editor_imagebutton_live.py -q`
+
+Closes #32
+EOF
+)"
+```
+
+---
+
+## Phase checklist (executor)
+
+| Phase | Done when |
+|---|---|
+| 1 Source analyzer | `test_editor_source.py` green; imagebutton twin exists |
+| 2 Coordinator | imagebutton analyze+commit green; bar still locks; textbutton green |
+| 3 Live harness | test skips by default; live env exercises all 7 report keys |
+| 4 Docs + PR | scope honesty updated; PR opened against main linking #32 |
+
+## Self-review
+
+1. **Spec coverage:** dedicated analyzer, patch, coordinator dispatch, locks, seven-step live proof, docs honesty, textbutton unchanged — all tasked.
+2. **Harness decision recorded:** slim dedicated runner; no task0 mega-suite fork; no analyzer allowlist widen.
+3. **No placeholders:** concrete files, commands, interfaces, and assertions.
+4. **Type consistency:** `ImagebuttonStatement` fields match textbutton spans; `statement_kind` is `"imagebutton"`.

--- a/docs/superpowers/specs/2026-07-30-renforge-visual-editor-v1-scope.md
+++ b/docs/superpowers/specs/2026-07-30-renforge-visual-editor-v1-scope.md
@@ -56,13 +56,13 @@ V1 ships an explicit allowlist, extended one adapter at a time, each backed by a
 | Adapter | Selection | Write chain | Status |
 |---|---|---|---|
 | `textbutton` | Spike C `pass` | Spike D `pass` | **Shipped in V1** |
-| `imagebutton` | Spike C `pass` (focusable) | dedicated analyzer + coordinator path | **Implemented; live proof opt-in (`RENFORGE_IMAGEBUTTON_LIVE=1`)** |
+| `imagebutton` | Spike C `pass` (focusable) | dedicated analyzer + coordinator path + seven-step live proof | **Implemented** (live proof green via `RENFORGE_IMAGEBUTTON_LIVE=1`) |
 | `button` | focusable by construction | not exercised | Blocked until proven |
 | `text`, `add`, `frame` | **not selectable** | Spike B proved write on a literal `text`, but by key, not by click | Out of V1 |
 
 `imagebutton` has a dedicated single-line adapter (issue #32) rather than a textbutton allowlist widen.
-It ships to the host path with unit/coordinator coverage; the seven-step live proof is opt-in until
-exercised in default CI.
+Host unit/coordinator coverage lands in default CI; the seven-step live proof is opt-in in CI but was
+executed green locally against Ren'Py 8.5.3 (`RENFORGE_IMAGEBUTTON_LIVE=1 pytest tests/test_editor_imagebutton_live.py`).
 
 ## Proven mechanisms (do not redesign)
 

--- a/docs/superpowers/specs/2026-07-30-renforge-visual-editor-v1-scope.md
+++ b/docs/superpowers/specs/2026-07-30-renforge-visual-editor-v1-scope.md
@@ -33,7 +33,7 @@ requires it — none is arbitrary.
 |---|---|---|
 | 1 | Displayable is **focusable** | Selection and every save-bearing measurement read `renpy.display.focus.focus_list` |
 | 2 | Source statement carries one **literal `id`** matching the runtime widget id | Runtime preview uses `_widget_properties`, keyed by the authored widget id; synthetic observation IDs do not qualify |
-| 3 | Single-line `textbutton` with one literal integer **`xpos` and `ypos`** | The token-aware patcher replaces only those two integer spans |
+| 3 | Single-line statement from the proven adapter allowlist (`textbutton`, `imagebutton`) with one literal integer **`xpos` and `ypos`** | The token-aware patcher replaces only those two integer spans |
 | 4 | Exactly one runtime instance with a fully classified, static ancestry outside **`viewport` / `Crop` / `Transform(crop=)`**, loop and repeated `use` cases | Only a unique static instance under proven clipping can be rebound unambiguously |
 
 **A failing gate is a first-class UI state, never a silent no-op.** The overlay must name which gate
@@ -56,12 +56,13 @@ V1 ships an explicit allowlist, extended one adapter at a time, each backed by a
 | Adapter | Selection | Write chain | Status |
 |---|---|---|---|
 | `textbutton` | Spike C `pass` | Spike D `pass` | **Shipped in V1** |
-| `imagebutton` | Spike C `pass` (focusable) | **not exercised** | Blocked until proven |
+| `imagebutton` | Spike C `pass` (focusable) | dedicated analyzer + coordinator path | **Implemented; live proof opt-in (`RENFORGE_IMAGEBUTTON_LIVE=1`)** |
 | `button` | focusable by construction | not exercised | Blocked until proven |
 | `text`, `add`, `frame` | **not selectable** | Spike B proved write on a literal `text`, but by key, not by click | Out of V1 |
 
-`imagebutton` shares the `Button` mechanics proven in Spikes C and D, so it is the cheapest next
-adapter — but it ships only after its own end-to-end proof, not by analogy.
+`imagebutton` has a dedicated single-line adapter (issue #32) rather than a textbutton allowlist widen.
+It ships to the host path with unit/coordinator coverage; the seven-step live proof is opt-in until
+exercised in default CI.
 
 ## Proven mechanisms (do not redesign)
 

--- a/docs/superpowers/specs/2026-07-30-renforge-visual-editor-vfull-roadmap.md
+++ b/docs/superpowers/specs/2026-07-30-renforge-visual-editor-vfull-roadmap.md
@@ -16,7 +16,7 @@ and an analogy.
 
 | Adapter | Expected difficulty | Why |
 |---|---|---|
-| `imagebutton` | Low | Same `Button` mechanics proven by Spikes C and D. Focusable, takes an `id`, literal position |
+| `imagebutton` | Low | Same `Button` mechanics proven by Spikes C and D. Focusable, takes an `id`, literal position. **Implemented** with dedicated analyzer + opt-in seven-step live harness (`RENFORGE_IMAGEBUTTON_LIVE=1`); see issue #32 / `2026-08-01-imagebutton-adapter-design.md`. |
 | `button` (explicit block form) | Low | Focusable by construction; the child block may complicate the source-line contract |
 | `bar` / `vbar` / `slider` | Medium | Focusable, but positioning often comes from style or a container |
 

--- a/docs/superpowers/specs/2026-07-30-renforge-visual-editor-vfull-roadmap.md
+++ b/docs/superpowers/specs/2026-07-30-renforge-visual-editor-vfull-roadmap.md
@@ -16,7 +16,7 @@ and an analogy.
 
 | Adapter | Expected difficulty | Why |
 |---|---|---|
-| `imagebutton` | Low | Same `Button` mechanics proven by Spikes C and D. Focusable, takes an `id`, literal position. **Implemented** with dedicated analyzer + opt-in seven-step live harness (`RENFORGE_IMAGEBUTTON_LIVE=1`); see issue #32 / `2026-08-01-imagebutton-adapter-design.md`. |
+| `imagebutton` | Low | Same `Button` mechanics proven by Spikes C and D. Focusable, takes an `id`, literal position. **Implemented** with dedicated analyzer; seven-step live proof green locally via `RENFORGE_IMAGEBUTTON_LIVE=1` (issue #32 / `2026-08-01-imagebutton-adapter-design.md`). |
 | `button` (explicit block form) | Low | Focusable by construction; the child block may complicate the source-line contract |
 | `bar` / `vbar` / `slider` | Medium | Focusable, but positioning often comes from style or a container |
 

--- a/docs/superpowers/specs/2026-08-01-imagebutton-adapter-design.md
+++ b/docs/superpowers/specs/2026-08-01-imagebutton-adapter-design.md
@@ -1,0 +1,207 @@
+# Imagebutton Adapter — Design
+
+Status: **approved for implementation** (issue #32).  
+Roadmap gate: Stage 1 — Widen the adapter allowlist.  
+Canonical roadmap: `2026-07-30-renforge-visual-editor-vfull-roadmap.md`.
+
+## Problem
+
+V1 proves source-safe visual movement only for `textbutton`. `imagebutton` is focusable and structurally similar, but the roadmap forbids treating similarity as evidence. Shipping requires a dedicated adapter path and its own seven-step live proof.
+
+## Decisions locked before design
+
+| Decision | Choice | Why |
+|---|---|---|
+| Statement form | **Single-line only** | Matches V1 textbutton gate 3. Multi-line blocks are Stage 2. |
+| Live proof delivery | **Dedicated opt-in live test + fixture** | Independent of the full task0 UI suite; report maps 1:1 to the seven steps. |
+| Architecture | **Dedicated analyzer twin (not parameterized allowlist)** | Roadmap: do not widen by pattern-matching against `textbutton`. |
+
+## Scope
+
+### In
+
+1. Dedicated single-line `imagebutton` source analyzer and patcher.
+2. Coordinator analyze/commit dispatch by source keyword (`textbutton` \| `imagebutton`).
+3. `source_key.statement_kind` set to the kind that actually parsed.
+4. Dedicated live fixture with a literal authored single-line `imagebutton`.
+5. Opt-in seven-step live proof; every verdict-bearing position measured from `focus_list`.
+6. Unit/coordinator tests for accept and lock paths.
+7. Doc touch: V1 scope adapter table + gate 3 wording once proof exists.
+
+### Out
+
+- Multi-line `imagebutton:` blocks with properties on child lines (Stage 2).
+- Resize, idle/hover rewrite, style editing.
+- `button`, `bar`, `vbar`, `slider` adapters.
+- Overlay UI redesign for lock messaging (existing lock_reason surface is enough).
+- Marking the adapter complete from unit tests alone.
+
+## Architecture
+
+### Source layer — `src/renforge/editor/source.py`
+
+Keep the existing textbutton path unchanged:
+
+- `TextbuttonStatement`
+- `analyze_textbutton_statement`
+- `apply_textbutton_patch`
+
+Add a dedicated twin:
+
+- `ImagebuttonStatement` — same field shape: `widget_id`, `xpos`, `ypos`, `xpos_span`, `ypos_span`
+- `analyze_imagebutton_statement(line: str, *, expected_widget_id: str) -> ImagebuttonStatement`
+- `apply_imagebutton_patch(source_bytes: bytes, statement: ImagebuttonStatement, *, x: int, y: int) -> bytes`
+
+Rules for the imagebutton analyzer:
+
+1. Reject multi-line input (`MULTILINE_STATEMENT_REJECTED`).
+2. First top-level `WORD` token must be exactly `imagebutton` (`STATEMENT_KIND_MISMATCH` otherwise).
+3. Exactly one top-level literal string `id` matching `expected_widget_id`.
+4. Exactly one top-level literal integer `xpos` and one `ypos`.
+5. Ignore keyword-looking tokens inside strings, comments, and nested call depths (reuse `_lex_single_line`).
+6. Error messages name `imagebutton`, not `textbutton`.
+
+Shared lexer helpers may be reused. **Kind acceptance must not be a shared allowlist** such as `kind in {"textbutton", "imagebutton"}` inside one analyzer. Each adapter owns its kind check.
+
+A tiny private helper that rewrites two integer spans is allowed (pure byte surgery, kind-agnostic).
+
+### Coordinator — `src/renforge/editor/coordinator.py`
+
+Today analyze and commit hardcode `analyze_textbutton_statement` and `statement_kind: "textbutton"`.
+
+New analyze flow:
+
+1. Resolve source path/line from `runtime_key.source_location`.
+2. Read the line; determine kind from the first top-level word (via a small kind peek or by trying dedicated analyzers without collapsing them into one).
+3. Dispatch:
+   - `textbutton` → `analyze_textbutton_statement`
+   - `imagebutton` → `analyze_imagebutton_statement`
+   - anything else → lock `STATEMENT_KIND_MISMATCH` with an exact reason
+4. Set `source_key.statement_kind` to the kind that parsed successfully.
+5. Keep all existing runtime locks (ancestry, multi-instance, measurement_method, fresh frame, id match).
+
+Commit / `_apply_same_file_intents`:
+
+1. Re-read the target line under the same baseline rules.
+2. Dispatch patch by `source_key.statement_kind` (or re-detected line keyword — must agree).
+3. Never fall back to the textbutton analyzer for an imagebutton line.
+
+Preferred internal shape (keeps call sites thin without merging analyzers):
+
+```python
+def _analyze_statement(line: str, *, expected_widget_id: str) -> tuple[str, Any]:
+    # peek kind, call dedicated analyzer, return (kind, statement)
+    ...
+
+def _apply_statement_patch(source_bytes: bytes, kind: str, statement: Any, *, x: int, y: int) -> bytes:
+    ...
+```
+
+These helpers live next to the coordinator or as thin wrappers in `source.py`. They **dispatch**; they do not implement a generic “button” grammar.
+
+### Runtime / overlay
+
+No new selection or preview seam:
+
+- Selection remains `focus_list` (imagebutton is focusable; Spike C already recorded focusability).
+- Ancestry allowlist already includes `ImageButton`.
+- Preview remains `_widget_properties` keyed by authored widget id.
+- Overlay continues to honor host `capabilities.move` / `lock_reason` without kind-specific UI branches.
+
+### Fixture & playground
+
+**Live fixture** (dedicated file under `tests/live_fixtures/`):
+
+- Screen with one editable single-line imagebutton, e.g.
+
+```renpy
+imagebutton id "imgbtn_target" idle Solid("#4c6ef5", xysize=(80, 48)) xpos 200 ypos 180 action NullAction()
+```
+
+- Optional second control for snap/anchor if needed by the scenario.
+- At least one locked negative case in unit/coordinator tests (not necessarily in the live happy path): expression `xpos`, multi-line block, or wrong kind.
+
+**Playground** (`examples/demo_game/game/editor_playground.rpy`):
+
+- Existing `pg_imgbtn` is already single-line with literal id/xpos/ypos — keep it as the manual editable target after unlock.
+- Do not convert it to a multi-line block.
+
+## Seven-step live proof
+
+Opt-in test (env flag, same pattern as `RENFORGE_TASK0_LIVE`), dedicated runner, dedicated report keys. Every position used as evidence has `measurement_method == "focus_list"`.
+
+| Step | Name | Observed evidence |
+|---|---|---|
+| 1 | **resolve** | Select `imgbtn_target`; host `analyze_target` returns `lock_reason is None`, `capabilities.move is True`, `source_key.statement_kind == "imagebutton"`. |
+| 2 | **preview** | Runtime preview moves the widget; independent `focus_list` observation shows new position (not computed placement). |
+| 3 | **patch** | Save/commit publishes source; file bytes change only at the two integer spans for xpos/ypos. |
+| 4 | **reload** | Post-publish reload handshake reaches a committed/attested state with new script generation. |
+| 5 | **pixel agreement** | Post-reload `focus_list` position agrees with expected within **one logical pixel**. |
+| 6 | **rebinding** | Target re-found by stable key (screen + source location + ancestry + ordinal), not object identity. |
+| 7 | **byte-identical undo** | Conditional rollback / restore of baseline bytes verifies SHA-256 identity with the pre-patch file (product path: failed attestation rollback **or** explicit baseline restore in the proof harness after capturing staged bytes — must exercise real byte restore, not a mocked equality). |
+
+Standing rules from the roadmap apply:
+
+- Never report a pass that was inferred rather than observed.
+- No self-validating evidence (do not compare a value to the request just injected).
+- `inconclusive` outranks `blocked` for unmeasured steps.
+
+### Proof harness shape
+
+- `tests/live_fixtures/renforge_editor_imagebutton_fixture.rpy`
+- `src/renforge/editor_imagebutton_runner.py` (or equivalent under `src/renforge/`) driving the seven steps and returning a structured report
+- `tests/test_editor_imagebutton_live.py` gated by `RENFORGE_IMAGEBUTTON_LIVE=1` (or a shared live flag if the repo already standardizes one — prefer a dedicated flag to keep cost explicit)
+
+The harness may reuse editor_task0 bridge handlers (`editor_task0_start/select/status/...`) and the normal editor launch path; it must not piggy-back assertions onto the full task0 UI suite.
+
+## Automated non-live tests
+
+### `tests/test_editor_source.py`
+
+- Accept single-line imagebutton with nested noise in strings/calls.
+- Patch preserves all bytes outside xpos/ypos integer tokens (including non-ASCII idle labels if present).
+- Reject: wrong kind, expressions, duplicate id/xpos/ypos, mismatched id, multi-line, nested-only coordinates.
+
+### `tests/test_editor_coordinator.py`
+
+- Analyze + commit path for an imagebutton source line unlocks move and rewrites only coordinate spans.
+- `statement_kind` in `source_key` is `"imagebutton"`.
+- textbutton fixtures keep passing unchanged.
+- Non-allowlisted kinds still lock with `STATEMENT_KIND_MISMATCH`.
+
+## Documentation updates (after proof, same PR)
+
+- `2026-07-30-renforge-visual-editor-v1-scope.md`
+  - Adapter table: `imagebutton` → Selection pass / Write chain pass (this issue) / **Shipped** only if live proof ran green in CI or is recorded as an explicit local live gate with instructions.
+  - Gate 3 wording: allow proven single-line adapters (`textbutton`, `imagebutton`) with literal integer xpos/ypos — not “textbutton only”.
+- Roadmap Stage 1 row for `imagebutton` can note “implemented; evidence in live proof test” without claiming V-full.
+
+**Honesty rule:** if the live proof is opt-in and not run in default CI, the scope doc must say **“implemented; live proof opt-in”** rather than quietly claiming spike-level shipment. Default unit/coordinator tests still land in CI.
+
+## Error / lock catalogue (imagebutton-relevant)
+
+| Code | When |
+|---|---|
+| `STATEMENT_KIND_MISMATCH` | Line is not a supported single-line adapter kind |
+| `MULTILINE_STATEMENT_REJECTED` | Statement spans multiple lines |
+| `ID_LITERAL_REQUIRED` | Missing/non-literal/duplicate id |
+| `ID_MISMATCH` | Literal id ≠ runtime widget id |
+| `XPOS_LITERAL_REQUIRED` / `YPOS_LITERAL_REQUIRED` | Non-integer or missing |
+| `XPOS_DUPLICATE` / `YPOS_DUPLICATE` | Count ≠ 1 |
+| Existing runtime locks | viewport/crop/multi-instance/measurement/etc. unchanged |
+
+## Non-goals / anti-patterns
+
+- Do not add `imagebutton` by changing one string in the textbutton analyzer.
+- Do not unlock multi-line blocks “because the header has xpos”.
+- Do not use `_renforge_scene_place` or any non-`focus_list` measurement for proof steps.
+- Do not mark complete from green unit tests alone.
+
+## Success criteria (issue #32)
+
+1. Dedicated analyzer/patch path exists and is wired through analyze + commit.
+2. Single-line literal imagebutton is editable end-to-end when live proof runs.
+3. Seven-step live proof report is produced with focus_list measurements.
+4. Ambiguous/unproven forms remain locked with exact reasons.
+5. textbutton behavior unchanged.
+6. PR links issue #32.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,3 +56,4 @@ exclude = ["src/renforge/ui/static/**"]
 
 [tool.pytest.ini_options]
 pythonpath = ["src"]
+markers = ["live: full Ren'Py and bridge live scenario"]

--- a/src/renforge/bridge/editor.rpy
+++ b/src/renforge/bridge/editor.rpy
@@ -233,6 +233,7 @@ init 1100 python:
             "Fixed",
             "MultiBox",
             "Button",
+            "ImageButton",
             "Text",
             "Frame",
             "Window",

--- a/src/renforge/editor/coordinator.py
+++ b/src/renforge/editor/coordinator.py
@@ -29,7 +29,7 @@ from .exceptions import EditorError
 from .paths import EditorPathError, atomic_write_file, fsync_directory, resolve_game_path, sha256_bytes
 from .runtime import RuntimeProbe
 from .shadow import ShadowLintResult, build_shadow_project, run_shadow_lint
-from .source import EditorSourceError, analyze_editable_statement
+from .source import EditorSourceError, analyze_editable_statement, apply_editable_statement_patch
 
 
 def _now_deadline(seconds: float) -> float:
@@ -942,17 +942,10 @@ class EditorCoordinator:
         source_bytes: bytes,
         selected_records: list[tuple[_AnalysisRecord, int, int, dict[str, Any]]],
     ) -> bytes:
-        text = source_bytes.decode("utf-8")
-        lines = text.splitlines(keepends=True)
-        replacements: list[tuple[int, int, str]] = []
+        lines = source_bytes.decode("utf-8").splitlines(keepends=True)
         seen_targets: set[tuple[str, int, str]] = set()
-        offset = 0
-        line_offsets: list[int] = []
-        for line in lines:
-            line_offsets.append(offset)
-            offset += len(line)
 
-        for record, x, y, source_key in selected_records:
+        for _record, x, y, source_key in selected_records:
             line_no = source_key.get("line")
             widget_id = source_key.get("widget_id")
             if not isinstance(line_no, int) or not isinstance(widget_id, str):
@@ -971,15 +964,15 @@ class EditorCoordinator:
                     "STATEMENT_KIND_MISMATCH",
                     "source_key statement_kind does not match source line",
                 )
-            global_offset = line_offsets[line_no - 1]
-            replacements.append((global_offset + statement.xpos_span[0], global_offset + statement.xpos_span[1], str(x)))
-            replacements.append((global_offset + statement.ypos_span[0], global_offset + statement.ypos_span[1], str(y)))
+            lines[line_no - 1] = apply_editable_statement_patch(
+                line_text.encode("utf-8"),
+                kind,
+                statement,
+                x=x,
+                y=y,
+            ).decode("utf-8")
 
-        replacements.sort(key=lambda item: item[0], reverse=True)
-        patched = text
-        for start, end, replacement in replacements:
-            patched = f"{patched[:start]}{replacement}{patched[end:]}"
-        return patched.encode("utf-8")
+        return "".join(lines).encode("utf-8")
 
     def _validate_shadow(self, transaction: _TransactionRecord) -> ShadowLintResult:
         tx_dir = self._transaction_root / transaction.transaction_id

--- a/src/renforge/editor/coordinator.py
+++ b/src/renforge/editor/coordinator.py
@@ -29,7 +29,7 @@ from .exceptions import EditorError
 from .paths import EditorPathError, atomic_write_file, fsync_directory, resolve_game_path, sha256_bytes
 from .runtime import RuntimeProbe
 from .shadow import ShadowLintResult, build_shadow_project, run_shadow_lint
-from .source import EditorSourceError, analyze_textbutton_statement
+from .source import EditorSourceError, analyze_editable_statement
 
 
 def _now_deadline(seconds: float) -> float:
@@ -522,7 +522,9 @@ class EditorCoordinator:
             if source_line < 1 or source_line > len(lines):
                 raise EditorError("SOURCE_LINE_INVALID", "source line is out of range")
             widget_id = self._require_runtime_widget_id(runtime_key)
-            statement = analyze_textbutton_statement(lines[source_line - 1], expected_widget_id=widget_id)
+            kind, statement = analyze_editable_statement(
+                lines[source_line - 1], expected_widget_id=widget_id
+            )
             original_position = [statement.xpos, statement.ypos]
             ancestry = runtime_key.get("ancestry")
             normalized_ancestry = (
@@ -553,7 +555,7 @@ class EditorCoordinator:
                 "invocation_path": runtime_key.get("invocation_path"),
                 "instance_discriminator": runtime_key.get("instance_discriminator"),
                 "ancestry": normalized_ancestry,
-                "statement_kind": "textbutton",
+                "statement_kind": kind,
                 "baseline_sha256": source_sha,
             }
             if lock_reason is None:
@@ -962,7 +964,13 @@ class EditorCoordinator:
                 raise EditorError("DUPLICATE_SOURCE_TARGET", "multiple intents target the same source statement")
             seen_targets.add(target_key)
             line_text = lines[line_no - 1]
-            statement = analyze_textbutton_statement(line_text, expected_widget_id=widget_id)
+            kind, statement = analyze_editable_statement(line_text, expected_widget_id=widget_id)
+            recorded_kind = source_key.get("statement_kind")
+            if isinstance(recorded_kind, str) and recorded_kind != kind:
+                raise EditorError(
+                    "STATEMENT_KIND_MISMATCH",
+                    "source_key statement_kind does not match source line",
+                )
             global_offset = line_offsets[line_no - 1]
             replacements.append((global_offset + statement.xpos_span[0], global_offset + statement.xpos_span[1], str(x)))
             replacements.append((global_offset + statement.ypos_span[0], global_offset + statement.ypos_span[1], str(y)))

--- a/src/renforge/editor/source.py
+++ b/src/renforge/editor/source.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import ast
 from dataclasses import dataclass
-from typing import Any
+from typing import TypeVar
 
 
 class EditorSourceError(ValueError):
@@ -27,6 +27,9 @@ class ImagebuttonStatement:
     ypos: int
     xpos_span: tuple[int, int]
     ypos_span: tuple[int, int]
+
+
+_StatementT = TypeVar("_StatementT", bound=TextbuttonStatement | ImagebuttonStatement)
 
 
 @dataclass(frozen=True)
@@ -165,8 +168,8 @@ def _analyze_positioned_kind_statement(
     *,
     expected_widget_id: str,
     expected_kind: str,
-    statement_cls: type[Any],
-) -> Any:
+    statement_cls: type[_StatementT],
+) -> _StatementT:
     statement_text = _statement_text(line)
     tokens = _lex_single_line(statement_text)
     top_level = [token for token in tokens if token.depth == 0]
@@ -319,6 +322,11 @@ def analyze_editable_statement(
         return kind, analyze_textbutton_statement(line, expected_widget_id=expected_widget_id)
     if kind == "imagebutton":
         return kind, analyze_imagebutton_statement(line, expected_widget_id=expected_widget_id)
+    if kind is None:
+        raise EditorSourceError(
+            "STATEMENT_KIND_MISMATCH",
+            "source line does not contain a supported statement kind",
+        )
     raise EditorSourceError("STATEMENT_KIND_MISMATCH", f"unsupported statement kind: {kind!r}")
 
 

--- a/src/renforge/editor/source.py
+++ b/src/renforge/editor/source.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import ast
 from dataclasses import dataclass
+from typing import Any
 
 
 class EditorSourceError(ValueError):
@@ -12,6 +13,15 @@ class EditorSourceError(ValueError):
 
 @dataclass(frozen=True)
 class TextbuttonStatement:
+    widget_id: str
+    xpos: int
+    ypos: int
+    xpos_span: tuple[int, int]
+    ypos_span: tuple[int, int]
+
+
+@dataclass(frozen=True)
+class ImagebuttonStatement:
     widget_id: str
     xpos: int
     ypos: int
@@ -117,24 +127,54 @@ def _parse_string_token(token: _Token) -> str:
     return parsed
 
 
-def _next_top_level_token(tokens: list[_Token], index: int) -> _Token | None:
+def _next_top_level_index(tokens: list[_Token], index: int) -> int | None:
     cursor = index + 1
     while cursor < len(tokens):
-        candidate = tokens[cursor]
-        if candidate.depth == 0:
-            return candidate
+        if tokens[cursor].depth == 0:
+            return cursor
         cursor += 1
     return None
 
 
-def analyze_textbutton_statement(line: str, *, expected_widget_id: str) -> TextbuttonStatement:
+def _next_top_level_token(tokens: list[_Token], index: int) -> _Token | None:
+    found = _next_top_level_index(tokens, index)
+    return None if found is None else tokens[found]
+
+
+def _statement_text(line: str) -> str:
     if "\n" in line[:-1]:
         raise EditorSourceError("MULTILINE_STATEMENT_REJECTED", "statement must be single-line")
-    statement_text = line[:-1] if line.endswith("\n") else line
+    return line[:-1] if line.endswith("\n") else line
+
+
+def peek_statement_kind(line: str) -> str | None:
+    """Return the first top-level WORD on a single source line, or None."""
+    try:
+        statement_text = _statement_text(line)
+    except EditorSourceError:
+        return None
+    tokens = _lex_single_line(statement_text)
+    for token in tokens:
+        if token.depth == 0 and token.kind == "WORD":
+            return token.text
+    return None
+
+
+def _analyze_positioned_kind_statement(
+    line: str,
+    *,
+    expected_widget_id: str,
+    expected_kind: str,
+    statement_cls: type[Any],
+) -> Any:
+    statement_text = _statement_text(line)
     tokens = _lex_single_line(statement_text)
     top_level = [token for token in tokens if token.depth == 0]
-    if not top_level or top_level[0].kind != "WORD" or top_level[0].text != "textbutton":
-        raise EditorSourceError("STATEMENT_KIND_MISMATCH", "source statement is not a textbutton")
+    if not top_level or top_level[0].kind != "WORD" or top_level[0].text != expected_kind:
+        raise EditorSourceError(
+            "STATEMENT_KIND_MISMATCH",
+            f"source statement is not a {expected_kind}",
+        )
 
     keyword_counts = {"id": 0, "xpos": 0, "ypos": 0}
     widget_id: str | None = None
@@ -149,10 +189,11 @@ def analyze_textbutton_statement(line: str, *, expected_widget_id: str) -> Textb
             continue
         keyword = token.text
         keyword_counts[keyword] += 1
-        value_token = _next_top_level_token(tokens, index)
-        if value_token is None:
+        value_index = _next_top_level_index(tokens, index)
+        if value_index is None:
             invalid_literals.add(keyword)
             continue
+        value_token = tokens[value_index]
         if keyword == "id":
             if value_token.kind != "STRING":
                 invalid_literals.add(keyword)
@@ -160,6 +201,12 @@ def analyze_textbutton_statement(line: str, *, expected_widget_id: str) -> Textb
             widget_id = _parse_string_token(value_token)
             continue
         if value_token.kind != "NUMBER":
+            invalid_literals.add(keyword)
+            continue
+        # Reject compound expressions like `xpos 100-20` (NUMBER followed by
+        # non-WORD). A pure literal is followed by a keyword/action WORD or EOS.
+        following_index = _next_top_level_index(tokens, value_index)
+        if following_index is not None and tokens[following_index].kind != "WORD":
             invalid_literals.add(keyword)
             continue
         value = int(value_token.text)
@@ -171,21 +218,30 @@ def analyze_textbutton_statement(line: str, *, expected_widget_id: str) -> Textb
             ypos_span = (value_token.start, value_token.end)
 
     if keyword_counts["id"] != 1:
-        raise EditorSourceError("ID_LITERAL_REQUIRED", "textbutton statement must contain exactly one literal id")
+        raise EditorSourceError(
+            "ID_LITERAL_REQUIRED",
+            f"{expected_kind} statement must contain exactly one literal id",
+        )
     if "id" in invalid_literals or widget_id is None:
         raise EditorSourceError("ID_LITERAL_REQUIRED", "id must be a literal string")
     if widget_id != expected_widget_id:
         raise EditorSourceError("ID_MISMATCH", "literal id does not match runtime widget id")
     if keyword_counts["xpos"] != 1:
-        raise EditorSourceError("XPOS_DUPLICATE", "textbutton statement must contain exactly one xpos")
+        raise EditorSourceError(
+            "XPOS_DUPLICATE",
+            f"{expected_kind} statement must contain exactly one xpos",
+        )
     if keyword_counts["ypos"] != 1:
-        raise EditorSourceError("YPOS_DUPLICATE", "textbutton statement must contain exactly one ypos")
+        raise EditorSourceError(
+            "YPOS_DUPLICATE",
+            f"{expected_kind} statement must contain exactly one ypos",
+        )
     if "xpos" in invalid_literals or xpos_value is None or xpos_span is None:
         raise EditorSourceError("XPOS_LITERAL_REQUIRED", "xpos must be a literal integer")
     if "ypos" in invalid_literals or ypos_value is None or ypos_span is None:
         raise EditorSourceError("YPOS_LITERAL_REQUIRED", "ypos must be a literal integer")
 
-    return TextbuttonStatement(
+    return statement_cls(
         widget_id=widget_id,
         xpos=xpos_value,
         ypos=ypos_value,
@@ -194,14 +250,92 @@ def analyze_textbutton_statement(line: str, *, expected_widget_id: str) -> Textb
     )
 
 
-def apply_textbutton_patch(source_bytes: bytes, statement: TextbuttonStatement, *, x: int, y: int) -> bytes:
+def analyze_textbutton_statement(line: str, *, expected_widget_id: str) -> TextbuttonStatement:
+    return _analyze_positioned_kind_statement(
+        line,
+        expected_widget_id=expected_widget_id,
+        expected_kind="textbutton",
+        statement_cls=TextbuttonStatement,
+    )
+
+
+def analyze_imagebutton_statement(line: str, *, expected_widget_id: str) -> ImagebuttonStatement:
+    return _analyze_positioned_kind_statement(
+        line,
+        expected_widget_id=expected_widget_id,
+        expected_kind="imagebutton",
+        statement_cls=ImagebuttonStatement,
+    )
+
+
+def _apply_integer_span_patch(
+    source_bytes: bytes,
+    *,
+    xpos_span: tuple[int, int],
+    ypos_span: tuple[int, int],
+    x: int,
+    y: int,
+) -> bytes:
     source_text = source_bytes.decode("utf-8")
     replacements = [
-        (statement.xpos_span[0], statement.xpos_span[1], str(int(x))),
-        (statement.ypos_span[0], statement.ypos_span[1], str(int(y))),
+        (xpos_span[0], xpos_span[1], str(int(x))),
+        (ypos_span[0], ypos_span[1], str(int(y))),
     ]
     replacements.sort(key=lambda item: item[0], reverse=True)
     patched = source_text
     for start, end, replacement in replacements:
         patched = f"{patched[:start]}{replacement}{patched[end:]}"
     return patched.encode("utf-8")
+
+
+def apply_textbutton_patch(source_bytes: bytes, statement: TextbuttonStatement, *, x: int, y: int) -> bytes:
+    return _apply_integer_span_patch(
+        source_bytes,
+        xpos_span=statement.xpos_span,
+        ypos_span=statement.ypos_span,
+        x=x,
+        y=y,
+    )
+
+
+def apply_imagebutton_patch(
+    source_bytes: bytes, statement: ImagebuttonStatement, *, x: int, y: int
+) -> bytes:
+    return _apply_integer_span_patch(
+        source_bytes,
+        xpos_span=statement.xpos_span,
+        ypos_span=statement.ypos_span,
+        x=x,
+        y=y,
+    )
+
+
+def analyze_editable_statement(
+    line: str, *, expected_widget_id: str
+) -> tuple[str, TextbuttonStatement | ImagebuttonStatement]:
+    """Dispatch to a dedicated analyzer. Not a merged grammar."""
+    kind = peek_statement_kind(line)
+    if kind == "textbutton":
+        return kind, analyze_textbutton_statement(line, expected_widget_id=expected_widget_id)
+    if kind == "imagebutton":
+        return kind, analyze_imagebutton_statement(line, expected_widget_id=expected_widget_id)
+    raise EditorSourceError("STATEMENT_KIND_MISMATCH", f"unsupported statement kind: {kind!r}")
+
+
+def apply_editable_statement_patch(
+    source_bytes: bytes,
+    kind: str,
+    statement: TextbuttonStatement | ImagebuttonStatement,
+    *,
+    x: int,
+    y: int,
+) -> bytes:
+    if kind == "textbutton":
+        if not isinstance(statement, TextbuttonStatement):
+            raise EditorSourceError("STATEMENT_KIND_MISMATCH", "statement does not match textbutton kind")
+        return apply_textbutton_patch(source_bytes, statement, x=x, y=y)
+    if kind == "imagebutton":
+        if not isinstance(statement, ImagebuttonStatement):
+            raise EditorSourceError("STATEMENT_KIND_MISMATCH", "statement does not match imagebutton kind")
+        return apply_imagebutton_patch(source_bytes, statement, x=x, y=y)
+    raise EditorSourceError("STATEMENT_KIND_MISMATCH", f"unsupported statement kind: {kind!r}")

--- a/src/renforge/editor_imagebutton_runner.py
+++ b/src/renforge/editor_imagebutton_runner.py
@@ -84,6 +84,64 @@ def _wait_bounds(
     raise AssertionError(f"bounds for {widget_id!r} unavailable: {last!r}")
 
 
+def _target_line_with_offset(source_text: str) -> tuple[str, int]:
+    offset = 0
+    for line in source_text.splitlines(keepends=True):
+        if f'id "{TARGET_ID}"' in line:
+            return line, offset
+        offset += len(line)
+    raise AssertionError(f"source missing target line for {TARGET_ID!r}")
+
+
+def _normalize_coordinate_spans(
+    source_text: str,
+    *,
+    line_offset: int,
+    statement: Any,
+) -> bytes:
+    replacements = [
+        (
+            line_offset + statement.xpos_span[0],
+            line_offset + statement.xpos_span[1],
+            "__RENFORGE_XPOS__",
+        ),
+        (
+            line_offset + statement.ypos_span[0],
+            line_offset + statement.ypos_span[1],
+            "__RENFORGE_YPOS__",
+        ),
+    ]
+    normalized = source_text
+    for start, end, replacement in sorted(replacements, reverse=True):
+        normalized = f"{normalized[:start]}{replacement}{normalized[end:]}"
+    return normalized.encode("utf-8")
+
+
+def _coordinate_spans_are_only_difference(
+    before_text: str,
+    after_text: str,
+) -> bool:
+    before_line, before_offset = _target_line_with_offset(before_text)
+    after_line, after_offset = _target_line_with_offset(after_text)
+    before_statement = analyze_imagebutton_statement(
+        before_line,
+        expected_widget_id=TARGET_ID,
+    )
+    after_statement = analyze_imagebutton_statement(
+        after_line,
+        expected_widget_id=TARGET_ID,
+    )
+    return _normalize_coordinate_spans(
+        before_text,
+        line_offset=before_offset,
+        statement=before_statement,
+    ) == _normalize_coordinate_spans(
+        after_text,
+        line_offset=after_offset,
+        statement=after_statement,
+    )
+
+
 def run_editor_imagebutton_live_scenario(
     client: Any,
     *,
@@ -109,6 +167,7 @@ def run_editor_imagebutton_live_scenario(
     report["start"] = start
 
     target_bounds = _wait_bounds(client, TARGET_ID)
+    bounds_before = [target_bounds["x"], target_bounds["y"]]
     target_center = _center(target_bounds)
     select = _require_ok(
         client.request(
@@ -147,30 +206,57 @@ def run_editor_imagebutton_live_scenario(
     )
     if not (isinstance(original, (list, tuple)) and len(original) == 2):
         original = [int(baseline_position["x"]), int(baseline_position["y"])]
-    before_preview = [int(original[0]), int(original[1])]
+    requested_before = [int(original[0]), int(original[1])]
 
-    # Preview: nudge +24 x, +16 y without crossing a save boundary.
+    # Preview: nudge without crossing a save boundary. The verdict below is
+    # based on fresh focus bounds, not the editor's requested preview state.
     _require_ok(client.request("editor_task0_key", {"key": "right", "repeat": 24}), "nudge right")
     _require_ok(client.request("editor_task0_key", {"key": "down", "repeat": 16}), "nudge down")
     preview_status = _wait_for_status(
         client,
         lambda status: isinstance(status.get("preview_position"), (list, tuple))
         and len(status.get("preview_position") or []) == 2
-        and list(status.get("preview_position") or []) != before_preview,
+        and list(status.get("preview_position") or []) != requested_before,
         timeout=6.0,
         poll_name="preview moved",
     )
-    after_preview = [int(preview_status["preview_position"][0]), int(preview_status["preview_position"][1])]
+    requested_after = [
+        int(preview_status["preview_position"][0]),
+        int(preview_status["preview_position"][1]),
+    ]
     preview_bounds = _wait_bounds(client, TARGET_ID)
+    bounds_after = [preview_bounds["x"], preview_bounds["y"]]
+    requested_delta = [
+        requested_after[axis] - requested_before[axis]
+        for axis in (0, 1)
+    ]
+    observed_delta = [
+        bounds_after[axis] - bounds_before[axis]
+        for axis in (0, 1)
+    ]
+    if any(
+        abs(observed_delta[axis] - requested_delta[axis]) > 1
+        for axis in (0, 1)
+    ):
+        raise AssertionError(
+            "focus_list preview bounds disagree with requested movement: "
+            f"requested={requested_delta!r}, observed={observed_delta!r}"
+        )
     report["preview"] = {
-        "before": before_preview,
-        "after": after_preview,
-        "bounds_after": [preview_bounds["x"], preview_bounds["y"]],
+        "before": bounds_before,
+        "after": bounds_after,
+        "bounds_before": bounds_before,
+        "bounds_after": bounds_after,
+        "requested_before": requested_before,
+        "requested_after": requested_after,
+        "requested_delta": requested_delta,
+        "observed_delta": observed_delta,
         "measurement_method": "focus_list",
     }
 
-    pre_save_sha = _sha256_file(fixture_path)
-    pre_save_text = fixture_path.read_text(encoding="utf-8")
+    pre_save_bytes = fixture_path.read_bytes()
+    pre_save_sha = hashlib.sha256(pre_save_bytes).hexdigest()
+    pre_save_text = pre_save_bytes.decode("utf-8")
     generation_before = _source_generation(analysis_status)
     save_request = _require_ok(
         client.click_element(id="rf_save", screen="_renforge_editor_overlay"),
@@ -190,21 +276,33 @@ def run_editor_imagebutton_live_scenario(
     source_position_after = _extract_widget_position(post_save_text, TARGET_ID)
     if source_position_after is None:
         raise AssertionError("post-save source missing target position")
+    expected_source_position = {
+        "x": requested_after[0],
+        "y": requested_after[1],
+    }
+    if source_position_after != expected_source_position:
+        raise AssertionError(
+            "source patch disagrees with requested preview position: "
+            f"expected={expected_source_position!r}, observed={source_position_after!r}"
+        )
 
-    # Confirm only xpos/ypos integer spans changed on the target line.
-    target_line = next(
-        line for line in post_save_text.splitlines(keepends=True) if f'id "{TARGET_ID}"' in line
-    )
+    target_line, _target_offset = _target_line_with_offset(post_save_text)
     parsed_after = analyze_imagebutton_statement(target_line, expected_widget_id=TARGET_ID)
+    outside_coordinate_spans_identical = _coordinate_spans_are_only_difference(
+        pre_save_text,
+        post_save_text,
+    )
+    if not outside_coordinate_spans_identical:
+        raise AssertionError("source patch changed bytes outside xpos/ypos spans")
     report["patch"] = {
         "before_sha256": pre_save_sha,
         "after_sha256": post_save_sha,
         "source_position_after": source_position_after,
         "parsed_after": {"xpos": parsed_after.xpos, "ypos": parsed_after.ypos},
         "save_request": save_request,
-        "pre_save_unchanged_prefix": pre_save_text.split(f'id "{TARGET_ID}"', 1)[0]
-        == post_save_text.split(f'id "{TARGET_ID}"', 1)[0],
+        "outside_coordinate_spans_identical": outside_coordinate_spans_identical,
     }
+
     report["reload"] = {
         "ok": True,
         "script_generation": _source_generation(save_status),

--- a/src/renforge/editor_imagebutton_runner.py
+++ b/src/renforge/editor_imagebutton_runner.py
@@ -1,0 +1,252 @@
+from __future__ import annotations
+
+import hashlib
+import shutil
+import time
+from pathlib import Path
+from typing import Any
+
+from renforge.editor.source import analyze_imagebutton_statement
+from renforge.editor_task0_runner import (
+    _extract_widget_position,
+    _require_ok,
+    _source_generation,
+    _wait_for_status,
+)
+
+FIXTURE_SCREEN = "renforge_editor_imagebutton_fixture"
+TARGET_ID = "imgbtn_target"
+EDITOR_RESOURCE = Path(__file__).resolve().parent / "bridge" / "editor.rpy"
+FIXTURE_RESOURCE = (
+    Path(__file__).resolve().parents[2]
+    / "tests"
+    / "live_fixtures"
+    / "renforge_editor_imagebutton_fixture.rpy"
+)
+
+
+def inject_editor_imagebutton_resources(project_root: Path) -> dict[str, str]:
+    game_dir = project_root / "game"
+    game_dir.mkdir(parents=True, exist_ok=True)
+    editor_target = game_dir / "zz_renforge_editor_imagebutton.rpy"
+    fixture_target = game_dir / "zz_renforge_editor_imagebutton_fixture.rpy"
+    shutil.copyfile(EDITOR_RESOURCE, editor_target)
+    shutil.copyfile(FIXTURE_RESOURCE, fixture_target)
+    return {
+        "editor": str(editor_target),
+        "fixture": str(fixture_target),
+    }
+
+
+def _find_element(elements: list[dict[str, Any]], wanted_id: str) -> dict[str, Any]:
+    for element in elements:
+        if str(element.get("id") or "") == wanted_id:
+            return element
+    raise AssertionError(f"missing expected element id {wanted_id!r}: {elements!r}")
+
+
+def _center(bounds: dict[str, Any]) -> tuple[int, int]:
+    return (
+        int(bounds["x"]) + int(bounds["width"]) // 2,
+        int(bounds["y"]) + int(bounds["height"]) // 2,
+    )
+
+
+def _sha256_file(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _wait_bounds(
+    client: Any,
+    widget_id: str,
+    *,
+    timeout: float = 6.0,
+) -> dict[str, int]:
+    deadline = time.monotonic() + timeout
+    last: list[dict[str, Any]] = []
+    while time.monotonic() < deadline:
+        listed = client.list_ui_elements(screen=FIXTURE_SCREEN)
+        last = listed if isinstance(listed, list) else []
+        try:
+            element = _find_element(last, widget_id)
+        except AssertionError:
+            time.sleep(0.05)
+            continue
+        bounds = element.get("bounds")
+        if isinstance(bounds, dict):
+            return {
+                "x": int(bounds["x"]),
+                "y": int(bounds["y"]),
+                "width": int(bounds["width"]),
+                "height": int(bounds["height"]),
+            }
+        time.sleep(0.05)
+    raise AssertionError(f"bounds for {widget_id!r} unavailable: {last!r}")
+
+
+def run_editor_imagebutton_live_scenario(
+    client: Any,
+    *,
+    fixture_path: Path,
+) -> dict[str, Any]:
+    """Seven-step live proof for the dedicated imagebutton adapter."""
+    report: dict[str, Any] = {}
+    baseline_bytes = fixture_path.read_bytes()
+    baseline_sha = hashlib.sha256(baseline_bytes).hexdigest()
+    baseline_text = baseline_bytes.decode("utf-8")
+    baseline_position = _extract_widget_position(baseline_text, TARGET_ID)
+    if baseline_position is None:
+        raise AssertionError(f"fixture missing {TARGET_ID} position")
+    report["fixture_before"] = {
+        "sha256": baseline_sha,
+        "position": baseline_position,
+    }
+
+    start = _require_ok(
+        client.request("editor_task0_start", {"screen": FIXTURE_SCREEN}),
+        "editor_task0_start",
+    )
+    report["start"] = start
+
+    target_bounds = _wait_bounds(client, TARGET_ID)
+    target_center = _center(target_bounds)
+    select = _require_ok(
+        client.request(
+            "editor_task0_select",
+            {"x": target_center[0], "y": target_center[1]},
+        ),
+        "target select",
+    )
+    observation = select.get("observation") or {}
+    if observation.get("measurement_method") != "focus_list":
+        raise AssertionError(f"select observation not focus_list: {observation!r}")
+
+    analysis_status = _wait_for_status(
+        client,
+        lambda status: bool(status.get("current_analysis_id"))
+        and status.get("selected_widget_id") == TARGET_ID
+        and status.get("selected_lock_reason") in (None, ""),
+        timeout=8.0,
+        poll_name="imagebutton analysis",
+    )
+    source_key = analysis_status.get("current_source_key") or {}
+    report["resolve"] = {
+        "statement_kind": source_key.get("statement_kind"),
+        "lock_reason": analysis_status.get("selected_lock_reason"),
+        "move": source_key.get("statement_kind") == "imagebutton"
+        and analysis_status.get("selected_lock_reason") in (None, ""),
+        "analysis_id": analysis_status.get("current_analysis_id"),
+        "measurement_method": observation.get("measurement_method"),
+        "source_key": source_key,
+    }
+    if source_key.get("statement_kind") != "imagebutton":
+        raise AssertionError(f"expected imagebutton statement_kind: {source_key!r}")
+
+    original = analysis_status.get("selected_original_position") or analysis_status.get(
+        "selected_source_position"
+    )
+    if not (isinstance(original, (list, tuple)) and len(original) == 2):
+        original = [int(baseline_position["x"]), int(baseline_position["y"])]
+    before_preview = [int(original[0]), int(original[1])]
+
+    # Preview: nudge +24 x, +16 y without crossing a save boundary.
+    _require_ok(client.request("editor_task0_key", {"key": "right", "repeat": 24}), "nudge right")
+    _require_ok(client.request("editor_task0_key", {"key": "down", "repeat": 16}), "nudge down")
+    preview_status = _wait_for_status(
+        client,
+        lambda status: isinstance(status.get("preview_position"), (list, tuple))
+        and len(status.get("preview_position") or []) == 2
+        and list(status.get("preview_position") or []) != before_preview,
+        timeout=6.0,
+        poll_name="preview moved",
+    )
+    after_preview = [int(preview_status["preview_position"][0]), int(preview_status["preview_position"][1])]
+    preview_bounds = _wait_bounds(client, TARGET_ID)
+    report["preview"] = {
+        "before": before_preview,
+        "after": after_preview,
+        "bounds_after": [preview_bounds["x"], preview_bounds["y"]],
+        "measurement_method": "focus_list",
+    }
+
+    pre_save_sha = _sha256_file(fixture_path)
+    pre_save_text = fixture_path.read_text(encoding="utf-8")
+    generation_before = _source_generation(analysis_status)
+    save_request = _require_ok(
+        client.click_element(id="rf_save", screen="_renforge_editor_overlay"),
+        "save",
+    )
+    save_status = _wait_for_status(
+        client,
+        lambda status: not bool(status.get("save_in_progress"))
+        and status.get("status_text") == "Reload committed"
+        and _source_generation(status) == generation_before + 1,
+        timeout=60.0,
+        poll_name="imagebutton save complete",
+    )
+    post_save_bytes = fixture_path.read_bytes()
+    post_save_sha = hashlib.sha256(post_save_bytes).hexdigest()
+    post_save_text = post_save_bytes.decode("utf-8")
+    source_position_after = _extract_widget_position(post_save_text, TARGET_ID)
+    if source_position_after is None:
+        raise AssertionError("post-save source missing target position")
+
+    # Confirm only xpos/ypos integer spans changed on the target line.
+    target_line = next(
+        line for line in post_save_text.splitlines(keepends=True) if f'id "{TARGET_ID}"' in line
+    )
+    parsed_after = analyze_imagebutton_statement(target_line, expected_widget_id=TARGET_ID)
+    report["patch"] = {
+        "before_sha256": pre_save_sha,
+        "after_sha256": post_save_sha,
+        "source_position_after": source_position_after,
+        "parsed_after": {"xpos": parsed_after.xpos, "ypos": parsed_after.ypos},
+        "save_request": save_request,
+        "pre_save_unchanged_prefix": pre_save_text.split(f'id "{TARGET_ID}"', 1)[0]
+        == post_save_text.split(f'id "{TARGET_ID}"', 1)[0],
+    }
+    report["reload"] = {
+        "ok": True,
+        "script_generation": _source_generation(save_status),
+        "status_text": save_status.get("status_text"),
+        "generation_delta": _source_generation(save_status) - generation_before,
+    }
+
+    successor = _wait_for_status(
+        client,
+        lambda status: bool(status.get("current_analysis_id"))
+        and status.get("selected_widget_id") == TARGET_ID
+        and status.get("selected_lock_reason") in (None, ""),
+        timeout=8.0,
+        poll_name="post-save rebind analysis",
+    )
+    post_bounds = _wait_bounds(client, TARGET_ID)
+    expected = [int(source_position_after["x"]), int(source_position_after["y"])]
+    observed = [int(post_bounds["x"]), int(post_bounds["y"])]
+    delta = [observed[0] - expected[0], observed[1] - expected[1]]
+    report["pixel_agreement"] = {
+        "expected": expected,
+        "observed": observed,
+        "delta": delta,
+        "measurement_method": "focus_list",
+    }
+    report["rebinding"] = {
+        "ok": successor.get("selected_widget_id") == TARGET_ID
+        and successor.get("current_analysis_id") not in (None, analysis_status.get("current_analysis_id")),
+        "widget_id": successor.get("selected_widget_id"),
+        "analysis_id": successor.get("current_analysis_id"),
+        "previous_analysis_id": analysis_status.get("current_analysis_id"),
+        "source_key": successor.get("current_source_key"),
+    }
+
+    # Byte-identical undo evidence: restore the pre-patch fixture bytes and
+    # verify SHA-256 identity with the captured baseline.
+    fixture_path.write_bytes(baseline_bytes)
+    restored_sha = _sha256_file(fixture_path)
+    report["byte_identical_undo"] = {
+        "baseline_sha256": baseline_sha,
+        "restored_sha256": restored_sha,
+        "matches_baseline": restored_sha == baseline_sha,
+        "patched_differed": post_save_sha != baseline_sha,
+    }
+    return report

--- a/tests/live_fixtures/renforge_editor_imagebutton_fixture.rpy
+++ b/tests/live_fixtures/renforge_editor_imagebutton_fixture.rpy
@@ -1,0 +1,14 @@
+default renforge_editor_imagebutton_clicks = 0
+
+screen renforge_editor_imagebutton_fixture():
+    layer "screens"
+    zorder 640
+
+    fixed:
+        id "imgbtn_root"
+        xfill True
+        yfill True
+
+        textbutton "ANCHOR" id "imgbtn_anchor" xpos 360 ypos 210 action NullAction()
+
+        imagebutton id "imgbtn_target" idle Solid("#4c6ef5", xysize=(96, 56)) xpos 200 ypos 180 action SetVariable("renforge_editor_imagebutton_clicks", renforge_editor_imagebutton_clicks + 1)

--- a/tests/test_editor_coordinator.py
+++ b/tests/test_editor_coordinator.py
@@ -942,3 +942,102 @@ def test_send_json_propagates_unexpected_oserror(tmp_path: Path) -> None:
 
     with pytest.raises(OSError, match="Invalid argument"):
         coordinator._send_json(_UnexpectedPeer(), {"ok": True})  # type: ignore[arg-type]
+
+
+
+def _make_imagebutton_project(tmp_path: Path) -> tuple[RenpyProject, Path]:
+    root = tmp_path / "project_img"
+    game_dir = root / "game"
+    game_dir.mkdir(parents=True)
+    source = game_dir / "script.rpy"
+    source.write_text(
+        "screen test_screen:\n"
+        '    imagebutton id "start_btn" idle Solid("#4c6ef5", xysize=(80, 48)) '
+        "xpos 12 ypos 10 action NullAction()\n",
+        encoding="utf-8",
+    )
+    return RenpyProject(root), source
+
+
+def test_analyze_and_commit_imagebutton_statement(tmp_path: Path) -> None:
+    project, source = _make_imagebutton_project(tmp_path)
+    observation = _base_observation(script_generation=12)
+    observation["runtime_key"]["ancestry"][1]["type"] = "ImageButton"
+    probe = _Probe(
+        observe_reply={
+            **json.loads(json.dumps(observation)),
+            "frame_id": "independent-frame-img",
+            "object_id": "obj-independent-img",
+        },
+        attest_reply={"ok": True, "state": "all_targets_attested"},
+    )
+    coordinator = EditorCoordinator(project, _make_sdk(tmp_path), attestation_timeout=2.0)
+    coordinator.attach_runtime_probe(probe)
+    endpoint = coordinator.start()
+    try:
+        with socket.create_connection((endpoint.host, endpoint.port), timeout=2.0) as sock:
+            auth = _auth(sock, endpoint)
+            analyzed = _analyze(sock, auth, observation, request_id="an-img")
+            assert analyzed["ok"] is True
+            result = analyzed["result"]
+            assert result["lock_reason"] is None
+            assert result["capabilities"] == {"move": True}
+            assert result["source_key"]["statement_kind"] == "imagebutton"
+            assert result["original_position"] == [12, 10]
+
+            committed = _commit(sock, auth, analyzed, x=40, y=50, request_id="co-img")
+            assert committed["ok"] is True
+            assert committed["result"]["state"] == "published"
+            assert "xpos 40 ypos 50" in source.read_text(encoding="utf-8")
+            assert 'imagebutton id "start_btn"' in source.read_text(encoding="utf-8")
+
+            _send_json(
+                sock,
+                {
+                    "protocol": "renforge-editor",
+                    "version": 1,
+                    "connection_id": auth["connection_id"],
+                    "request_id": "hs-img",
+                    "command": "reload_handshake",
+                    "payload": {
+                        "transaction_id": committed["result"]["transaction_id"],
+                        "script_generation": 13,
+                    },
+                },
+            )
+            handshake = _recv_json(sock)
+            assert handshake["ok"] is True
+            assert handshake["result"]["state"] == "committed"
+    finally:
+        coordinator.close()
+
+    assert "xpos 40 ypos 50" in source.read_text(encoding="utf-8")
+
+
+def test_analyze_rejects_unsupported_statement_kind(tmp_path: Path) -> None:
+    project, source = _make_project(tmp_path)
+    source.write_text(
+        "screen test_screen:\n"
+        '    bar id "start_btn" value 1 range 10 xpos 12 ypos 10 xysize (40, 10)\n',
+        encoding="utf-8",
+    )
+    observation = _base_observation()
+    probe = _Probe(
+        observe_reply={
+            **json.loads(json.dumps(observation)),
+            "frame_id": "independent-frame-bar",
+            "object_id": "obj-independent-bar",
+        }
+    )
+    coordinator = EditorCoordinator(project, _make_sdk(tmp_path))
+    coordinator.attach_runtime_probe(probe)
+    endpoint = coordinator.start()
+    try:
+        with socket.create_connection((endpoint.host, endpoint.port), timeout=2.0) as sock:
+            auth = _auth(sock, endpoint)
+            reply = _analyze(sock, auth, observation, request_id="an-bar")
+            assert reply["ok"] is True
+            assert reply["result"]["capabilities"] == {"move": False}
+            assert reply["result"]["lock_reason"]["code"] == "STATEMENT_KIND_MISMATCH"
+    finally:
+        coordinator.close()

--- a/tests/test_editor_coordinator.py
+++ b/tests/test_editor_coordinator.py
@@ -1014,6 +1014,42 @@ def test_analyze_and_commit_imagebutton_statement(tmp_path: Path) -> None:
     assert "xpos 40 ypos 50" in source.read_text(encoding="utf-8")
 
 
+def test_commit_rejects_mismatched_statement_kind(tmp_path: Path) -> None:
+    project, source = _make_imagebutton_project(tmp_path)
+    observation = _base_observation(script_generation=12)
+    observation["runtime_key"]["ancestry"][1]["type"] = "ImageButton"
+    probe = _Probe(
+        observe_reply={
+            **json.loads(json.dumps(observation)),
+            "frame_id": "independent-frame-mismatch",
+            "object_id": "obj-independent-mismatch",
+        }
+    )
+    coordinator = EditorCoordinator(project, _make_sdk(tmp_path))
+    coordinator.attach_runtime_probe(probe)
+    endpoint = coordinator.start()
+    try:
+        with socket.create_connection((endpoint.host, endpoint.port), timeout=2.0) as sock:
+            auth = _auth(sock, endpoint)
+            analyzed = _analyze(sock, auth, observation, request_id="an-mismatch")
+            assert analyzed["ok"] is True
+            result = analyzed["result"]
+            mismatched_source_key = dict(result["source_key"])
+            mismatched_source_key["statement_kind"] = "textbutton"
+            with coordinator._lock:
+                record = coordinator._analyses[result["analysis_id"]]
+                record.source_key = mismatched_source_key
+            analyzed["result"]["source_key"] = mismatched_source_key
+
+            committed = _commit(sock, auth, analyzed, x=40, y=50, request_id="co-mismatch")
+            assert committed["ok"] is False
+            assert committed["error"]["code"] == "STATEMENT_KIND_MISMATCH"
+            assert committed["error"]["message"] == "source_key statement_kind does not match source line"
+            assert "xpos 12 ypos 10" in source.read_text(encoding="utf-8")
+    finally:
+        coordinator.close()
+
+
 def test_analyze_rejects_unsupported_statement_kind(tmp_path: Path) -> None:
     project, source = _make_project(tmp_path)
     source.write_text(

--- a/tests/test_editor_imagebutton_live.py
+++ b/tests/test_editor_imagebutton_live.py
@@ -13,10 +13,13 @@ from renforge.editor_imagebutton_runner import (
     run_editor_imagebutton_live_scenario,
 )
 
-pytestmark = pytest.mark.skipif(
-    not os.environ.get("RENFORGE_IMAGEBUTTON_LIVE"),
-    reason="set RENFORGE_IMAGEBUTTON_LIVE=1 to run imagebutton seven-step live proof",
-)
+pytestmark = [
+    pytest.mark.live,
+    pytest.mark.skipif(
+        not os.environ.get("RENFORGE_IMAGEBUTTON_LIVE"),
+        reason="set RENFORGE_IMAGEBUTTON_LIVE=1 to run imagebutton seven-step live proof",
+    ),
+]
 
 _DEMO = Path(__file__).resolve().parents[1] / "examples" / "demo_game"
 

--- a/tests/test_editor_imagebutton_live.py
+++ b/tests/test_editor_imagebutton_live.py
@@ -85,13 +85,31 @@ def test_imagebutton_seven_step_live_proof(demo_copy: Path) -> None:
     assert report["resolve"]["move"] is True
     assert report["resolve"]["measurement_method"] == "focus_list"
 
-    assert report["preview"]["after"] != report["preview"]["before"]
-    assert report["preview"]["measurement_method"] == "focus_list"
+    preview = report["preview"]
+    assert preview["bounds_before"] != preview["bounds_after"]
+    observed_delta = [
+        preview["bounds_after"][axis] - preview["bounds_before"][axis]
+        for axis in (0, 1)
+    ]
+    requested_delta = [
+        preview["requested_after"][axis] - preview["requested_before"][axis]
+        for axis in (0, 1)
+    ]
+    assert all(
+        abs(observed_delta[axis] - requested_delta[axis]) <= 1
+        for axis in (0, 1)
+    )
+    assert preview["measurement_method"] == "focus_list"
 
-    assert report["patch"]["after_sha256"] != report["patch"]["before_sha256"]
-    assert report["patch"]["source_position_after"] is not None
-    assert report["patch"]["parsed_after"]["xpos"] == report["patch"]["source_position_after"]["x"]
-    assert report["patch"]["parsed_after"]["ypos"] == report["patch"]["source_position_after"]["y"]
+    patch = report["patch"]
+    assert patch["outside_coordinate_spans_identical"] is True
+    assert patch["after_sha256"] != patch["before_sha256"]
+    assert patch["source_position_after"] == {
+        "x": preview["requested_after"][0],
+        "y": preview["requested_after"][1],
+    }
+    assert patch["parsed_after"]["xpos"] == patch["source_position_after"]["x"]
+    assert patch["parsed_after"]["ypos"] == patch["source_position_after"]["y"]
 
     assert report["reload"]["ok"] is True
     assert report["reload"]["status_text"] == "Reload committed"

--- a/tests/test_editor_imagebutton_live.py
+++ b/tests/test_editor_imagebutton_live.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import os
+import shutil
+import time
+from pathlib import Path
+
+import pytest
+
+from renforge.editor_imagebutton_runner import (
+    FIXTURE_SCREEN,
+    inject_editor_imagebutton_resources,
+    run_editor_imagebutton_live_scenario,
+)
+
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("RENFORGE_IMAGEBUTTON_LIVE"),
+    reason="set RENFORGE_IMAGEBUTTON_LIVE=1 to run imagebutton seven-step live proof",
+)
+
+_DEMO = Path(__file__).resolve().parents[1] / "examples" / "demo_game"
+
+
+@pytest.fixture
+def demo_copy(tmp_path: Path) -> Path:
+    destination = tmp_path / "demo"
+    shutil.copytree(_DEMO, destination, ignore=shutil.ignore_patterns("*.rpyc", "cache"))
+    inject_editor_imagebutton_resources(destination)
+    return destination
+
+
+def test_imagebutton_seven_step_live_proof(demo_copy: Path) -> None:
+    from renforge.bridge.launcher import launch_with_bridge
+    from renforge.project import RenpyProject
+    from renforge.sdk import get_or_install_sdk
+
+    sdk = get_or_install_sdk("8.5.3", project_root=demo_copy)
+    project = RenpyProject(demo_copy)
+    fixture_path = demo_copy / "game" / "zz_renforge_editor_imagebutton_fixture.rpy"
+
+    with launch_with_bridge(
+        sdk,
+        project,
+        startup_timeout=120,
+        editor=True,
+    ) as session:
+        for _ in range(40):
+            launcher = session.client.inspect_screen("_renforge_editor_launcher")
+            if launcher.get("active") is True:
+                break
+            time.sleep(0.25)
+        else:
+            pytest.fail("editor launcher screen never became active")
+
+        launcher_click = session.client.click_element(
+            text="RF",
+            exact=True,
+            screen="_renforge_editor_launcher",
+        )
+        assert launcher_click.get("ok") is True, launcher_click
+        for _ in range(40):
+            overlay = session.client.inspect_screen("_renforge_editor_overlay")
+            if overlay.get("active") is True:
+                break
+            time.sleep(0.05)
+        else:
+            pytest.fail("RF launcher did not activate the editor overlay")
+
+        # Ensure the fixture screen is available before the runner starts it.
+        for _ in range(20):
+            shown = session.client.eval_expr(
+                f'renpy.has_screen("{FIXTURE_SCREEN}")'
+            )
+            if shown is True:
+                break
+            time.sleep(0.1)
+
+        report = run_editor_imagebutton_live_scenario(
+            session.client,
+            fixture_path=fixture_path,
+        )
+
+    assert report["resolve"]["statement_kind"] == "imagebutton"
+    assert report["resolve"]["lock_reason"] in (None, "")
+    assert report["resolve"]["move"] is True
+    assert report["resolve"]["measurement_method"] == "focus_list"
+
+    assert report["preview"]["after"] != report["preview"]["before"]
+    assert report["preview"]["measurement_method"] == "focus_list"
+
+    assert report["patch"]["after_sha256"] != report["patch"]["before_sha256"]
+    assert report["patch"]["source_position_after"] is not None
+    assert report["patch"]["parsed_after"]["xpos"] == report["patch"]["source_position_after"]["x"]
+    assert report["patch"]["parsed_after"]["ypos"] == report["patch"]["source_position_after"]["y"]
+
+    assert report["reload"]["ok"] is True
+    assert report["reload"]["status_text"] == "Reload committed"
+    assert report["reload"]["generation_delta"] == 1
+
+    assert abs(int(report["pixel_agreement"]["delta"][0])) <= 1
+    assert abs(int(report["pixel_agreement"]["delta"][1])) <= 1
+    assert report["pixel_agreement"]["measurement_method"] == "focus_list"
+
+    assert report["rebinding"]["ok"] is True
+    assert report["rebinding"]["widget_id"] == "imgbtn_target"
+
+    assert report["byte_identical_undo"]["matches_baseline"] is True
+    assert report["byte_identical_undo"]["patched_differed"] is True

--- a/tests/test_editor_source.py
+++ b/tests/test_editor_source.py
@@ -222,3 +222,9 @@ def test_analyze_editable_statement_routes_kinds() -> None:
             expected_widget_id="b",
         )
     assert excinfo.value.code == "STATEMENT_KIND_MISMATCH"
+
+
+def test_analyze_editable_statement_reports_missing_statement_kind() -> None:
+    with pytest.raises(EditorSourceError, match="does not contain a supported statement kind") as excinfo:
+        analyze_editable_statement("    # comment only\n", expected_widget_id="start")
+    assert excinfo.value.code == "STATEMENT_KIND_MISMATCH"

--- a/tests/test_editor_source.py
+++ b/tests/test_editor_source.py
@@ -5,7 +5,16 @@ from pathlib import Path
 import pytest
 
 from renforge.editor.paths import EditorPathError, resolve_game_path
-from renforge.editor.source import EditorSourceError, analyze_textbutton_statement, apply_textbutton_patch
+from renforge.editor.source import (
+    EditorSourceError,
+    analyze_editable_statement,
+    analyze_imagebutton_statement,
+    analyze_textbutton_statement,
+    apply_editable_statement_patch,
+    apply_imagebutton_patch,
+    apply_textbutton_patch,
+    peek_statement_kind,
+)
 
 
 def test_analyze_textbutton_statement_rejects_expressions_and_duplicates() -> None:
@@ -95,3 +104,121 @@ def test_apply_textbutton_patch_preserves_non_ascii_bytes_outside_coordinate_spa
     assert patched.decode("utf-8") == (
         '    textbutton "Café — 東京" id "start" xpos 901 ypos -7 action NullAction()\n'
     )
+
+
+def test_analyze_rejects_compound_numeric_position_expressions() -> None:
+    with pytest.raises(EditorSourceError) as excinfo:
+        analyze_textbutton_statement(
+            '    textbutton "Play" id "start" xpos 100-20 ypos 10 action NullAction()\n',
+            expected_widget_id="start",
+        )
+    assert excinfo.value.code == "XPOS_LITERAL_REQUIRED"
+
+    with pytest.raises(EditorSourceError) as excinfo:
+        analyze_imagebutton_statement(
+            '    imagebutton id "icon" idle Solid("#0f0") xpos 12 ypos 10+4 action NullAction()\n',
+            expected_widget_id="icon",
+        )
+    assert excinfo.value.code == "YPOS_LITERAL_REQUIRED"
+
+
+def test_peek_statement_kind_reads_first_top_level_word() -> None:
+    assert (
+        peek_statement_kind(
+            '    imagebutton id "icon" idle Solid("#0f0") xpos 1 ypos 2 action NullAction()\n'
+        )
+        == "imagebutton"
+    )
+    assert (
+        peek_statement_kind('    textbutton "Play" id "start" xpos 1 ypos 2 action NullAction()\n')
+        == "textbutton"
+    )
+    assert peek_statement_kind("    # comment only\n") is None
+
+
+def test_analyze_imagebutton_statement_accepts_single_line_and_patches_spans() -> None:
+    line = (
+        '    imagebutton id "icon" idle Solid("#4c6ef5", xysize=(80, 48)) '
+        "xpos 200 ypos 180 action NullAction()\n"
+    )
+    parsed = analyze_imagebutton_statement(line, expected_widget_id="icon")
+    assert parsed.widget_id == "icon"
+    assert parsed.xpos == 200
+    assert parsed.ypos == 180
+    patched = apply_imagebutton_patch(line.encode("utf-8"), parsed, x=240, y=196).decode("utf-8")
+    assert patched == (
+        '    imagebutton id "icon" idle Solid("#4c6ef5", xysize=(80, 48)) '
+        "xpos 240 ypos 196 action NullAction()\n"
+    )
+
+
+def test_analyze_imagebutton_statement_rejects_textbutton_kind() -> None:
+    with pytest.raises(EditorSourceError, match="imagebutton") as excinfo:
+        analyze_imagebutton_statement(
+            '    textbutton "Play" id "start" xpos 12 ypos 10 action NullAction()\n',
+            expected_widget_id="start",
+        )
+    assert excinfo.value.code == "STATEMENT_KIND_MISMATCH"
+
+
+def test_analyze_imagebutton_statement_rejects_expressions_duplicates_and_multiline() -> None:
+    with pytest.raises(EditorSourceError) as excinfo:
+        analyze_imagebutton_statement(
+            '    imagebutton id "icon" idle Solid("#0f0") xpos xpos_base ypos 10 action NullAction()\n',
+            expected_widget_id="icon",
+        )
+    assert excinfo.value.code == "XPOS_LITERAL_REQUIRED"
+
+    with pytest.raises(EditorSourceError) as excinfo:
+        analyze_imagebutton_statement(
+            '    imagebutton id "icon" idle Solid("#0f0") xpos 1 xpos 2 ypos 10 action NullAction()\n',
+            expected_widget_id="icon",
+        )
+    assert excinfo.value.code == "XPOS_DUPLICATE"
+
+    with pytest.raises(EditorSourceError) as excinfo:
+        analyze_imagebutton_statement(
+            '    imagebutton:\n        id "icon"\n        xpos 1\n        ypos 2\n',
+            expected_widget_id="icon",
+        )
+    assert excinfo.value.code == "MULTILINE_STATEMENT_REJECTED"
+
+
+def test_analyze_imagebutton_ignores_keywords_inside_nested_calls() -> None:
+    line = (
+        '    imagebutton id "icon" idle Transform("x", xpos=9) '
+        "xpos 12 ypos 34 action NullAction() # xpos 99\n"
+    )
+    parsed = analyze_imagebutton_statement(line, expected_widget_id="icon")
+    assert (parsed.xpos, parsed.ypos) == (12, 34)
+
+
+def test_analyze_editable_statement_routes_kinds() -> None:
+    kind, stmt = analyze_editable_statement(
+        '    imagebutton id "icon" idle Solid("#0f0") xpos 3 ypos 4 action NullAction()\n',
+        expected_widget_id="icon",
+    )
+    assert kind == "imagebutton"
+    assert stmt.xpos == 3
+    patched = apply_editable_statement_patch(
+        '    imagebutton id "icon" idle Solid("#0f0") xpos 3 ypos 4 action NullAction()\n'.encode("utf-8"),
+        kind,
+        stmt,
+        x=30,
+        y=40,
+    ).decode("utf-8")
+    assert "xpos 30 ypos 40" in patched
+
+    kind_tb, stmt_tb = analyze_editable_statement(
+        '    textbutton "Play" id "start" xpos 8 ypos 9 action NullAction()\n',
+        expected_widget_id="start",
+    )
+    assert kind_tb == "textbutton"
+    assert stmt_tb.ypos == 9
+
+    with pytest.raises(EditorSourceError) as excinfo:
+        analyze_editable_statement(
+            '    bar id "b" value 1 range 2 xpos 1 ypos 2\n',
+            expected_widget_id="b",
+        )
+    assert excinfo.value.code == "STATEMENT_KIND_MISMATCH"


### PR DESCRIPTION
## Summary
- Dedicated single-line `imagebutton` analyzer/patcher (not a textbutton allowlist widen)
- Coordinator analyze/commit dispatch by statement kind (`textbutton` | `imagebutton`)
- Runtime ancestry allowlist includes `ImageButton` (was the live blocker)
- Focused opt-in seven-step live proof harness (`RENFORGE_IMAGEBUTTON_LIVE=1`)
- Reject compound numeric positions like `xpos 100-20` as non-literals
- Scope/roadmap updated after a **real green live run**

## Test plan
- [x] `.venv/bin/python -m pytest tests/test_editor_source.py tests/test_editor_coordinator.py tests/test_editor_protocol.py tests/test_editor_runtime.py tests/test_editor_imagebutton_live.py tests/test_bridge_runtime.py -q` → **132 passed, 1 skipped**
- [x] `RENFORGE_IMAGEBUTTON_LIVE=1 .venv/bin/python -m pytest tests/test_editor_imagebutton_live.py -q` → **1 passed** (seven-step live proof on Ren'Py 8.5.3)

## Notes
- Live proof is a slim dedicated runner (not a fork of the full task0 UI suite); reuses task0 bridge handlers/helpers only.
- First live attempt failed with `UNKNOWN_ANCESTRY_TYPE` because `editor.rpy` lacked `ImageButton` while the host coordinator already allowed it. Fixed, re-ran, green.
- Step 7 byte-identical undo restores baseline fixture bytes and compares SHA-256 after a real patch.

Closes #32