### PR TITLE
feat(editor): add explicit-block button adapter (#33)

### DIFF
--- a/docs/superpowers/specs/2026-07-30-renforge-visual-editor-v1-scope.md
+++ b/docs/superpowers/specs/2026-07-30-renforge-visual-editor-v1-scope.md
@@ -33,7 +33,7 @@ requires it — none is arbitrary.
 |---|---|---|
 | 1 | Displayable is **focusable** | Selection and every save-bearing measurement read `renpy.display.focus.focus_list` |
 | 2 | Source statement carries one **literal `id`** matching the runtime widget id | Runtime preview uses `_widget_properties`, keyed by the authored widget id; synthetic observation IDs do not qualify |
-| 3 | Single-line statement from the proven adapter allowlist (`textbutton`, `imagebutton`) with one literal integer **`xpos` and `ypos`** | The token-aware patcher replaces only those two integer spans |
+| 3 | A proven adapter statement (`textbutton`, `imagebutton`) or an explicit-block `button`, with one literal integer **`xpos` and `ypos`** | The token-aware patcher replaces only the coordinate spans; the button adapter preserves child block bytes |
 | 4 | Exactly one runtime instance with a fully classified, static ancestry outside **`viewport` / `Crop` / `Transform(crop=)`**, loop and repeated `use` cases | Only a unique static instance under proven clipping can be rebound unambiguously |
 
 **A failing gate is a first-class UI state, never a silent no-op.** The overlay must name which gate
@@ -57,12 +57,16 @@ V1 ships an explicit allowlist, extended one adapter at a time, each backed by a
 |---|---|---|---|
 | `textbutton` | Spike C `pass` | Spike D `pass` | **Shipped in V1** |
 | `imagebutton` | Spike C `pass` (focusable) | dedicated analyzer + coordinator path + seven-step live proof | **Implemented** (live proof green via `RENFORGE_IMAGEBUTTON_LIVE=1`) |
-| `button` | focusable by construction | not exercised | Blocked until proven |
+| `button` | focusable by construction | Seven-step live proof (explicit block) | **Shipped in V1** |
 | `text`, `add`, `frame` | **not selectable** | Spike B proved write on a literal `text`, but by key, not by click | Out of V1 |
 
 `imagebutton` has a dedicated single-line adapter (issue #32) rather than a textbutton allowlist widen.
 Host unit/coordinator coverage lands in default CI; the seven-step live proof is opt-in in CI but was
 executed green locally against Ren'Py 8.5.3 (`RENFORGE_IMAGEBUTTON_LIVE=1 pytest tests/test_editor_imagebutton_live.py`).
+
+The `button` adapter is intentionally limited to `button id "..." xpos N ypos N:` headers. Computed
+coordinates, direct child `xpos`/`ypos`, layout-container ancestry, and ambiguous or unproven runtime
+instances remain selectable but locked with an exact reason.
 
 ## Proven mechanisms (do not redesign)
 

--- a/examples/demo_game/game/screens.rpy
+++ b/examples/demo_game/game/screens.rpy
@@ -238,6 +238,40 @@ screen village_gate_choices():
     textbutton "Ask the Elder to send someone else." id "demo_lantern_decline" xpos 160 ypos 380 action Return("decline_lantern")
     textbutton "Hold the gate (locked demo)." id "demo_locked_expr" xpos gui.choice_spacing ypos 440 action NullAction()
 
+default renforge_story_button_x = 820
+
+screen renforge_hidden_shrine_controls():
+    zorder 150
+    text "Shrine controls" id "story_shrine_label" xpos 60 ypos 120
+    imagebutton id "story_imgbtn" idle Transform("wisp glow", zoom=0.18) xpos 900 ypos 170 action NullAction()
+    button id "story_button" xpos 520 ypos 230:
+        text "Touch the shrine" xpos 7
+        action NullAction()
+
+screen renforge_cave_mouth_controls():
+    zorder 150
+    text "Cave controls" id "story_cave_label" xpos 60 ypos 120
+    button id "story_button_computed" xpos renforge_story_button_x ypos 220:
+        text "Computed button"
+        action NullAction()
+
+screen renforge_crossroads_controls():
+    zorder 150
+    text "Crossroads controls" id "story_crossroads_label" xpos 60 ypos 120
+    vbox id "story_layout_controls" xpos 900 ypos 170 spacing 8:
+        button id "story_layout_button" xpos 0 ypos 0:
+            text "Layout button"
+            action NullAction()
+
+screen renforge_summit_controls():
+    zorder 150
+    text "Summit controls" id "story_summit_label" xpos 60 ypos 120
+    button id "story_button_in_block":
+        xpos 720
+        ypos 240
+        text "Position in block"
+        action NullAction()
+
 
 ## Quick Menu screen ###########################################################
 ##

--- a/examples/demo_game/game/script.rpy
+++ b/examples/demo_game/game/script.rpy
@@ -52,11 +52,14 @@ label stay_home:
 label crossroads:
     scene bg forest with dissolve
     w "Two ways up: through the deep woods, or along the ridge."
+    show screen renforge_crossroads_controls
     menu:
         "Cut through the deep woods.":
+            hide screen renforge_crossroads_controls
             $ renforge_choice = "forest"
             jump forest_path
         "Climb along the ridge.":
+            hide screen renforge_crossroads_controls
             $ renforge_choice = "ridge"
             jump ridge_path
 
@@ -73,19 +76,24 @@ label forest_path:
 
 label hidden_shrine:
     scene bg shrine with dissolve
+    show screen renforge_hidden_shrine_controls
     narrator "A forgotten shrine, warm as a heartbeat. The flame in your lantern turns silver."
     $ lantern = True
     w "The old fire remembers you."
+    hide screen renforge_hidden_shrine_controls
     jump summit
 
 label cave_mouth:
     scene bg cave with dissolve
+    show screen renforge_cave_mouth_controls
     narrator "The trail ends at a yawning cave. Cold air breathes out of the dark."
     menu:
         "Enter the cave.":
+            hide screen renforge_cave_mouth_controls
             $ courage += 1
             jump cave_depths
         "Turn back to the crossroads.":
+            hide screen renforge_cave_mouth_controls
             jump crossroads
 
 label cave_depths:
@@ -113,10 +121,13 @@ label wisp_advice:
 
 label summit:
     scene bg summit with dissolve
+    show screen renforge_summit_controls
     narrator "The beacon tower stands empty, its great bowl cold."
     if lantern:
+        hide screen renforge_summit_controls
         jump ending_light
     else:
+        hide screen renforge_summit_controls
         jump ending_ash
 
 label ending_light:

--- a/src/renforge/bridge/editor.rpy
+++ b/src/renforge/bridge/editor.rpy
@@ -430,7 +430,7 @@ init 1100 python:
 
 
     def _renforge_editor_lock_code(lock_reason):
-        if isinstance(lock_reason, dict):
+        if isinstance(lock_reason, builtins.dict):
             return str(lock_reason.get("code") or "")
         if lock_reason is None:
             return None
@@ -820,6 +820,11 @@ init 1100 python:
                 or getattr(node, "_renforge_editor_owner", None) == _EDITOR_OWNER
                 or getattr(named_widget, "_renforge_editor_owner", None) == _EDITOR_OWNER
             )
+            style = getattr(node, "style", None)
+            layout = getattr(style, "box_layout", None) if style is not None else None
+            if layout is None:
+                layout = getattr(node, "default_layout", None)
+            layout_name = layout if isinstance(layout, builtins.str) else None
             ancestry.append(
                 {
                     "index": int(index),
@@ -828,6 +833,7 @@ init 1100 python:
                     "screen_owner": _EDITOR_OWNER if editor_owned else "game",
                     "crop_state": crop_state,
                     "editor_owned": editor_owned,
+                    "layout": layout_name,
                 }
             )
         key = {

--- a/src/renforge/bridge/editor.rpy
+++ b/src/renforge/bridge/editor.rpy
@@ -133,6 +133,7 @@ screen _renforge_editor_overlay():
                     textbutton "Exit":
                         id "rf_exit"
                         action Function(_renforge_editor_consume, _renforge_editor_exit)
+                        sensitive not _renforge_editor_state().save_in_progress
                         text_color "#f4f4f5"
                     textbutton "Undo":
                         id "rf_undo"
@@ -377,11 +378,6 @@ init 1100 python:
             return {"ok": False, "error": "editor session unavailable"}
         state.active = True
         state.selected_lock_reason = None
-        if (
-            state.editor_session_screen is not None
-            and renpy.get_screen(state.editor_session_screen) is None
-        ):
-            renpy.show_screen(state.editor_session_screen, _layer="screens")
         renpy.show_screen(_EDITOR_SCREEN, _layer="screens")
         renpy.restart_interaction()
         return {"ok": True}
@@ -1791,7 +1787,45 @@ init 1100 python:
 
     def _renforge_editor_exit():
         state = _renforge_editor_state()
+        if state.save_in_progress:
+            return {"ok": False, "error": "SAVE_IN_PROGRESS", "active": True}
+        dirty_screens = []
+        for target in state.targets.values():
+            if not isinstance(target, builtins.dict) or not target.get("dirty"):
+                continue
+            target["dirty"] = False
+            screen = target.get("screen")
+            if (
+                isinstance(screen, str)
+                and screen not in dirty_screens
+                and renpy.get_screen(screen) is not None
+            ):
+                dirty_screens.append(screen)
+        for screen in dirty_screens:
+            renpy.show_screen(screen, _layer="screens")
         state.active = False
+        state.screen = None
+        state.editor_session_screen = None
+        state.selected_runtime_key = None
+        state.selected_widget_id = None
+        state.selected_screen = None
+        state.selected_target_key = None
+        state.selected_lock_reason = None
+        state.selected_original_position = None
+        state.selected_source_position = None
+        state.selected_rect = None
+        state.selected_analysis_pending = False
+        state.preview_position = None
+        state.current_analysis_id = None
+        state.current_source_key = None
+        state.pending_analysis_key = None
+        state.history = []
+        state.history_entries = []
+        state.history_index = -1
+        state.targets = {}
+        state.save_enabled = False
+        state.save_button_state = "idle"
+        state.label_text = "No selection"
         state.drag_active = False
         state.snap_anchor_x = None
         state.snap_anchor_y = None
@@ -2365,6 +2399,12 @@ init 1100 python:
             "up": (0, -1),
             "down": (0, 1),
         }
+        if key_name == "escape":
+            exit_reply = _renforge_editor_exit()
+            state.last_event_trace = [{"key": key_name, "shift": shift}]
+            if not exit_reply.get("ok", False):
+                return exit_reply
+            return {"ok": True, "repeat": repeat, "shift": shift, "active": state.active}
         traces = []
         for _index in range(repeat):
             if key_name in nudge_map:

--- a/src/renforge/editor/coordinator.py
+++ b/src/renforge/editor/coordinator.py
@@ -29,11 +29,20 @@ from .exceptions import EditorError
 from .paths import EditorPathError, atomic_write_file, fsync_directory, resolve_game_path, sha256_bytes
 from .runtime import RuntimeProbe
 from .shadow import ShadowLintResult, build_shadow_project, run_shadow_lint
-from .source import EditorSourceError, analyze_editable_statement, apply_editable_statement_patch
+from .source import (
+    EditorSourceError,
+    analyze_button_statement,
+    analyze_editable_statement,
+    apply_button_patch,
+    apply_editable_statement_patch,
+    peek_statement_kind,
+)
 
 
 def _now_deadline(seconds: float) -> float:
     return time.monotonic() + max(0.01, seconds)
+
+
 
 
 @dataclass(frozen=True)
@@ -518,13 +527,23 @@ class EditorCoordinator:
             source_path = resolve_game_path(self._project.root, relative_path)
             source_bytes = source_path.read_bytes()
             source_sha = sha256_bytes(source_bytes)
-            lines = source_bytes.decode("utf-8").splitlines(keepends=True)
+            source_text = source_bytes.decode("utf-8")
+            lines = source_text.splitlines(keepends=True)
             if source_line < 1 or source_line > len(lines):
                 raise EditorError("SOURCE_LINE_INVALID", "source line is out of range")
             widget_id = self._require_runtime_widget_id(runtime_key)
-            kind, statement = analyze_editable_statement(
-                lines[source_line - 1], expected_widget_id=widget_id
-            )
+            if peek_statement_kind(lines[source_line - 1]) == "button":
+                statement = analyze_button_statement(
+                    source_text,
+                    source_line=source_line,
+                    expected_widget_id=widget_id,
+                )
+                statement_kind = "button"
+            else:
+                statement_kind, statement = analyze_editable_statement(
+                    lines[source_line - 1],
+                    expected_widget_id=widget_id,
+                )
             original_position = [statement.xpos, statement.ypos]
             ancestry = runtime_key.get("ancestry")
             normalized_ancestry = (
@@ -555,7 +574,7 @@ class EditorCoordinator:
                 "invocation_path": runtime_key.get("invocation_path"),
                 "instance_discriminator": runtime_key.get("instance_discriminator"),
                 "ancestry": normalized_ancestry,
-                "statement_kind": kind,
+                "statement_kind": statement_kind,
                 "baseline_sha256": source_sha,
             }
             if lock_reason is None:
@@ -902,6 +921,14 @@ class EditorCoordinator:
                 return self._lock_reason("ANCESTRY_TYPE_UNPROVEN", "ancestor type is missing")
             if ancestor_type not in allowed_types:
                 return self._lock_reason("ANCESTRY_TYPE_UNPROVEN", f"unproven ancestor type: {ancestor_type}")
+            if ancestor_type in {"VBox", "HBox", "Grid"} or (
+                ancestor_type == "MultiBox"
+                and ancestor.get("layout") in {"horizontal", "vertical"}
+            ):
+                return self._lock_reason(
+                    "CONTAINER_POSITION_UNSUPPORTED",
+                    "direct movement inside layout containers is not editable",
+                )
             if ancestor_type == "Viewport":
                 return self._lock_reason("VIEWPORT_ANCESTRY_UNSUPPORTED", "viewport ancestry is not editable in V1")
             if ancestor_type == "Crop":
@@ -956,21 +983,40 @@ class EditorCoordinator:
             if target_key in seen_targets:
                 raise EditorError("DUPLICATE_SOURCE_TARGET", "multiple intents target the same source statement")
             seen_targets.add(target_key)
-            line_text = lines[line_no - 1]
-            kind, statement = analyze_editable_statement(line_text, expected_widget_id=widget_id)
+            source_text = "".join(lines)
             recorded_kind = source_key.get("statement_kind")
-            if isinstance(recorded_kind, str) and recorded_kind != kind:
+            actual_kind = peek_statement_kind(lines[line_no - 1])
+            if not isinstance(actual_kind, str):
+                raise EditorError("SOURCE_KEY_INVALID", "source line statement kind is invalid")
+            if isinstance(recorded_kind, str) and recorded_kind != actual_kind:
                 raise EditorError(
                     "STATEMENT_KIND_MISMATCH",
                     "source_key statement_kind does not match source line",
                 )
-            lines[line_no - 1] = apply_editable_statement_patch(
-                line_text.encode("utf-8"),
-                kind,
-                statement,
-                x=x,
-                y=y,
-            ).decode("utf-8")
+            if actual_kind == "button":
+                statement = analyze_button_statement(
+                    source_text,
+                    source_line=line_no,
+                    expected_widget_id=widget_id,
+                )
+                lines = apply_button_patch(
+                    "".join(lines).encode("utf-8"),
+                    statement,
+                    x=x,
+                    y=y,
+                ).decode("utf-8").splitlines(keepends=True)
+            else:
+                kind, statement = analyze_editable_statement(
+                    lines[line_no - 1],
+                    expected_widget_id=widget_id,
+                )
+                lines[line_no - 1] = apply_editable_statement_patch(
+                    lines[line_no - 1].encode("utf-8"),
+                    kind,
+                    statement,
+                    x=x,
+                    y=y,
+                ).decode("utf-8")
 
         return "".join(lines).encode("utf-8")
 

--- a/src/renforge/editor/source.py
+++ b/src/renforge/editor/source.py
@@ -20,6 +20,17 @@ class TextbuttonStatement:
     ypos_span: tuple[int, int]
 
 
+
+@dataclass(frozen=True)
+class ButtonStatement:
+    widget_id: str
+    xpos: int
+    ypos: int
+    xpos_span: tuple[int, int]
+    ypos_span: tuple[int, int]
+    source_line: int
+
+
 @dataclass(frozen=True)
 class ImagebuttonStatement:
     widget_id: str
@@ -347,3 +358,146 @@ def apply_editable_statement_patch(
             raise EditorSourceError("STATEMENT_KIND_MISMATCH", "statement does not match imagebutton kind")
         return apply_imagebutton_patch(source_bytes, statement, x=x, y=y)
     raise EditorSourceError("STATEMENT_KIND_MISMATCH", f"unsupported statement kind: {kind!r}")
+
+
+def _button_child_line_indexes(lines: list[str], source_line: int, header_indent: int) -> list[int]:
+    child_indexes: list[int] = []
+    for index in range(source_line, len(lines)):
+        line = lines[index]
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        indent = len(line) - len(line.lstrip(" \t"))
+        if indent <= header_indent:
+            break
+        child_indexes.append(index)
+
+    if not child_indexes:
+        raise EditorSourceError(
+            "BUTTON_BLOCK_REQUIRED",
+            "button statement must contain an explicit child block",
+        )
+    return child_indexes
+
+
+def analyze_button_statement(
+    source_text: str,
+    *,
+    source_line: int,
+    expected_widget_id: str,
+) -> ButtonStatement:
+    lines = source_text.splitlines(keepends=True)
+    if source_line < 1 or source_line > len(lines):
+        raise EditorSourceError("SOURCE_LINE_INVALID", "button source line is outside the source file")
+
+    header_line = lines[source_line - 1]
+    header_text = header_line.rstrip("\r\n")
+    tokens = _lex_single_line(header_text)
+    top_level = [token for token in tokens if token.depth == 0]
+    if not top_level or top_level[0].kind != "WORD" or top_level[0].text != "button":
+        raise EditorSourceError("STATEMENT_KIND_MISMATCH", "source statement is not a button")
+
+    colon_tokens = [token for token in top_level if token.kind == "SYMBOL" and token.text == ":"]
+    if len(colon_tokens) != 1 or top_level[-1] is not colon_tokens[0]:
+        raise EditorSourceError(
+            "BUTTON_BLOCK_REQUIRED",
+            "button statement must end with an explicit block header",
+        )
+
+    header_indent = len(header_line) - len(header_line.lstrip(" \t"))
+    child_indexes = _button_child_line_indexes(lines, source_line, header_indent)
+    child_indent = min(
+        len(lines[index]) - len(lines[index].lstrip(" \t"))
+        for index in child_indexes
+    )
+    for child_index in child_indexes:
+        child_line = lines[child_index]
+        child_indent_value = len(child_line) - len(child_line.lstrip(" \t"))
+        if child_indent_value != child_indent:
+            continue
+        child_tokens = _lex_single_line(child_line.rstrip("\r\n"))
+        child_top_level = [token for token in child_tokens if token.depth == 0]
+        if (
+            child_top_level
+            and child_top_level[0].kind == "WORD"
+            and child_top_level[0].text in {"xpos", "ypos"}
+        ):
+            raise EditorSourceError(
+                "POSITION_IN_BLOCK",
+                "button xpos/ypos inside the child block are not editable",
+            )
+
+    keyword_counts = {"id": 0, "xpos": 0, "ypos": 0}
+    widget_id: str | None = None
+    xpos_value: int | None = None
+    ypos_value: int | None = None
+    xpos_span: tuple[int, int] | None = None
+    ypos_span: tuple[int, int] | None = None
+    invalid_literals: set[str] = set()
+
+    for index, token in enumerate(tokens):
+        if token.depth != 0 or token.kind != "WORD" or token.text not in keyword_counts:
+            continue
+        keyword = token.text
+        keyword_counts[keyword] += 1
+        value_token = _next_top_level_token(tokens, index)
+        if value_token is None:
+            invalid_literals.add(keyword)
+            continue
+        if keyword == "id":
+            if value_token.kind != "STRING":
+                invalid_literals.add(keyword)
+                continue
+            widget_id = _parse_string_token(value_token)
+            continue
+        if value_token.kind != "NUMBER":
+            invalid_literals.add(keyword)
+            continue
+        value = int(value_token.text)
+        if keyword == "xpos":
+            xpos_value = value
+            xpos_span = (value_token.start, value_token.end)
+        else:
+            ypos_value = value
+            ypos_span = (value_token.start, value_token.end)
+
+    if keyword_counts["id"] != 1:
+        raise EditorSourceError("ID_LITERAL_REQUIRED", "button statement must contain exactly one literal id")
+    if "id" in invalid_literals or widget_id is None:
+        raise EditorSourceError("ID_LITERAL_REQUIRED", "button id must be a literal string")
+    if widget_id != expected_widget_id:
+        raise EditorSourceError("ID_MISMATCH", "literal button id does not match runtime widget id")
+    if keyword_counts["xpos"] != 1:
+        raise EditorSourceError("XPOS_DUPLICATE", "button statement must contain exactly one xpos")
+    if keyword_counts["ypos"] != 1:
+        raise EditorSourceError("YPOS_DUPLICATE", "button statement must contain exactly one ypos")
+    if "xpos" in invalid_literals or xpos_value is None or xpos_span is None:
+        raise EditorSourceError("XPOS_LITERAL_REQUIRED", "button xpos must be a literal integer")
+    if "ypos" in invalid_literals or ypos_value is None or ypos_span is None:
+        raise EditorSourceError("YPOS_LITERAL_REQUIRED", "button ypos must be a literal integer")
+
+    return ButtonStatement(
+        widget_id=widget_id,
+        xpos=xpos_value,
+        ypos=ypos_value,
+        xpos_span=xpos_span,
+        ypos_span=ypos_span,
+        source_line=source_line,
+    )
+
+
+def apply_button_patch(source_bytes: bytes, statement: ButtonStatement, *, x: int, y: int) -> bytes:
+    source_text = source_bytes.decode("utf-8")
+    lines = source_text.splitlines(keepends=True)
+    if statement.source_line < 1 or statement.source_line > len(lines):
+        raise EditorSourceError("SOURCE_LINE_INVALID", "button source line is outside the source file")
+    header_offset = sum(len(line) for line in lines[: statement.source_line - 1])
+    replacements = [
+        (header_offset + statement.xpos_span[0], header_offset + statement.xpos_span[1], str(int(x))),
+        (header_offset + statement.ypos_span[0], header_offset + statement.ypos_span[1], str(int(y))),
+    ]
+    replacements.sort(key=lambda item: item[0], reverse=True)
+    patched = source_text
+    for start, end, replacement in replacements:
+        patched = f"{patched[:start]}{replacement}{patched[end:]}"
+    return patched.encode("utf-8")

--- a/src/renforge/editor/source.py
+++ b/src/renforge/editor/source.py
@@ -150,9 +150,6 @@ def _next_top_level_index(tokens: list[_Token], index: int) -> int | None:
     return None
 
 
-def _next_top_level_token(tokens: list[_Token], index: int) -> _Token | None:
-    found = _next_top_level_index(tokens, index)
-    return None if found is None else tokens[found]
 
 
 def _statement_text(line: str) -> str:
@@ -440,10 +437,11 @@ def analyze_button_statement(
             continue
         keyword = token.text
         keyword_counts[keyword] += 1
-        value_token = _next_top_level_token(tokens, index)
-        if value_token is None:
+        value_index = _next_top_level_index(tokens, index)
+        if value_index is None:
             invalid_literals.add(keyword)
             continue
+        value_token = tokens[value_index]
         if keyword == "id":
             if value_token.kind != "STRING":
                 invalid_literals.add(keyword)
@@ -453,6 +451,16 @@ def analyze_button_statement(
         if value_token.kind != "NUMBER":
             invalid_literals.add(keyword)
             continue
+        following_index = _next_top_level_index(tokens, value_index)
+        if following_index is not None:
+            following_token = tokens[following_index]
+            if following_token.kind != "WORD" and not (
+                following_token.kind == "SYMBOL"
+                and following_token.text == ":"
+                and following_index == len(tokens) - 1
+            ):
+                invalid_literals.add(keyword)
+                continue
         value = int(value_token.text)
         if keyword == "xpos":
             xpos_value = value

--- a/src/renforge/editor_button_runner.py
+++ b/src/renforge/editor_button_runner.py
@@ -1,0 +1,473 @@
+from __future__ import annotations
+
+import hashlib
+import shutil
+import time
+from pathlib import Path
+from typing import Any
+
+from renforge.editor.source import analyze_button_statement
+from renforge.editor_task0_runner import (
+    _require_ok,
+    _source_generation,
+    _wait_for_status,
+)
+
+FIXTURE_SCREEN = "renforge_editor_button_fixture"
+TARGET_ID = "button_target"
+EDITOR_RESOURCE = Path(__file__).resolve().parent / "bridge" / "editor.rpy"
+FIXTURE_RESOURCE = (
+    Path(__file__).resolve().parents[2]
+    / "tests"
+    / "live_fixtures"
+    / "renforge_editor_button_fixture.rpy"
+)
+
+
+def inject_editor_button_resources(project_root: Path) -> dict[str, str]:
+    game_dir = project_root / "game"
+    game_dir.mkdir(parents=True, exist_ok=True)
+    editor_target = game_dir / "zz_renforge_editor_button.rpy"
+    fixture_target = game_dir / "zz_renforge_editor_button_fixture.rpy"
+    shutil.copyfile(EDITOR_RESOURCE, editor_target)
+    shutil.copyfile(FIXTURE_RESOURCE, fixture_target)
+    return {
+        "editor": str(editor_target),
+        "fixture": str(fixture_target),
+    }
+
+
+def _find_element(
+    elements: list[dict[str, Any]],
+    wanted_id: str,
+    *,
+    wanted_text: str | None = None,
+) -> dict[str, Any]:
+    for element in elements:
+        element_id = str(element.get("id") or "")
+        if wanted_text is not None:
+            if element_id == wanted_id and str(element.get("text") or "") == wanted_text:
+                return element
+            continue
+        if element_id == wanted_id:
+            return element
+    raise AssertionError(
+        f"missing expected element id {wanted_id!r} text {wanted_text!r}: {elements!r}"
+    )
+
+
+def _center(bounds: dict[str, Any]) -> tuple[int, int]:
+    return (
+        int(bounds["x"]) + int(bounds["width"]) // 2,
+        int(bounds["y"]) + int(bounds["height"]) // 2,
+    )
+
+
+def _sha256_file(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _wait_bounds(client: Any, widget_id: str, *, timeout: float = 6.0) -> dict[str, int]:
+    deadline = time.monotonic() + timeout
+    last: list[dict[str, Any]] = []
+    while time.monotonic() < deadline:
+        listed = client.list_ui_elements(screen=FIXTURE_SCREEN)
+        last = listed if isinstance(listed, list) else []
+        try:
+            element = _find_element(last, widget_id)
+        except AssertionError:
+            time.sleep(0.05)
+            continue
+        bounds = element.get("bounds")
+        if isinstance(bounds, dict):
+            return {
+                "x": int(bounds["x"]),
+                "y": int(bounds["y"]),
+                "width": int(bounds["width"]),
+                "height": int(bounds["height"]),
+            }
+        time.sleep(0.05)
+    raise AssertionError(f"bounds for {widget_id!r} unavailable: {last!r}")
+
+
+def _target_line_with_offset(source_text: str) -> tuple[str, int, int]:
+    offset = 0
+    for source_line, line in enumerate(source_text.splitlines(keepends=True), start=1):
+        if f'id "{TARGET_ID}"' in line and "button" in line:
+            return line, source_line, offset
+        offset += len(line)
+    raise AssertionError(f"source missing target line for {TARGET_ID!r}")
+
+
+def _child_block_bytes(source_text: str, source_line: int) -> bytes:
+    lines = source_text.splitlines(keepends=True)
+    if source_line < 1 or source_line > len(lines):
+        raise AssertionError(f"invalid button source line: {source_line}")
+    header = lines[source_line - 1]
+    header_indent = len(header) - len(header.lstrip(" \t"))
+    end_line = source_line
+    for index in range(source_line, len(lines)):
+        line = lines[index]
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            end_line = index + 1
+            continue
+        indent = len(line) - len(line.lstrip(" \t"))
+        if indent <= header_indent:
+            end_line = index
+            break
+        end_line = index + 1
+    start_offset = sum(len(line) for line in lines[:source_line])
+    end_offset = sum(len(line) for line in lines[:end_line])
+    return source_text[start_offset:end_offset].encode("utf-8")
+
+
+def _normalize_coordinate_spans(source_text: str) -> bytes:
+    _line, source_line, line_offset = _target_line_with_offset(source_text)
+    statement = analyze_button_statement(
+        source_text,
+        source_line=source_line,
+        expected_widget_id=TARGET_ID,
+    )
+    replacements = [
+        (
+            line_offset + statement.xpos_span[0],
+            line_offset + statement.xpos_span[1],
+            "__RENFORGE_XPOS__",
+        ),
+        (
+            line_offset + statement.ypos_span[0],
+            line_offset + statement.ypos_span[1],
+            "__RENFORGE_YPOS__",
+        ),
+    ]
+    normalized = source_text
+    for start, end, replacement in sorted(replacements, reverse=True):
+        normalized = f"{normalized[:start]}{replacement}{normalized[end:]}"
+    return normalized.encode("utf-8")
+
+
+def _coordinate_spans_are_only_difference(before_text: str, after_text: str) -> bool:
+    return _normalize_coordinate_spans(before_text) == _normalize_coordinate_spans(after_text)
+
+
+def _select_lock(client: Any, widget_id: str, expected_code: str) -> str:
+    bounds = _wait_bounds(client, widget_id)
+    selection = client.request(
+        "editor_task0_select",
+        {"x": _center(bounds)[0], "y": _center(bounds)[1]},
+    )
+    immediate = selection.get("lock_reason") if isinstance(selection, dict) else None
+    if immediate == expected_code:
+        return expected_code
+    status = _wait_for_status(
+        client,
+        lambda current: current.get("selected_widget_id") == widget_id
+        and current.get("selected_lock_reason") == expected_code,
+        timeout=10.0,
+        poll_name=f"{widget_id} lock",
+    )
+    lock_reason = status.get("selected_lock_reason")
+    if lock_reason != expected_code:
+        raise AssertionError(f"unexpected lock for {widget_id!r}: {status!r}")
+    return str(lock_reason)
+
+
+def run_editor_button_live_scenario(client: Any, *, fixture_path: Path) -> dict[str, Any]:
+    """Run the seven-step live proof for the dedicated explicit-block button adapter."""
+    report: dict[str, Any] = {}
+    baseline_bytes = fixture_path.read_bytes()
+    baseline_sha = hashlib.sha256(baseline_bytes).hexdigest()
+    baseline_text = baseline_bytes.decode("utf-8")
+    target_line, target_source_line, _target_offset = _target_line_with_offset(baseline_text)
+    baseline_statement = analyze_button_statement(
+        baseline_text,
+        source_line=target_source_line,
+        expected_widget_id=TARGET_ID,
+    )
+    baseline_child = _child_block_bytes(baseline_text, target_source_line)
+    report["fixture_before"] = {
+        "sha256": baseline_sha,
+        "position": {"x": baseline_statement.xpos, "y": baseline_statement.ypos},
+        "child_sha256": hashlib.sha256(baseline_child).hexdigest(),
+        "source_line": target_source_line,
+        "header": target_line.rstrip("\n"),
+    }
+
+    start = _require_ok(
+        client.request("editor_task0_start", {"screen": FIXTURE_SCREEN}),
+        "editor_task0_start",
+    )
+    report["start"] = start
+
+    target_bounds = _wait_bounds(client, TARGET_ID)
+    bounds_before = [target_bounds["x"], target_bounds["y"]]
+    target_center = _center(target_bounds)
+    select = _require_ok(
+        client.request(
+            "editor_task0_select",
+            {"x": target_center[0], "y": target_center[1]},
+        ),
+        "target select",
+    )
+    observation = select.get("observation") or {}
+    if observation.get("measurement_method") != "focus_list":
+        raise AssertionError(f"select observation not focus_list: {observation!r}")
+
+    analysis_status = _wait_for_status(
+        client,
+        lambda status: bool(status.get("current_analysis_id"))
+        and status.get("selected_widget_id") == TARGET_ID
+        and status.get("selected_lock_reason") in (None, ""),
+        timeout=10.0,
+        poll_name="button analysis",
+    )
+    source_key = analysis_status.get("current_source_key") or {}
+    report["resolve"] = {
+        "statement_kind": source_key.get("statement_kind"),
+        "lock_reason": analysis_status.get("selected_lock_reason"),
+        "move": source_key.get("statement_kind") == "button"
+        and analysis_status.get("selected_lock_reason") in (None, ""),
+        "analysis_id": analysis_status.get("current_analysis_id"),
+        "measurement_method": observation.get("measurement_method"),
+        "source_key": source_key,
+    }
+    if source_key.get("statement_kind") != "button":
+        raise AssertionError(f"expected button statement_kind: {source_key!r}")
+
+    original = analysis_status.get("selected_original_position") or analysis_status.get(
+        "selected_source_position"
+    )
+    if not (isinstance(original, (list, tuple)) and len(original) == 2):
+        original = [baseline_statement.xpos, baseline_statement.ypos]
+    requested_before = [int(original[0]), int(original[1])]
+
+    # Keep the adapter-specific locked cases as live evidence before moving the
+    # editable target. Visible selections are resolved from focus_list bounds.
+    report["locks"] = {
+        "computed": _select_lock(client, "button_computed", "XPOS_LITERAL_REQUIRED"),
+        "position_in_block": _select_lock(client, "button_in_block", "POSITION_IN_BLOCK"),
+        "container": _select_lock(client, "button_container", "CONTAINER_POSITION_UNSUPPORTED"),
+    }
+    dupe_info = client.list_ui_elements_info(screen=FIXTURE_SCREEN)
+    dupe_elements = dupe_info.get("elements") if isinstance(dupe_info, dict) else None
+    dupe = _find_element(
+        dupe_elements if isinstance(dupe_elements, list) else [],
+        "button_dupe_target",
+        wanted_text="DUPE A",
+    )
+    dupe_bounds = dupe.get("bounds")
+    if not isinstance(dupe_bounds, dict):
+        raise AssertionError(f"duplicate button has no focus bounds: {dupe!r}")
+    dupe_select = client.request(
+        "editor_task0_select",
+        {
+            "x": int(dupe_bounds["x"]) + 3,
+            "y": int(dupe_bounds["y"]) + int(dupe_bounds["height"]) - 2,
+        },
+    )
+    ambiguous = dupe_select.get("lock_reason") if isinstance(dupe_select, dict) else None
+    if ambiguous not in {"SYNTHETIC_WIDGET_ID", "MULTI_INSTANCE_UNSUPPORTED"}:
+        raise AssertionError(f"duplicate button was not locked ambiguously: {dupe_select!r}")
+    report["locks"]["ambiguous"] = ambiguous
+
+    unknown = client.request(
+        "editor_task0_validate_runtime_key",
+        {
+            "runtime_key": {
+                "screen": FIXTURE_SCREEN,
+                "invocation_path": [FIXTURE_SCREEN],
+                "widget_id": TARGET_ID,
+                "source_location": ["game/zz_renforge_editor_button_fixture.rpy", target_source_line],
+                "instance_discriminator": {"kind": "static", "instance_count": 1},
+                "ancestry": [
+                    {
+                        "index": 0,
+                        "type": "UnknownWidget",
+                        "source_location": ["game/zz_renforge_editor_button_fixture.rpy", target_source_line],
+                        "screen_owner": "game",
+                        "crop_state": "none",
+                        "editor_owned": False,
+                    }
+                ],
+            }
+        },
+    )
+    report["locks"]["unproven"] = unknown.get("lock_reason")
+
+    # Reselect the proven target after the lock matrix and establish the
+    # preview baseline from a fresh focus_list measurement.
+    target_bounds = _wait_bounds(client, TARGET_ID)
+    target_center = _center(target_bounds)
+    _require_ok(
+        client.request(
+            "editor_task0_select",
+            {"x": target_center[0], "y": target_center[1]},
+        ),
+        "target reselect",
+    )
+    _wait_for_status(
+        client,
+        lambda status: bool(status.get("current_analysis_id"))
+        and status.get("selected_widget_id") == TARGET_ID
+        and status.get("selected_lock_reason") in (None, ""),
+        timeout=10.0,
+        poll_name="button target reanalysis",
+    )
+
+    # Step 2: preview. Nudge only after the selected target has been resolved.
+    _require_ok(client.request("editor_task0_key", {"key": "right", "repeat": 24}), "nudge right")
+    _require_ok(client.request("editor_task0_key", {"key": "down", "repeat": 16}), "nudge down")
+    preview_status = _wait_for_status(
+        client,
+        lambda status: isinstance(status.get("preview_position"), (list, tuple))
+        and len(status.get("preview_position") or []) == 2
+        and list(status.get("preview_position") or []) != requested_before,
+        timeout=8.0,
+        poll_name="button preview moved",
+    )
+    requested_after = [
+        int(preview_status["preview_position"][0]),
+        int(preview_status["preview_position"][1]),
+    ]
+    preview_bounds = _wait_bounds(client, TARGET_ID)
+    bounds_after = [preview_bounds["x"], preview_bounds["y"]]
+    requested_delta = [
+        requested_after[axis] - requested_before[axis]
+        for axis in (0, 1)
+    ]
+    observed_delta = [
+        bounds_after[axis] - bounds_before[axis]
+        for axis in (0, 1)
+    ]
+    if any(abs(observed_delta[axis] - requested_delta[axis]) > 1 for axis in (0, 1)):
+        raise AssertionError(
+            "focus_list preview bounds disagree with requested movement: "
+            f"requested={requested_delta!r}, observed={observed_delta!r}"
+        )
+    report["preview"] = {
+        "bounds_before": bounds_before,
+        "bounds_after": bounds_after,
+        "requested_before": requested_before,
+        "requested_after": requested_after,
+        "requested_delta": requested_delta,
+        "observed_delta": observed_delta,
+        "measurement_method": "focus_list",
+    }
+
+    # Step 3: patch. Capture source bytes before the save boundary.
+    pre_save_bytes = fixture_path.read_bytes()
+    pre_save_sha = hashlib.sha256(pre_save_bytes).hexdigest()
+    pre_save_text = pre_save_bytes.decode("utf-8")
+    pre_save_child = _child_block_bytes(pre_save_text, target_source_line)
+    generation_before = _source_generation(analysis_status)
+    save_request = _require_ok(
+        client.click_element(id="rf_save", screen="_renforge_editor_overlay"),
+        "button save",
+    )
+    save_status = _wait_for_status(
+        client,
+        lambda status: not bool(status.get("save_in_progress"))
+        and status.get("status_text") == "Reload committed"
+        and _source_generation(status) == generation_before + 1,
+        timeout=60.0,
+        poll_name="button save complete",
+    )
+    post_save_bytes = fixture_path.read_bytes()
+    post_save_sha = hashlib.sha256(post_save_bytes).hexdigest()
+    post_save_text = post_save_bytes.decode("utf-8")
+    post_line, post_source_line, _post_offset = _target_line_with_offset(post_save_text)
+    parsed_after = analyze_button_statement(
+        post_save_text,
+        source_line=post_source_line,
+        expected_widget_id=TARGET_ID,
+    )
+    source_position_after = {"x": parsed_after.xpos, "y": parsed_after.ypos}
+    expected_source_position = {"x": requested_after[0], "y": requested_after[1]}
+    if source_position_after != expected_source_position:
+        raise AssertionError(
+            "source patch disagrees with requested preview position: "
+            f"expected={expected_source_position!r}, observed={source_position_after!r}"
+        )
+    outside_coordinate_spans_identical = _coordinate_spans_are_only_difference(
+        pre_save_text,
+        post_save_text,
+    )
+    if not outside_coordinate_spans_identical:
+        raise AssertionError("source patch changed bytes outside xpos/ypos spans")
+    post_save_child = _child_block_bytes(post_save_text, post_source_line)
+    report["patch"] = {
+        "before_sha256": pre_save_sha,
+        "after_sha256": post_save_sha,
+        "source_position_after": source_position_after,
+        "parsed_after": {"xpos": parsed_after.xpos, "ypos": parsed_after.ypos},
+        "outside_coordinate_spans_identical": outside_coordinate_spans_identical,
+        "child_bytes_identical": post_save_child == pre_save_child,
+        "child_sha256_before": hashlib.sha256(pre_save_child).hexdigest(),
+        "child_sha256_after": hashlib.sha256(post_save_child).hexdigest(),
+        "header_after": post_line.rstrip("\n"),
+        "save_request": save_request,
+    }
+    if post_save_child != pre_save_child:
+        raise AssertionError("button child block changed during patch")
+
+    # Step 4: reload.
+    report["reload"] = {
+        "ok": True,
+        "script_generation": _source_generation(save_status),
+        "status_text": save_status.get("status_text"),
+        "generation_delta": _source_generation(save_status) - generation_before,
+    }
+
+    # Step 5: pixel agreement, again using fresh focus_list bounds.
+    successor = _wait_for_status(
+        client,
+        lambda status: bool(status.get("current_analysis_id"))
+        and status.get("selected_widget_id") == TARGET_ID
+        and status.get("selected_lock_reason") in (None, ""),
+        timeout=10.0,
+        poll_name="button post-save rebind analysis",
+    )
+    post_bounds = _wait_bounds(client, TARGET_ID)
+    expected = [source_position_after["x"], source_position_after["y"]]
+    observed = [post_bounds["x"], post_bounds["y"]]
+    delta = [observed[0] - expected[0], observed[1] - expected[1]]
+    report["pixel_agreement"] = {
+        "expected": expected,
+        "observed": observed,
+        "delta": delta,
+        "measurement_method": "focus_list",
+    }
+
+    # Step 6: the reload must bind a new analysis to the same source identity.
+    report["rebinding"] = {
+        "ok": successor.get("selected_widget_id") == TARGET_ID
+        and successor.get("current_analysis_id") not in (None, analysis_status.get("current_analysis_id")),
+        "widget_id": successor.get("selected_widget_id"),
+        "analysis_id": successor.get("current_analysis_id"),
+        "previous_analysis_id": analysis_status.get("current_analysis_id"),
+        "source_key": successor.get("current_source_key"),
+    }
+
+    # Step 7: restore the exact baseline bytes and prove both whole-file and
+    # child-block identity. The running session is intentionally left alone;
+    # the next isolated live run starts from the restored fixture.
+    fixture_path.write_bytes(baseline_bytes)
+    restored_bytes = fixture_path.read_bytes()
+    restored_text = restored_bytes.decode("utf-8")
+    restored_line, restored_source_line, _restored_offset = _target_line_with_offset(restored_text)
+    restored_child = _child_block_bytes(restored_text, restored_source_line)
+    restored_sha = _sha256_file(fixture_path)
+    report["byte_identical_undo"] = {
+        "baseline_sha256": baseline_sha,
+        "restored_sha256": restored_sha,
+        "matches_baseline": restored_sha == baseline_sha,
+        "patched_differed": post_save_sha != baseline_sha,
+        "child_matches_baseline": restored_child == baseline_child,
+        "child_sha256_baseline": hashlib.sha256(baseline_child).hexdigest(),
+        "child_sha256_restored": hashlib.sha256(restored_child).hexdigest(),
+        "header_restored": restored_line.rstrip("\n"),
+    }
+    if restored_bytes != baseline_bytes or restored_child != baseline_child:
+        raise AssertionError("button byte-identical undo did not restore the baseline")
+    return report

--- a/tests/live_fixtures/renforge_editor_button_fixture.rpy
+++ b/tests/live_fixtures/renforge_editor_button_fixture.rpy
@@ -1,0 +1,44 @@
+default renforge_editor_button_computed_x = 520
+
+
+screen renforge_editor_button_dupe(label_text, left_x):
+    button id "button_dupe_target" xpos left_x ypos 430:
+        text label_text
+        action NullAction()
+
+
+screen renforge_editor_button_fixture():
+    layer "screens"
+    zorder 640
+
+    fixed:
+        id "button_root"
+        xfill True
+        yfill True
+
+        button id "button_target" xpos 200 ypos 180:
+            text "BUTTON TARGET" xpos 7
+            action NullAction()
+
+        button id "button_computed" xpos renforge_editor_button_computed_x ypos 300:
+            text "COMPUTED"
+            action NullAction()
+
+        button id "button_in_block":
+            xpos 720
+            ypos 300
+            text "POSITION IN BLOCK"
+            action NullAction()
+
+        vbox:
+            id "button_container_parent"
+            xpos 900
+            ypos 120
+            spacing 12
+
+            button id "button_container" xpos 0 ypos 0:
+                text "CONTAINER"
+                action NullAction()
+
+        use renforge_editor_button_dupe("DUPE A", 520)
+        use renforge_editor_button_dupe("DUPE B", 720)

--- a/tests/test_bridge_runtime.py
+++ b/tests/test_bridge_runtime.py
@@ -760,6 +760,212 @@ def test_dispatch_mouse_click_uses_focused_displayable_local_coordinates(running
     assert seen == [(30, 50, 0), (30, 50, 0)]
 
 
+def test_editor_reactivation_does_not_restore_a_previous_game_screen(
+    running_bridge, monkeypatch
+):
+    renpy = running_bridge.renpy
+    globs = running_bridge.globs
+    for name, value in (
+        ("RENFORGE_EDITOR_HOST", "127.0.0.1"),
+        ("RENFORGE_EDITOR_PORT", "12345"),
+        ("RENFORGE_EDITOR_TOKEN", "editor-token"),
+        ("RENFORGE_EDITOR_PROTOCOL", "1"),
+    ):
+        monkeypatch.setenv(name, value)
+
+    active_screens = {"page_a", "_renforge_editor_overlay"}
+    shown_screens = []
+    renpy.config.after_load_callbacks = []
+    renpy.Displayable = object
+    renpy.Render = lambda width, height: types.SimpleNamespace(
+        width=width, height=height
+    )
+    renpy.IgnoreEvent = type("IgnoreEvent", (Exception,), {})
+    renpy.session = {}
+    renpy.get_screen = lambda name: object() if name in active_screens else None
+
+    def show_screen(name, **_kwargs):
+        shown_screens.append(name)
+        active_screens.add(name)
+
+    renpy.show_screen = show_screen
+    renpy.hide_screen = lambda name, **_kwargs: active_screens.discard(name)
+
+    exec(compile(_load_editor_body(), "editor.rpy", "exec"), globs)
+    try:
+        state = globs["_renforge_editor_state"]()
+        state.active = True
+        state.screen = "page_a"
+        state.editor_session_screen = "page_a"
+
+        globs["_renforge_editor_exit"]()
+        active_screens.discard("page_a")
+        active_screens.add("page_b")
+        assert globs["_renforge_editor_activate"]()["ok"] is True
+        globs["_renforge_editor_periodic"]()
+
+        assert "page_b" in active_screens
+        assert "page_a" not in active_screens
+        assert "page_a" not in shown_screens
+    finally:
+        globs["_renforge_editor_stop_coordinator"]()
+
+
+def test_editor_periodic_restores_active_session_after_reload(
+    running_bridge, monkeypatch
+):
+    renpy = running_bridge.renpy
+    globs = running_bridge.globs
+    for name in (
+        "RENFORGE_EDITOR_HOST",
+        "RENFORGE_EDITOR_PORT",
+        "RENFORGE_EDITOR_TOKEN",
+        "RENFORGE_EDITOR_PROTOCOL",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+    active_screens = set()
+    shown_screens = []
+    renpy.config.after_load_callbacks = []
+    renpy.Displayable = object
+    renpy.Render = lambda width, height: types.SimpleNamespace(
+        width=width, height=height
+    )
+    renpy.IgnoreEvent = type("IgnoreEvent", (Exception,), {})
+    renpy.session = {}
+    renpy.get_screen = lambda name: object() if name in active_screens else None
+
+    def show_screen(name, **_kwargs):
+        shown_screens.append(name)
+        active_screens.add(name)
+
+    renpy.show_screen = show_screen
+    renpy.hide_screen = lambda name, **_kwargs: active_screens.discard(name)
+
+    exec(compile(_load_editor_body(), "editor.rpy", "exec"), globs)
+    try:
+        state = globs["_renforge_editor_state"]()
+        state.active = True
+        state.screen = "page_a"
+        state.editor_session_screen = "page_a"
+        state.save_in_progress = True
+
+        globs["_renforge_editor_periodic"]()
+
+        assert shown_screens == ["page_a", "_renforge_editor_overlay"]
+        assert active_screens == {"page_a", "_renforge_editor_overlay"}
+    finally:
+        globs["_renforge_editor_stop_coordinator"]()
+
+
+def test_editor_exit_reverts_unsaved_previews_before_clearing_state(
+    running_bridge, monkeypatch
+):
+    renpy = running_bridge.renpy
+    globs = running_bridge.globs
+    for name in (
+        "RENFORGE_EDITOR_HOST",
+        "RENFORGE_EDITOR_PORT",
+        "RENFORGE_EDITOR_TOKEN",
+        "RENFORGE_EDITOR_PROTOCOL",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+    active_screens = {"page_a", "_renforge_editor_overlay"}
+    shown_screens = []
+    renpy.config.after_load_callbacks = []
+    renpy.Displayable = object
+    renpy.Render = lambda width, height: types.SimpleNamespace(
+        width=width, height=height
+    )
+    renpy.IgnoreEvent = type("IgnoreEvent", (Exception,), {})
+    renpy.get_screen = lambda name: object() if name in active_screens else None
+
+    def show_screen(name, **kwargs):
+        shown_screens.append((name, kwargs))
+        active_screens.add(name)
+
+    renpy.show_screen = show_screen
+    renpy.hide_screen = lambda name, **_kwargs: active_screens.discard(name)
+
+    exec(compile(_load_editor_body(), "editor.rpy", "exec"), globs)
+    try:
+        state = globs["_renforge_editor_state"]()
+        state.active = True
+        state.screen = "page_a"
+        state.editor_session_screen = "page_a"
+        state.targets["target"] = {
+            "screen": "page_a",
+            "widget_id": "choice",
+            "runtime_baseline": [100, 200],
+            "source_position": [100, 200],
+            "position": [140, 230],
+            "dirty": True,
+        }
+
+        result = globs["_renforge_editor_exit"]()
+
+        assert result == {"ok": True, "active": False}
+        assert shown_screens == [("page_a", {"_layer": "screens"})]
+        assert state.targets == {}
+        assert state.history_entries == []
+    finally:
+        globs["_renforge_editor_stop_coordinator"]()
+
+
+def test_editor_exit_during_save_preserves_transaction_state(
+    running_bridge, monkeypatch
+):
+    renpy = running_bridge.renpy
+    globs = running_bridge.globs
+    for name in (
+        "RENFORGE_EDITOR_HOST",
+        "RENFORGE_EDITOR_PORT",
+        "RENFORGE_EDITOR_TOKEN",
+        "RENFORGE_EDITOR_PROTOCOL",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+    active_screens = {"page_a", "_renforge_editor_overlay"}
+    renpy.config.after_load_callbacks = []
+    renpy.Displayable = object
+    renpy.Render = lambda width, height: types.SimpleNamespace(
+        width=width, height=height
+    )
+    renpy.IgnoreEvent = type("IgnoreEvent", (Exception,), {})
+    renpy.get_screen = lambda name: object() if name in active_screens else None
+    renpy.show_screen = lambda name, **_kwargs: active_screens.add(name)
+    renpy.hide_screen = lambda name, **_kwargs: active_screens.discard(name)
+
+    exec(compile(_load_editor_body(), "editor.rpy", "exec"), globs)
+    try:
+        state = globs["_renforge_editor_state"]()
+        state.active = True
+        state.screen = "page_a"
+        state.editor_session_screen = "page_a"
+        state.save_in_progress = True
+        state.pending_transaction_id = "transaction-1"
+        state.pending_commit_request_id = 41
+        state.pending_reload_requested = True
+        state.pending_handshake_generation = 7
+
+        globs["pygame"].K_ESCAPE = 27
+        result = globs["_renforge_editor_h_key"]({"key": "escape"})
+
+        assert result == {"ok": False, "error": "SAVE_IN_PROGRESS", "active": True}
+        assert state.active is True
+        assert state.screen == "page_a"
+        assert state.editor_session_screen == "page_a"
+        assert state.save_in_progress is True
+        assert state.pending_transaction_id == "transaction-1"
+        assert state.pending_commit_request_id == 41
+        assert state.pending_reload_requested is True
+        assert state.pending_handshake_generation == 7
+        assert "_renforge_editor_overlay" in active_screens
+    finally:
+        globs["_renforge_editor_stop_coordinator"]()
+
+
 def test_editor_mouse_up_applies_final_drag_position_without_motion(
     running_bridge, monkeypatch
 ):

--- a/tests/test_editor_button_live.py
+++ b/tests/test_editor_button_live.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import os
+import shutil
+import time
+from pathlib import Path
+
+import pytest
+
+from renforge.editor_button_runner import (
+    FIXTURE_SCREEN,
+    inject_editor_button_resources,
+    run_editor_button_live_scenario,
+)
+
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("RENFORGE_BUTTON_LIVE"),
+    reason="set RENFORGE_BUTTON_LIVE=1 to run button seven-step live proof",
+)
+
+_DEMO = Path(__file__).resolve().parents[1] / "examples" / "demo_game"
+
+
+@pytest.fixture
+def demo_copy(tmp_path: Path) -> Path:
+    destination = tmp_path / "demo"
+    shutil.copytree(_DEMO, destination, ignore=shutil.ignore_patterns("*.rpyc", "cache"))
+    inject_editor_button_resources(destination)
+    return destination
+
+
+def test_button_seven_step_live_proof(demo_copy: Path) -> None:
+    from renforge.bridge.launcher import launch_with_bridge
+    from renforge.project import RenpyProject
+    from renforge.sdk import get_or_install_sdk
+
+    sdk = get_or_install_sdk("8.5.3", project_root=demo_copy)
+    project = RenpyProject(demo_copy)
+    fixture_path = demo_copy / "game" / "zz_renforge_editor_button_fixture.rpy"
+
+    with launch_with_bridge(
+        sdk,
+        project,
+        startup_timeout=120,
+        editor=True,
+    ) as session:
+        for _ in range(40):
+            launcher = session.client.inspect_screen("_renforge_editor_launcher")
+            if launcher.get("active") is True:
+                break
+            time.sleep(0.25)
+        else:
+            pytest.fail("editor launcher never became active")
+
+        launcher_click = session.client.click_element(
+            text="RF",
+            exact=True,
+            screen="_renforge_editor_launcher",
+        )
+        assert launcher_click.get("ok") is True, launcher_click
+        for _ in range(40):
+            overlay = session.client.inspect_screen("_renforge_editor_overlay")
+            if overlay.get("active") is True:
+                break
+            time.sleep(0.05)
+        else:
+            pytest.fail("editor overlay never became active")
+
+        for _ in range(20):
+            available = session.client.eval_expr(f'renpy.has_screen("{FIXTURE_SCREEN}")')
+            if available is True:
+                break
+            time.sleep(0.1)
+        else:
+            pytest.fail("button fixture screen never became available")
+
+        report = run_editor_button_live_scenario(
+            session.client,
+            fixture_path=fixture_path,
+        )
+
+    assert report["resolve"]["statement_kind"] == "button"
+    assert report["resolve"]["lock_reason"] in (None, "")
+    assert report["resolve"]["move"] is True
+    assert report["resolve"]["measurement_method"] == "focus_list"
+
+    preview = report["preview"]
+    assert preview["bounds_before"] != preview["bounds_after"]
+    assert all(
+        abs(preview["observed_delta"][axis] - preview["requested_delta"][axis]) <= 1
+        for axis in (0, 1)
+    )
+    assert preview["measurement_method"] == "focus_list"
+
+    patch = report["patch"]
+    assert patch["outside_coordinate_spans_identical"] is True
+    assert patch["child_bytes_identical"] is True
+    assert patch["after_sha256"] != patch["before_sha256"]
+    assert patch["source_position_after"] == {
+        "x": preview["requested_after"][0],
+        "y": preview["requested_after"][1],
+    }
+    assert patch["parsed_after"]["xpos"] == patch["source_position_after"]["x"]
+    assert patch["parsed_after"]["ypos"] == patch["source_position_after"]["y"]
+
+    assert report["reload"]["ok"] is True
+    assert report["reload"]["status_text"] == "Reload committed"
+    assert report["reload"]["generation_delta"] == 1
+
+    assert all(abs(int(value)) <= 1 for value in report["pixel_agreement"]["delta"])
+    assert report["pixel_agreement"]["measurement_method"] == "focus_list"
+    assert report["rebinding"]["ok"] is True
+    assert report["rebinding"]["widget_id"] == "button_target"
+
+    locks = report["locks"]
+    assert locks["computed"] == "XPOS_LITERAL_REQUIRED"
+    assert locks["position_in_block"] == "POSITION_IN_BLOCK"
+    assert locks["container"] == "CONTAINER_POSITION_UNSUPPORTED"
+    assert locks["ambiguous"] in {"SYNTHETIC_WIDGET_ID", "MULTI_INSTANCE_UNSUPPORTED"}
+    assert locks["unproven"] == "UNKNOWN_ANCESTRY_TYPE"
+
+    undo = report["byte_identical_undo"]
+    assert undo["matches_baseline"] is True
+    assert undo["patched_differed"] is True
+    assert undo["child_matches_baseline"] is True

--- a/tests/test_editor_coordinator.py
+++ b/tests/test_editor_coordinator.py
@@ -291,6 +291,18 @@ def test_analyze_target_returns_lock_reasons_for_runtime_denials(tmp_path: Path)
 
             cases = [
                 (
+                    "layout-container",
+                    lambda o: o["runtime_key"]["ancestry"].insert(
+                        1,
+                        {
+                            **o["runtime_key"]["ancestry"][1],
+                            "type": "MultiBox",
+                            "layout": "vertical",
+                        },
+                    ),
+                    "CONTAINER_POSITION_UNSUPPORTED",
+                ),
+                (
                     "unknown-ancestor-type",
                     lambda o: o["runtime_key"]["ancestry"].__setitem__(
                         1,
@@ -391,6 +403,49 @@ def test_analyze_target_normalizes_game_prefixed_source_location(tmp_path: Path)
             assert reply["result"]["original_position"] == [12, 10]
             for ancestor in source_key["ancestry"]:
                 assert ancestor["source_location"][0] == "script.rpy"
+    finally:
+        coordinator.close()
+
+
+def test_button_statement_dispatches_through_analyze_and_commit(tmp_path: Path) -> None:
+    project, source = _make_project(tmp_path)
+    source.write_text(
+        "screen test_screen:\n"
+        '    button id "button_target" xpos 12 ypos 10:\n'
+        '        text "Child content" xpos 7\n'
+        "        action NullAction()\n",
+        encoding="utf-8",
+    )
+    observation = _base_observation()
+    observation["runtime_key"]["widget_id"] = "button_target"
+    observation["rect"] = [12, 10, 120, 40]
+    probe = _Probe(
+        observe_reply={
+            **json.loads(json.dumps(observation)),
+            "frame_id": "independent-button-frame",
+            "object_id": "obj-independent-button",
+        }
+    )
+    coordinator = EditorCoordinator(project, _make_sdk(tmp_path))
+    coordinator.attach_runtime_probe(probe)
+    endpoint = coordinator.start()
+    try:
+        with socket.create_connection((endpoint.host, endpoint.port), timeout=2.0) as sock:
+            auth = _auth(sock, endpoint)
+            analysis = _analyze(sock, auth, observation, request_id="an-button")
+            assert analysis["ok"] is True
+            assert analysis["result"]["lock_reason"] is None
+            assert analysis["result"]["original_position"] == [12, 10]
+            assert analysis["result"]["source_key"]["statement_kind"] == "button"
+
+            commit = _commit(sock, auth, analysis, x=333, y=444, request_id="co-button")
+            assert commit["ok"] is True
+            assert source.read_text(encoding="utf-8") == (
+                "screen test_screen:\n"
+                '    button id "button_target" xpos 333 ypos 444:\n'
+                '        text "Child content" xpos 7\n'
+                "        action NullAction()\n"
+            )
     finally:
         coordinator.close()
 

--- a/tests/test_editor_source.py
+++ b/tests/test_editor_source.py
@@ -6,10 +6,13 @@ import pytest
 
 from renforge.editor.paths import EditorPathError, resolve_game_path
 from renforge.editor.source import (
+    ButtonStatement,
     EditorSourceError,
+    analyze_button_statement,
     analyze_editable_statement,
     analyze_imagebutton_statement,
     analyze_textbutton_statement,
+    apply_button_patch,
     apply_editable_statement_patch,
     apply_imagebutton_patch,
     apply_textbutton_patch,
@@ -228,3 +231,70 @@ def test_analyze_editable_statement_reports_missing_statement_kind() -> None:
     with pytest.raises(EditorSourceError, match="does not contain a supported statement kind") as excinfo:
         analyze_editable_statement("    # comment only\n", expected_widget_id="start")
     assert excinfo.value.code == "STATEMENT_KIND_MISMATCH"
+def test_analyze_button_statement_patches_header_only_and_preserves_child_bytes() -> None:
+    source = (
+        "screen test_screen:\n"
+        '    button id "button_target" xpos 120 ypos 80:\n'
+        '        text "Keep this child block byte-for-byte" xpos 7\n'
+        "        action NullAction()\n"
+    )
+
+    parsed = analyze_button_statement(
+        source,
+        source_line=2,
+        expected_widget_id="button_target",
+    )
+
+    assert isinstance(parsed, ButtonStatement)
+    assert parsed.widget_id == "button_target"
+    assert parsed.xpos == 120
+    assert parsed.ypos == 80
+
+    patched = apply_button_patch(source.encode("utf-8"), parsed, x=301, y=409).decode("utf-8")
+
+    assert patched == (
+        "screen test_screen:\n"
+        '    button id "button_target" xpos 301 ypos 409:\n'
+        '        text "Keep this child block byte-for-byte" xpos 7\n'
+        "        action NullAction()\n"
+    )
+    assert patched.splitlines(keepends=True)[2:] == source.splitlines(keepends=True)[2:]
+
+
+def test_analyze_button_statement_locks_coordinates_inside_child_block() -> None:
+    source = (
+        "screen test_screen:\n"
+        '    button id "button_target":\n'
+        "        xpos 120\n"
+        "        ypos 80\n"
+        '        text "Child"\n'
+    )
+
+    with pytest.raises(EditorSourceError) as exc_info:
+        analyze_button_statement(
+            source,
+            source_line=2,
+            expected_widget_id="button_target",
+        )
+
+    assert exc_info.value.code == "POSITION_IN_BLOCK"
+
+
+def test_analyze_button_statement_requires_literal_header_coordinates_and_child_block() -> None:
+    computed = (
+        "screen test_screen:\n"
+        '    button id "button_target" xpos base_x ypos 80:\n'
+        '        text "Child"\n'
+    )
+    with pytest.raises(EditorSourceError) as exc_info:
+        analyze_button_statement(computed, source_line=2, expected_widget_id="button_target")
+    assert exc_info.value.code == "XPOS_LITERAL_REQUIRED"
+
+    without_child = (
+        "screen test_screen:\n"
+        '    button id "button_target" xpos 120 ypos 80:\n'
+        '    text "Sibling"\n'
+    )
+    with pytest.raises(EditorSourceError) as exc_info:
+        analyze_button_statement(without_child, source_line=2, expected_widget_id="button_target")
+    assert exc_info.value.code == "BUTTON_BLOCK_REQUIRED"

--- a/tests/test_editor_source.py
+++ b/tests/test_editor_source.py
@@ -125,6 +125,117 @@ def test_analyze_rejects_compound_numeric_position_expressions() -> None:
     assert excinfo.value.code == "YPOS_LITERAL_REQUIRED"
 
 
+def test_analyze_button_statement_rejects_compound_numeric_position_expressions() -> None:
+    invalid_headers = (
+        (
+            '    button id "button_target" xpos 100-20 ypos 10:\n',
+            "XPOS_LITERAL_REQUIRED",
+        ),
+        (
+            '    button id "button_target" xpos 100 ypos 10+4:\n',
+            "YPOS_LITERAL_REQUIRED",
+        ),
+        (
+            '    button id "button_target" xpos 100.5 ypos 10:\n',
+            "XPOS_LITERAL_REQUIRED",
+        ),
+    )
+    for header, expected_code in invalid_headers:
+        source = "screen test_screen:\n" + header + '        text "Child"\n'
+        with pytest.raises(EditorSourceError) as exc_info:
+            analyze_button_statement(source, source_line=2, expected_widget_id="button_target")
+        assert exc_info.value.code == expected_code
+
+    for header in (
+        '    button id "button_target" xpos 100 ypos 200:\n',
+        '    button id "button_target" xpos 100 ypos 200 :\n',
+    ):
+        source = "screen test_screen:\n" + header + '        text "Child"\n'
+        parsed = analyze_button_statement(source, source_line=2, expected_widget_id="button_target")
+        assert (parsed.xpos, parsed.ypos) == (100, 200)
+
+
+@pytest.mark.parametrize(
+    ("source_line", "header", "expected_widget_id", "expected_code"),
+    (
+        (
+            2,
+            '    text "not_a_button":\n',
+            "not_a_button",
+            "STATEMENT_KIND_MISMATCH",
+        ),
+        (
+            0,
+            '    button id "button_target" xpos 120 ypos 80:\n',
+            "button_target",
+            "SOURCE_LINE_INVALID",
+        ),
+        (
+            10,
+            '    button id "button_target" xpos 120 ypos 80:\n',
+            "button_target",
+            "SOURCE_LINE_INVALID",
+        ),
+        (
+            2,
+            "    button xpos 120 ypos 80:\n",
+            "button_target",
+            "ID_LITERAL_REQUIRED",
+        ),
+        (
+            2,
+            '    button id "first" id "second" xpos 120 ypos 80:\n',
+            "button_target",
+            "ID_LITERAL_REQUIRED",
+        ),
+        (
+            2,
+            "    button id 123 xpos 120 ypos 80:\n",
+            "button_target",
+            "ID_LITERAL_REQUIRED",
+        ),
+        (
+            2,
+            '    button id "actual" xpos 120 ypos 80:\n',
+            "expected",
+            "ID_MISMATCH",
+        ),
+        (
+            2,
+            '    button id "button_target" xpos 10 xpos 20 ypos 80:\n',
+            "button_target",
+            "XPOS_DUPLICATE",
+        ),
+        (
+            2,
+            '    button id "button_target" xpos 10:\n',
+            "button_target",
+            "YPOS_DUPLICATE",
+        ),
+        (
+            2,
+            '    button id "button_target" xpos 10 ypos "not_a_number":\n',
+            "button_target",
+            "YPOS_LITERAL_REQUIRED",
+        ),
+    ),
+)
+def test_analyze_button_statement_rejects_invalid_headers(
+    source_line: int,
+    header: str,
+    expected_widget_id: str,
+    expected_code: str,
+) -> None:
+    source = "screen test_screen:\n" + header + '        text "Child"\n'
+    with pytest.raises(EditorSourceError) as exc_info:
+        analyze_button_statement(
+            source,
+            source_line=source_line,
+            expected_widget_id=expected_widget_id,
+        )
+    assert exc_info.value.code == expected_code
+
+
 def test_peek_statement_kind_reads_first_top_level_word() -> None:
     assert (
         peek_statement_kind(


### PR DESCRIPTION
## Summary

Adds a dedicated Ren'Py `button` adapter for the explicit-block form, with source-safe header patching and a live seven-step proof.

## Motivation and related issue

Fixes #33

The adapter is intentionally separate from `textbutton` and `imagebutton`; it is not enabled by analogy or pattern matching.

## Changes

- Add a dedicated `ButtonStatement` analyzer for `button id "..." xpos N ypos N:` headers.
- Patch only header coordinate spans and preserve child-block bytes exactly.
- Route button analysis and commits through the coordinator with a recorded statement kind.
- Lock computed coordinates, direct child positions, layout-container ancestry, ambiguous instances, and unproven ancestry with exact reasons.
- Add a fixture, unit/coordinator coverage, and an opt-in seven-step live proof.
- Update the V1 adapter allowlist documentation.

## Validation

- `python -m compileall -q src tests`: passed.
- `python -m pytest -q`: 530 passed, 24 skipped.
- `npm --prefix ui run build`: Not applicable; this change does not modify the dashboard.
- Manual/live verification: `RENFORGE_BUTTON_LIVE=1 RENFORGE_IMAGEBUTTON_LIVE=1 pytest tests/test_editor_button_live.py tests/test_editor_imagebutton_live.py -q`: 2 passed.

## User-facing changes

The visual editor can now move supported explicit-block `button` widgets while retaining their child content. Unsupported forms remain selectable but locked with a precise reason.

## Internationalization

- [x] No new user-visible copy; i18n is not applicable.
- [x] `npm --prefix ui run i18n:check` is not applicable.

## Breaking changes

None

## Documentation

Updated `docs/superpowers/specs/2026-07-30-renforge-visual-editor-v1-scope.md` to mark the explicit-block button adapter as shipped in V1.

## Reviewer notes

- The branch was rebased onto current `main` after issue #32 was merged in PR #53.
- #32 and #33 share parser/coordinator files; the rebase resolved that overlap while preserving both dedicated adapter paths and the recorded statement-kind guard.
- Supported source form is `button id "..." xpos N ypos N:` with literal integer coordinates and an explicit child block.
- Computed coordinates, direct child `xpos`/`ypos`, layout containers, ambiguous instances, and unproven ancestry remain locked by design.

## Final checklist

- [x] The PR is focused on one coherent change.
- [x] Tests were added or updated for behavior changes.
- [x] Generated `src/renforge/ui/static/` assets remain untracked; CI and release builds produce them.
- [x] No credentials, tokens, personal paths, or other secrets are included.
- [x] I understand the submitted code and can explain how it works.

## Validation detail

The full suite required a temporary local link to the existing root UI TypeScript dependency for the i18n scanner; the link was removed after verification and no dependency artifact was committed.

## Summary by Sourcery

Ajouter un adaptateur dédié pour les boutons en bloc explicite dans l’éditeur visuel et le raccorder aux flux d’analyse, de verrouillage, de patch et de preuve live.

New Features:
- Prendre en charge le déplacement des widgets Ren'Py `button` en bloc explicite dans l’éditeur visuel tout en préservant leur contenu enfant.
- Introduire un analyseur et un patcheur dédiés pour les en-têtes `button id "..." xpos N ypos N:` acheminés via le coordinateur de l’éditeur.
- Ajouter un runner de preuve live en sept étapes, activable à la demande, ainsi qu’un fixture pour l’adaptateur de bouton.

Enhancements:
- Étendre la logique de verrouillage à l’exécution pour couvrir l’ascendance des conteneurs de mise en page (layout-container) pour les positions de boutons non modifiables.
- Inclure des métadonnées de mise en page dans l’ascendance rapportée par le pont Ren'Py pour les décisions de l’éditeur.

Documentation:
- Mettre à jour la documentation de portée V1 pour marquer l’adaptateur de bouton en bloc explicite comme livré et documenter ses formes prises en charge ainsi que son comportement de verrouillage.

Tests:
- Ajouter des tests unitaires pour l’analyse de la source des boutons et le comportement de patch, y compris les formes verrouillées et invalides.
- Ajouter un test d’intégration live qui exerce l’adaptateur de bouton de bout en bout contre le jeu de démo lorsqu’il est activé via `RENFORGE_BUTTON_LIVE`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a dedicated explicit-block button adapter to the visual editor and wire it through analysis, locking, patching, and live proof flows.

New Features:
- Support moving explicit-block Ren'Py `button` widgets in the visual editor while preserving their child content.
- Introduce a dedicated analyzer and patcher for `button id "..." xpos N ypos N:` headers routed through the editor coordinator.
- Add an opt-in seven-step live proof runner and fixture for the button adapter.

Enhancements:
- Extend runtime lock reasoning to cover layout-container ancestry for non-editable button positions.
- Include layout metadata in ancestry reported from the Ren'Py bridge for editor decisions.

Documentation:
- Update V1 scope documentation to mark the explicit-block button adapter as shipped and document its supported forms and lock behavior.

Tests:
- Add unit tests for button source analysis and patching behavior, including locked and invalid forms.
- Add a live integration test that exercises the button adapter end-to-end against the demo game when enabled via `RENFORGE_BUTTON_LIVE`.

</details>