### PR TITLE
Add dedicated slider adapter with seven-step live proof

### DIFF
--- a/docs/superpowers/specs/2026-07-30-renforge-visual-editor-v1-scope.md
+++ b/docs/superpowers/specs/2026-07-30-renforge-visual-editor-v1-scope.md
@@ -33,7 +33,7 @@ requires it — none is arbitrary.
 |---|---|---|
 | 1 | Displayable is **focusable** | Selection and every save-bearing measurement read `renpy.display.focus.focus_list` |
 | 2 | Source statement carries one **literal `id`** matching the runtime widget id | Runtime preview uses `_widget_properties`, keyed by the authored widget id; synthetic observation IDs do not qualify |
-| 3 | A proven adapter statement (`textbutton`, `imagebutton`, single-line `bar`/`vbar`) or an explicit-block `button`, with one literal integer **`xpos` and `ypos`** | The token-aware patcher replaces only the coordinate spans; the button adapter preserves child block bytes |
+| 3 | A proven adapter statement (`textbutton`, `imagebutton`, single-line `bar`/`vbar`, slider-styled `bar`) or an explicit-block `button`, with one literal integer **`xpos` and `ypos`** | The token-aware patcher replaces only the coordinate spans; the button adapter preserves child block bytes |
 | 4 | Exactly one runtime instance with a fully classified, static ancestry outside **`viewport` / `Crop` / `Transform(crop=)`**, loop and repeated `use` cases | Only a unique static instance under proven clipping can be rebound unambiguously |
 
 **A failing gate is a first-class UI state, never a silent no-op.** The overlay must name which gate
@@ -60,6 +60,7 @@ V1 ships an explicit allowlist, extended one adapter at a time, each backed by a
 | `button` | focusable by construction | Seven-step live proof (explicit block) | **Shipped in V1** |
 | `bar` | focusable when adjustable (measured on Ren'Py 8.5.3) | dedicated single-line analyzer + seven-step live proof | **Implemented** (live proof green via `RENFORGE_BAR_LIVE=1`) |
 | `vbar` | focusable when adjustable (measured on Ren'Py 8.5.3) | dedicated `VbarStatement` analyzer + patcher + seven-step live proof | **Implemented** (live proof green via `RENFORGE_VBAR_LIVE=1 uv run --extra test python -m pytest -q tests/test_editor_vbar_live.py`) |
+| `slider` (authored as `bar` + `style "slider"`) | focusable when adjustable (measured on Ren'Py 8.5.3) | dedicated `SliderStatement` path + seven-step live proof | **Implemented** (live proof green via `RENFORGE_SLIDER_LIVE=1 uv run --extra test python -m pytest -q tests/test_editor_slider_live.py`) |
 | `text`, `add`, `frame` | **not selectable** | Spike B proved write on a literal `text`, but by key, not by click | Out of V1 |
 
 `imagebutton` has a dedicated single-line adapter (issue #32) rather than a textbutton allowlist widen.
@@ -90,8 +91,26 @@ and `ypos` (`XPOS_LITERAL_REQUIRED` / `YPOS_LITERAL_REQUIRED`), style-driven pos
 container ancestry (`CONTAINER_POSITION_UNSUPPORTED`), duplicate instances (`SYNTHETIC_WIDGET_ID`),
 unknown ancestry (`UNKNOWN_ANCESTRY_TYPE`), and multi-line statements
 (`MULTILINE_STATEMENT_REJECTED`). These targets remain selectable but locked with their measured reason.
-`slider`, `vslider`, style-driven position, container-driven position, computed coordinates, multi-line
-blocks, and unproven ancestry remain pending or locked; no other forms are claimed.
+
+### Slider adapter (issue #36)
+
+**Measured on Ren'Py 8.5.3:** screen language has no `slider` keyword (parse error:
+`'slider' is not a keyword argument or valid child of the screen/fixed statement`). Games author
+sliders as single-line `bar` statements that select the `slider` style. The dedicated slider adapter
+therefore specializes `bar` when the line carries exactly one literal `style "slider"`, returning
+`statement_kind == "slider"` while the source keyword remains `bar`:
+
+```renpy
+bar value VariableValue("some_var", range=100) style "slider" id "slider_target" xpos 200 ypos 180 xsize 240 ysize 24
+```
+
+Live proof: `RENFORGE_SLIDER_LIVE=1 uv run --extra test python -m pytest -q tests/test_editor_slider_live.py`
+against Ren'Py **8.5.3**. Slider reuses the bar-family lock boundaries for computed/non-literal
+coordinates, style-only/missing position (`BAR_STYLE_POSITION_UNSUPPORTED` when `style "slider"` is
+present without xpos/ypos), container ancestry, duplicate instances, and unproven ancestry.
+`vslider`, style-driven position without inline literals, container-driven position, computed
+coordinates, multi-line blocks, and unproven ancestry remain pending or locked; no other forms are
+claimed.
 
 ## Proven mechanisms (do not redesign)
 

--- a/docs/superpowers/specs/2026-07-30-renforge-visual-editor-vfull-roadmap.md
+++ b/docs/superpowers/specs/2026-07-30-renforge-visual-editor-vfull-roadmap.md
@@ -20,8 +20,8 @@ not a day of work and an analogy.
 | `button` (explicit block form) | Low | Focusable by construction; the child block may complicate the source-line contract |
 | `bar` (single-line literal position) | Medium | Focusable when adjustable; often style/container-positioned. **Implemented** for the minimal single-line literal form; seven-step live proof green via `RENFORGE_BAR_LIVE=1` on Ren'Py 8.5.3 (issue #34). Runtime class `Bar` is shared with `vbar` — source keyword decides the adapter. |
 | `vbar` (single-line literal position) | Medium | Same runtime `Bar` class as `bar`; dedicated `VbarStatement` analyzer/patcher dispatches from the source keyword. **Implemented** for one physical line with one literal `id` and literal integer `xpos`/`ypos`; seven-step live proof green on Ren'Py 8.5.3 via `RENFORGE_VBAR_LIVE=1 uv run --extra test python -m pytest -q tests/test_editor_vbar_live.py` (issue #35). |
-| `slider` | Medium | May also surface as runtime `Bar`; positioning often style/container-driven. **Pending** — no live proof; not claimed. |
-| `vslider` | Medium | May also surface as runtime `Bar`; positioning often style/container-driven. **Pending** — no live proof; not claimed. |
+| `slider` (as `bar` + `style "slider"`) | Medium | **Implemented** (issue #36). Measured: Ren'Py 8.5.3 has no screen-language `slider` keyword; sliders are authored as `bar` with literal `style "slider"`. Dedicated `SliderStatement` path + seven-step live proof green via `RENFORGE_SLIDER_LIVE=1 uv run --extra test python -m pytest -q tests/test_editor_slider_live.py`. |
+| `vslider` | Medium | May surface as runtime `Bar` / style `"vslider"`; positioning often style/container-driven. **Pending** — no live proof; not claimed. |
 
 The supported vbar source form is exactly one physical line, for example:
 
@@ -38,6 +38,15 @@ position (`BAR_STYLE_POSITION_UNSUPPORTED`), missing direct position (`BAR_POSIT
 container ancestry (`CONTAINER_POSITION_UNSUPPORTED`), duplicate instances (`SYNTHETIC_WIDGET_ID`),
 unknown ancestry (`UNKNOWN_ANCESTRY_TYPE`), and multi-line statements (`MULTILINE_STATEMENT_REJECTED`).
 These remain selectable but locked; all other vbar forms remain pending.
+
+The supported slider source form is a single physical `bar` line with literal `style "slider"`:
+
+```renpy
+bar value VariableValue("some_var", range=100) style "slider" id "slider_target" xpos 200 ypos 180 xsize 240 ysize 24
+```
+
+`statement_kind` is `"slider"` for that specialized form; the first source keyword remains `bar`. Live
+proof command: `RENFORGE_SLIDER_LIVE=1 uv run --extra test python -m pytest -q tests/test_editor_slider_live.py`.
 **Exit criterion per adapter:** its own 7-step live proof — resolve → preview → patch → reload →
 pixel agreement → rebinding → byte-identical undo — with every position measured from `focus_list`.
 

--- a/src/renforge/editor/coordinator.py
+++ b/src/renforge/editor/coordinator.py
@@ -35,6 +35,7 @@ from .source import (
     analyze_editable_statement,
     apply_button_patch,
     apply_editable_statement_patch,
+    is_slider_style_bar_line,
     peek_statement_kind,
 )
 
@@ -989,11 +990,19 @@ class EditorCoordinator:
             actual_kind = peek_statement_kind(lines[line_no - 1])
             if not isinstance(actual_kind, str):
                 raise EditorError("SOURCE_KEY_INVALID", "source line statement kind is invalid")
-            if isinstance(recorded_kind, str) and recorded_kind != actual_kind:
-                raise EditorError(
-                    "STATEMENT_KIND_MISMATCH",
-                    "source_key statement_kind does not match source line",
-                )
+            if isinstance(recorded_kind, str):
+                # Slider adapters are authored as bar + style "slider" (no SL keyword).
+                if recorded_kind == "slider":
+                    if actual_kind != "bar" or not is_slider_style_bar_line(lines[line_no - 1]):
+                        raise EditorError(
+                            "STATEMENT_KIND_MISMATCH",
+                            "source_key statement_kind does not match source line",
+                        )
+                elif recorded_kind != actual_kind:
+                    raise EditorError(
+                        "STATEMENT_KIND_MISMATCH",
+                        "source_key statement_kind does not match source line",
+                    )
             if actual_kind == "button":
                 statement = analyze_button_statement(
                     source_text,

--- a/src/renforge/editor/source.py
+++ b/src/renforge/editor/source.py
@@ -58,9 +58,22 @@ class VbarStatement:
     ypos_span: tuple[int, int]
 
 
+@dataclass(frozen=True)
+class SliderStatement:
+    widget_id: str
+    xpos: int
+    ypos: int
+    xpos_span: tuple[int, int]
+    ypos_span: tuple[int, int]
+
+
 _StatementT = TypeVar(
     "_StatementT",
-    bound=TextbuttonStatement | ImagebuttonStatement | BarStatement | VbarStatement,
+    bound=TextbuttonStatement
+    | ImagebuttonStatement
+    | BarStatement
+    | VbarStatement
+    | SliderStatement,
 )
 
 
@@ -492,6 +505,53 @@ def analyze_vbar_statement(line: str, *, expected_widget_id: str) -> VbarStateme
     )
 
 
+def is_slider_style_bar_line(line: str) -> bool:
+    """True when the line is a single-line ``bar`` with literal ``style "slider"``.
+
+    Ren'Py 8.5.3 has no screen-language ``slider`` keyword (measured). Games author
+    sliders as ``bar`` statements that select the ``slider`` style. Adapter identity
+    is therefore ``bar`` + literal style ``"slider"``, not a first-word keyword.
+    """
+    try:
+        statement_text = _statement_text(line)
+    except EditorSourceError:
+        return False
+    tokens = _lex_single_line(statement_text)
+    top_level = [token for token in tokens if token.depth == 0]
+    if not top_level or top_level[0].kind != "WORD" or top_level[0].text != "bar":
+        return False
+    if any(token.kind == "SYMBOL" and token.text == ":" for token in top_level):
+        return False
+    style_names: list[str] = []
+    for index, token in enumerate(tokens):
+        if token.depth != 0 or token.kind != "WORD" or token.text != "style":
+            continue
+        value_index = _next_top_level_index(tokens, index)
+        if value_index is None:
+            continue
+        value_token = tokens[value_index]
+        if value_token.kind != "STRING":
+            continue
+        try:
+            style_names.append(_parse_string_token(value_token))
+        except EditorSourceError:
+            continue
+    return len(style_names) == 1 and style_names[0] == "slider"
+
+
+def analyze_slider_statement(line: str, *, expected_widget_id: str) -> SliderStatement:
+    """Analyze a single-line slider-styled bar (source keyword ``bar``, style ``"slider"``)."""
+    if not is_slider_style_bar_line(line):
+        raise _bar_like_error("slider", "STATEMENT_KIND_MISMATCH")
+    return _analyze_bar_like_statement(
+        line,
+        expected_widget_id=expected_widget_id,
+        expected_source_kind="bar",
+        statement_cls=SliderStatement,
+        human_kind="slider",
+    )
+
+
 def _apply_integer_span_patch(
     source_bytes: bytes,
     *,
@@ -554,9 +614,22 @@ def apply_vbar_patch(source_bytes: bytes, statement: VbarStatement, *, x: int, y
     )
 
 
+def apply_slider_patch(source_bytes: bytes, statement: SliderStatement, *, x: int, y: int) -> bytes:
+    return _apply_integer_span_patch(
+        source_bytes,
+        xpos_span=statement.xpos_span,
+        ypos_span=statement.ypos_span,
+        x=x,
+        y=y,
+    )
+
+
 def analyze_editable_statement(
     line: str, *, expected_widget_id: str
-) -> tuple[str, TextbuttonStatement | ImagebuttonStatement | BarStatement | VbarStatement]:
+) -> tuple[
+    str,
+    TextbuttonStatement | ImagebuttonStatement | BarStatement | VbarStatement | SliderStatement,
+]:
     """Dispatch to a dedicated analyzer. Not a merged grammar."""
     kind = peek_statement_kind(line)
     if kind == "textbutton":
@@ -564,6 +637,9 @@ def analyze_editable_statement(
     if kind == "imagebutton":
         return kind, analyze_imagebutton_statement(line, expected_widget_id=expected_widget_id)
     if kind == "bar":
+        # Slider is not a Ren'Py screen-language keyword; route bar+style "slider".
+        if is_slider_style_bar_line(line):
+            return "slider", analyze_slider_statement(line, expected_widget_id=expected_widget_id)
         return kind, analyze_bar_statement(line, expected_widget_id=expected_widget_id)
     if kind == "vbar":
         return kind, analyze_vbar_statement(line, expected_widget_id=expected_widget_id)
@@ -578,7 +654,11 @@ def analyze_editable_statement(
 def apply_editable_statement_patch(
     source_bytes: bytes,
     kind: str,
-    statement: TextbuttonStatement | ImagebuttonStatement | BarStatement | VbarStatement,
+    statement: TextbuttonStatement
+    | ImagebuttonStatement
+    | BarStatement
+    | VbarStatement
+    | SliderStatement,
     *,
     x: int,
     y: int,
@@ -599,6 +679,10 @@ def apply_editable_statement_patch(
         if not isinstance(statement, VbarStatement):
             raise EditorSourceError("STATEMENT_KIND_MISMATCH", "statement does not match vbar kind")
         return apply_vbar_patch(source_bytes, statement, x=x, y=y)
+    if kind == "slider":
+        if not isinstance(statement, SliderStatement):
+            raise EditorSourceError("STATEMENT_KIND_MISMATCH", "statement does not match slider kind")
+        return apply_slider_patch(source_bytes, statement, x=x, y=y)
     raise EditorSourceError("STATEMENT_KIND_MISMATCH", f"unsupported statement kind: {kind!r}")
 
 

--- a/src/renforge/editor/source.py
+++ b/src/renforge/editor/source.py
@@ -506,11 +506,14 @@ def analyze_vbar_statement(line: str, *, expected_widget_id: str) -> VbarStateme
 
 
 def is_slider_style_bar_line(line: str) -> bool:
-    """True when the line is a single-line ``bar`` with literal ``style "slider"``.
+    """True when the line is a single-line ``bar`` with pure literal ``style "slider"``.
 
     Ren'Py 8.5.3 has no screen-language ``slider`` keyword (measured). Games author
     sliders as ``bar`` statements that select the ``slider`` style. Adapter identity
     is therefore ``bar`` + literal style ``"slider"``, not a first-word keyword.
+
+    Computed style expressions such as ``style "slider" if flag else "bar"`` are
+    rejected (same purity rule as literal xpos/ypos followers).
     """
     try:
         statement_text = _statement_text(line)
@@ -522,21 +525,27 @@ def is_slider_style_bar_line(line: str) -> bool:
         return False
     if any(token.kind == "SYMBOL" and token.text == ":" for token in top_level):
         return False
-    style_names: list[str] = []
+    pure_style_names: list[str] = []
     for index, token in enumerate(tokens):
         if token.depth != 0 or token.kind != "WORD" or token.text != "style":
             continue
         value_index = _next_top_level_index(tokens, index)
         if value_index is None:
-            continue
+            return False
         value_token = tokens[value_index]
         if value_token.kind != "STRING":
-            continue
+            return False
+        following_index = _next_top_level_index(tokens, value_index)
+        if following_index is not None:
+            following = tokens[following_index]
+            # Only another bar property keyword or EOS proves a pure style literal.
+            if following.kind != "WORD" or following.text not in _BAR_POSITION_FOLLOWER_WORDS:
+                return False
         try:
-            style_names.append(_parse_string_token(value_token))
+            pure_style_names.append(_parse_string_token(value_token))
         except EditorSourceError:
-            continue
-    return len(style_names) == 1 and style_names[0] == "slider"
+            return False
+    return len(pure_style_names) == 1 and pure_style_names[0] == "slider"
 
 
 def analyze_slider_statement(line: str, *, expected_widget_id: str) -> SliderStatement:

--- a/src/renforge/editor_slider_runner.py
+++ b/src/renforge/editor_slider_runner.py
@@ -1,0 +1,510 @@
+from __future__ import annotations
+
+import hashlib
+import re
+import shutil
+import time
+from pathlib import Path
+from typing import Any
+
+from renforge.editor.source import analyze_slider_statement
+from renforge.editor_task0_runner import (
+    _require_ok,
+    _source_generation,
+    _wait_for_status,
+)
+
+FIXTURE_SCREEN = "renforge_editor_slider_fixture"
+TARGET_ID = "slider_target"
+EDITOR_RESOURCE = Path(__file__).resolve().parent / "bridge" / "editor.rpy"
+FIXTURE_RESOURCE = (
+    Path(__file__).resolve().parents[2]
+    / "tests"
+    / "live_fixtures"
+    / "renforge_editor_slider_fixture.rpy"
+)
+
+
+def inject_editor_slider_resources(project_root: Path) -> dict[str, str]:
+    game_dir = project_root / "game"
+    game_dir.mkdir(parents=True, exist_ok=True)
+    editor_target = game_dir / "zz_renforge_editor_slider.rpy"
+    fixture_target = game_dir / "zz_renforge_editor_slider_fixture.rpy"
+    shutil.copyfile(EDITOR_RESOURCE, editor_target)
+    shutil.copyfile(FIXTURE_RESOURCE, fixture_target)
+    return {
+        "editor": str(editor_target),
+        "fixture": str(fixture_target),
+    }
+
+
+def _find_element(
+    elements: list[dict[str, Any]],
+    wanted_id: str,
+    *,
+    wanted_text: str | None = None,
+) -> dict[str, Any]:
+    for element in elements:
+        element_id = str(element.get("id") or "")
+        if wanted_text is not None:
+            if element_id == wanted_id and str(element.get("text") or "") == wanted_text:
+                return element
+            continue
+        if element_id == wanted_id:
+            return element
+    raise AssertionError(
+        f"missing expected element id {wanted_id!r} text {wanted_text!r}: {elements!r}"
+    )
+
+
+def _center(bounds: dict[str, Any]) -> tuple[int, int]:
+    return (
+        int(bounds["x"]) + int(bounds["width"]) // 2,
+        int(bounds["y"]) + int(bounds["height"]) // 2,
+    )
+
+
+def _sha256_file(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _list_info(client: Any) -> dict[str, Any]:
+    info = client.list_ui_elements_info(screen=FIXTURE_SCREEN)
+    if not isinstance(info, dict):
+        raise AssertionError(f"list_ui_elements_info returned non-dict: {info!r}")
+    return info
+
+
+def _wait_bounds(client: Any, widget_id: str, *, timeout: float = 6.0) -> dict[str, int]:
+    deadline = time.monotonic() + timeout
+    last: list[dict[str, Any]] = []
+    while time.monotonic() < deadline:
+        info = _list_info(client)
+        last = info.get("elements") if isinstance(info.get("elements"), list) else []
+        try:
+            element = _find_element(last, widget_id)
+        except AssertionError:
+            time.sleep(0.05)
+            continue
+        bounds = element.get("bounds")
+        if isinstance(bounds, dict):
+            return {
+                "x": int(bounds["x"]),
+                "y": int(bounds["y"]),
+                "width": int(bounds["width"]),
+                "height": int(bounds["height"]),
+            }
+        time.sleep(0.05)
+    raise AssertionError(f"bounds for {widget_id!r} unavailable: {last!r}")
+
+
+def _target_line_with_offset(source_text: str) -> tuple[str, int]:
+    offset = 0
+    for line in source_text.splitlines(keepends=True):
+        if f'id "{TARGET_ID}"' in line and line.lstrip().startswith("bar "):
+            analyze_slider_statement(line, expected_widget_id=TARGET_ID)
+            return line, offset
+        offset += len(line)
+    raise AssertionError(f"source missing target line for {TARGET_ID!r}")
+
+
+def _independent_expected_after_patch(before_text: str, *, x: int, y: int) -> str:
+    """Build expected fixture text without calling apply_slider_patch."""
+    line, offset = _target_line_with_offset(before_text)
+    patched_line = re.sub(r"(\bxpos\s+)-?\d+", rf"\g<1>{int(x)}", line, count=1)
+    patched_line = re.sub(r"(\bypos\s+)-?\d+", rf"\g<1>{int(y)}", patched_line, count=1)
+    if patched_line == line:
+        raise AssertionError("independent patch constructor did not change target line")
+    return f"{before_text[:offset]}{patched_line}{before_text[offset + len(line) :]}"
+
+
+def _outside_coordinate_spans_identical(before_text: str, after_text: str) -> bool:
+    before_line, _ = _target_line_with_offset(before_text)
+    after_line, _ = _target_line_with_offset(after_text)
+    before_norm = re.sub(r"(\bxpos\s+)-?\d+", r"\1__X__", before_line, count=1)
+    before_norm = re.sub(r"(\bypos\s+)-?\d+", r"\1__Y__", before_norm, count=1)
+    after_norm = re.sub(r"(\bxpos\s+)-?\d+", r"\1__X__", after_line, count=1)
+    after_norm = re.sub(r"(\bypos\s+)-?\d+", r"\1__Y__", after_norm, count=1)
+    if before_norm != after_norm:
+        return False
+    before_rest = before_text.replace(before_line, "", 1)
+    after_rest = after_text.replace(after_line, "", 1)
+    return before_rest == after_rest
+
+
+def _parse_xy_from_target_line(source_text: str) -> dict[str, int]:
+    line, _ = _target_line_with_offset(source_text)
+    xpos = re.search(r"\bxpos\s+(-?\d+)\b", line)
+    ypos = re.search(r"\bypos\s+(-?\d+)\b", line)
+    if xpos is None or ypos is None:
+        raise AssertionError(f"target line missing literal xpos/ypos: {line!r}")
+    return {"x": int(xpos.group(1)), "y": int(ypos.group(1))}
+
+
+def _select_lock(client: Any, widget_id: str, expected_code: str) -> str:
+    bounds = _wait_bounds(client, widget_id)
+    selection = client.request(
+        "editor_task0_select",
+        {"x": _center(bounds)[0], "y": _center(bounds)[1]},
+    )
+    immediate = selection.get("lock_reason") if isinstance(selection, dict) else None
+    if immediate == expected_code:
+        return expected_code
+    status = _wait_for_status(
+        client,
+        lambda current: current.get("selected_widget_id") == widget_id
+        and current.get("selected_lock_reason") == expected_code,
+        timeout=10.0,
+        poll_name=f"{widget_id} lock",
+    )
+    lock_reason = status.get("selected_lock_reason")
+    if lock_reason != expected_code:
+        raise AssertionError(f"unexpected lock for {widget_id!r}: {status!r}")
+    return str(lock_reason)
+
+
+def _observe_selected(client: Any) -> dict[str, Any]:
+    reply = client.request("editor_task0_observe_selected", {})
+    if not isinstance(reply, dict) or reply.get("ok") is not True:
+        raise AssertionError(f"observe_selected failed: {reply!r}")
+    observation = reply.get("observation")
+    if not isinstance(observation, dict):
+        raise AssertionError(f"observe_selected missing observation: {reply!r}")
+    return observation
+
+
+def run_editor_slider_live_scenario(client: Any, *, fixture_path: Path) -> dict[str, Any]:
+    """Seven-step live proof for the dedicated single-line slider adapter."""
+    report: dict[str, Any] = {}
+    baseline_bytes = fixture_path.read_bytes()
+    baseline_sha = hashlib.sha256(baseline_bytes).hexdigest()
+    baseline_text = baseline_bytes.decode("utf-8")
+    baseline_position = _parse_xy_from_target_line(baseline_text)
+    report["fixture_before"] = {
+        "sha256": baseline_sha,
+        "position": baseline_position,
+    }
+
+    start = _require_ok(
+        client.request("editor_task0_start", {"screen": FIXTURE_SCREEN}),
+        "editor_task0_start",
+    )
+    report["start"] = start
+
+    # Lock matrix first on real focusable widgets (measured codes).
+    report["locks"] = {
+        "computed": _select_lock(client, "slider_computed", "XPOS_LITERAL_REQUIRED"),
+        "style": _select_lock(client, "slider_style", "BAR_STYLE_POSITION_UNSUPPORTED"),
+        # style "slider" is present, so missing xpos/ypos is a style-position lock.
+        "missing_position": _select_lock(
+            client, "slider_missing_position", "BAR_STYLE_POSITION_UNSUPPORTED"
+        ),
+        "container": _select_lock(client, "slider_container", "CONTAINER_POSITION_UNSUPPORTED"),
+    }
+
+    # Measured live: two use-statements with the same id surface as
+    # slider_dupe_target / slider_dupe_target#2 and resolve with SYNTHETIC_WIDGET_ID.
+    dupe_info = _list_info(client)
+    dupe_elements = dupe_info.get("elements") if isinstance(dupe_info, dict) else None
+    dupe_candidates = [
+        element
+        for element in (dupe_elements if isinstance(dupe_elements, list) else [])
+        if str(element.get("id") or "").startswith("slider_dupe_target")
+    ]
+    if len(dupe_candidates) < 2:
+        raise AssertionError(f"expected two slider_dupe_target instances: {dupe_candidates!r}")
+    dupe = next(
+        (element for element in dupe_candidates if str(element.get("id") or "") == "slider_dupe_target"),
+        dupe_candidates[0],
+    )
+    dupe_bounds = dupe.get("bounds")
+    if not isinstance(dupe_bounds, dict):
+        raise AssertionError(f"duplicate slider has no focus bounds: {dupe!r}")
+    dupe_select = client.request(
+        "editor_task0_select",
+        {
+            "x": int(dupe_bounds["x"]) + max(2, int(dupe_bounds["width"]) // 4),
+            "y": int(dupe_bounds["y"]) + int(dupe_bounds["height"]) // 2,
+        },
+    )
+    ambiguous = dupe_select.get("lock_reason") if isinstance(dupe_select, dict) else None
+    if ambiguous in (None, ""):
+        status = _wait_for_status(
+            client,
+            lambda current: current.get("selected_lock_reason") == "SYNTHETIC_WIDGET_ID",
+            timeout=10.0,
+            poll_name="slider dupe lock",
+        )
+        ambiguous = status.get("selected_lock_reason")
+    if ambiguous != "SYNTHETIC_WIDGET_ID":
+        raise AssertionError(f"duplicate slider lock was not SYNTHETIC_WIDGET_ID: {ambiguous!r}")
+    report["locks"]["ambiguous"] = ambiguous
+
+    # Measured live: Side is not in the ancestry allowlist → UNKNOWN_ANCESTRY_TYPE.
+    side_bounds = _wait_bounds(client, "slider_side", timeout=3.0)
+    side_select = client.request(
+        "editor_task0_select",
+        {"x": _center(side_bounds)[0], "y": _center(side_bounds)[1]},
+    )
+    unproven = side_select.get("lock_reason") if isinstance(side_select, dict) else None
+    if unproven in (None, ""):
+        status = _wait_for_status(
+            client,
+            lambda current: current.get("selected_lock_reason") == "UNKNOWN_ANCESTRY_TYPE",
+            timeout=10.0,
+            poll_name="slider side lock",
+        )
+        unproven = status.get("selected_lock_reason")
+    if unproven != "UNKNOWN_ANCESTRY_TYPE":
+        raise AssertionError(
+            f"side-ancestor slider lock was not UNKNOWN_ANCESTRY_TYPE: {unproven!r}"
+        )
+    report["locks"]["unproven"] = unproven
+
+    # Step 1: resolve the editable slider from a fresh focus rect.
+    target_bounds = _wait_bounds(client, TARGET_ID)
+    target_center = _center(target_bounds)
+    select = _require_ok(
+        client.request(
+            "editor_task0_select",
+            {"x": target_center[0], "y": target_center[1]},
+        ),
+        "target select",
+    )
+    observation = select.get("observation") or {}
+    if observation.get("measurement_method") != "focus_list":
+        raise AssertionError(f"select observation not focus_list: {observation!r}")
+
+    analysis_status = _wait_for_status(
+        client,
+        lambda status: bool(status.get("current_analysis_id"))
+        and status.get("selected_widget_id") == TARGET_ID
+        and status.get("selected_lock_reason") in (None, ""),
+        timeout=10.0,
+        poll_name="slider analysis",
+    )
+    source_key = analysis_status.get("current_source_key") or {}
+    capabilities = analysis_status.get("current_capabilities") or {}
+    host_move = capabilities.get("move")
+    report["resolve"] = {
+        "statement_kind": source_key.get("statement_kind"),
+        "lock_reason": analysis_status.get("selected_lock_reason"),
+        "move": host_move,
+        "analysis_id": analysis_status.get("current_analysis_id"),
+        "measurement_method": observation.get("measurement_method"),
+        "frame_id": observation.get("frame_id"),
+        "source_key": source_key,
+    }
+    if source_key.get("statement_kind") != "slider":
+        raise AssertionError(f"expected slider statement_kind: {source_key!r}")
+    if host_move is not True:
+        raise AssertionError(f"host did not unlock move for slider: {analysis_status!r}")
+
+    original = analysis_status.get("selected_original_position") or analysis_status.get(
+        "selected_source_position"
+    )
+    if not (isinstance(original, (list, tuple)) and len(original) == 2):
+        original = [int(baseline_position["x"]), int(baseline_position["y"])]
+    requested_before = [int(original[0]), int(original[1])]
+
+    # Fresh focus_list observation before preview movement.
+    value_baseline = client.eval_expr("renforge_editor_slider_value")
+    before_obs = _observe_selected(client)
+    before_rect = before_obs.get("rect") or []
+    if len(before_rect) < 2:
+        raise AssertionError(f"pre-preview observation missing rect: {before_obs!r}")
+    bounds_before = [int(before_rect[0]), int(before_rect[1])]
+    frame_before = before_obs.get("frame_id")
+
+    # Step 2: preview.
+    _require_ok(client.request("editor_task0_key", {"key": "right", "repeat": 24}), "nudge right")
+    _require_ok(client.request("editor_task0_key", {"key": "down", "repeat": 16}), "nudge down")
+    preview_status = _wait_for_status(
+        client,
+        lambda status: isinstance(status.get("preview_position"), (list, tuple))
+        and len(status.get("preview_position") or []) == 2
+        and list(status.get("preview_position") or []) != requested_before,
+        timeout=8.0,
+        poll_name="slider preview moved",
+    )
+    requested_after = [
+        int(preview_status["preview_position"][0]),
+        int(preview_status["preview_position"][1]),
+    ]
+    after_obs = _observe_selected(client)
+    value_preview = client.eval_expr("renforge_editor_slider_value")
+    after_rect = after_obs.get("rect") or []
+    if len(after_rect) < 2:
+        raise AssertionError(f"post-preview observation missing rect: {after_obs!r}")
+    bounds_after = [int(after_rect[0]), int(after_rect[1])]
+    frame_after = after_obs.get("frame_id")
+    if not frame_before or not frame_after or frame_before == frame_after:
+        raise AssertionError(
+            f"preview observations must have distinct real frame_ids: "
+            f"before={frame_before!r}, after={frame_after!r}"
+        )
+    if before_obs.get("measurement_method") != "focus_list" or after_obs.get("measurement_method") != "focus_list":
+        raise AssertionError(
+            "preview observations must report measurement_method from bridge: "
+            f"before={before_obs.get('measurement_method')!r}, after={after_obs.get('measurement_method')!r}"
+        )
+    requested_delta = [requested_after[axis] - requested_before[axis] for axis in (0, 1)]
+    observed_delta = [bounds_after[axis] - bounds_before[axis] for axis in (0, 1)]
+    if any(abs(observed_delta[axis] - requested_delta[axis]) > 1 for axis in (0, 1)):
+        raise AssertionError(
+            "focus_list preview bounds disagree with requested movement: "
+            f"requested={requested_delta!r}, observed={observed_delta!r}"
+        )
+    report["preview"] = {
+        "bounds_before": bounds_before,
+        "bounds_after": bounds_after,
+        "requested_before": requested_before,
+        "requested_after": requested_after,
+        "requested_delta": requested_delta,
+        "observed_delta": observed_delta,
+        "measurement_method_before": before_obs.get("measurement_method"),
+        "measurement_method_after": after_obs.get("measurement_method"),
+        "measurement_method": after_obs.get("measurement_method"),
+        "frame_id_before": frame_before,
+        "frame_id_after": frame_after,
+    }
+
+    # Step 3: patch via real Save overlay control.
+    pre_save_bytes = fixture_path.read_bytes()
+    pre_save_sha = hashlib.sha256(pre_save_bytes).hexdigest()
+    pre_save_text = pre_save_bytes.decode("utf-8")
+    generation_before = _source_generation(analysis_status)
+    save_request = _require_ok(
+        client.click_element(id="rf_save", screen="_renforge_editor_overlay"),
+        "slider save",
+    )
+    save_status = _wait_for_status(
+        client,
+        lambda status: not bool(status.get("save_in_progress"))
+        and status.get("status_text") == "Reload committed"
+        and _source_generation(status) == generation_before + 1,
+        timeout=60.0,
+        poll_name="slider save complete",
+    )
+    post_save_bytes = fixture_path.read_bytes()
+    post_save_sha = hashlib.sha256(post_save_bytes).hexdigest()
+    post_save_text = post_save_bytes.decode("utf-8")
+    source_position_after = _parse_xy_from_target_line(post_save_text)
+    expected_source_position = {"x": requested_after[0], "y": requested_after[1]}
+    if source_position_after != expected_source_position:
+        raise AssertionError(
+            "source patch disagrees with requested preview position: "
+            f"expected={expected_source_position!r}, observed={source_position_after!r}"
+        )
+    expected_text = _independent_expected_after_patch(
+        pre_save_text,
+        x=requested_after[0],
+        y=requested_after[1],
+    )
+    if post_save_text != expected_text:
+        raise AssertionError("patched fixture bytes disagree with independent expected content")
+    outside_coordinate_spans_identical = _outside_coordinate_spans_identical(
+        pre_save_text,
+        post_save_text,
+    )
+    if not outside_coordinate_spans_identical:
+        raise AssertionError("source patch changed bytes outside xpos/ypos spans")
+    report["patch"] = {
+        "before_sha256": pre_save_sha,
+        "after_sha256": post_save_sha,
+        "source_position_after": source_position_after,
+        "outside_coordinate_spans_identical": outside_coordinate_spans_identical,
+        "matches_independent_expected": True,
+        "save_request": save_request,
+    }
+
+    # Step 4: reload publication cycle (frame_id filled after rebind observation).
+    report["reload"] = {
+        "ok": True,
+        "script_generation": _source_generation(save_status),
+        "status_text": save_status.get("status_text"),
+        "generation_delta": _source_generation(save_status) - generation_before,
+        "pending_handshake_sent": save_status.get("pending_handshake_sent"),
+        "frame_id": None,
+    }
+
+    # Step 5: pixel agreement between post-preview focus rect and post-reload focus rect.
+    successor = _wait_for_status(
+        client,
+        lambda status: bool(status.get("current_analysis_id"))
+        and status.get("selected_widget_id") == TARGET_ID
+        and status.get("selected_lock_reason") in (None, ""),
+        timeout=10.0,
+        poll_name="slider post-save rebind analysis",
+    )
+    reload_obs = _observe_selected(client)
+    value_reload = client.eval_expr("renforge_editor_slider_value")
+    reload_rect = reload_obs.get("rect") or []
+    if len(reload_rect) < 2:
+        raise AssertionError(f"post-reload observation missing rect: {reload_obs!r}")
+    reload_bounds = [int(reload_rect[0]), int(reload_rect[1])]
+    pixel_delta = [
+        reload_bounds[0] - bounds_after[0],
+        reload_bounds[1] - bounds_after[1],
+    ]
+    if any(abs(value) > 1 for value in pixel_delta):
+        raise AssertionError(
+            "post-reload focus rect disagrees with post-preview focus rect: "
+            f"preview={bounds_after!r}, reload={reload_bounds!r}, delta={pixel_delta!r}"
+        )
+    report["pixel_agreement"] = {
+        "preview_after": bounds_after,
+        "reload_after": reload_bounds,
+        "delta": pixel_delta,
+        "measurement_method": reload_obs.get("measurement_method"),
+        "measurement_method_preview": after_obs.get("measurement_method"),
+        "measurement_method_reload": reload_obs.get("measurement_method"),
+        "frame_id_preview": frame_after,
+        "frame_id_reload": reload_obs.get("frame_id"),
+    }
+    reload_frame = reload_obs.get("frame_id")
+    if not reload_frame or reload_frame == frame_after:
+        raise AssertionError(
+            f"reload observation must have a distinct real frame_id: "
+            f"preview={frame_after!r}, reload={reload_frame!r}"
+        )
+    report["value_invariance"] = {
+        "baseline": value_baseline,
+        "preview": value_preview,
+        "reload": value_reload,
+    }
+    if value_preview != value_baseline or value_reload != value_baseline:
+        raise AssertionError(
+            "slider runtime value changed during preview/reload: "
+            f"baseline={value_baseline!r}, preview={value_preview!r}, reload={value_reload!r}"
+        )
+    report["reload"]["frame_id"] = reload_obs.get("frame_id")
+
+    # Step 6: rebinding.
+    report["rebinding"] = {
+        "ok": successor.get("selected_widget_id") == TARGET_ID
+        and successor.get("current_analysis_id")
+        not in (None, analysis_status.get("current_analysis_id"))
+        and (successor.get("current_source_key") or {}).get("statement_kind") == "slider",
+        "widget_id": successor.get("selected_widget_id"),
+        "analysis_id": successor.get("current_analysis_id"),
+        "previous_analysis_id": analysis_status.get("current_analysis_id"),
+        "source_key": successor.get("current_source_key"),
+        "lock_reason": successor.get("selected_lock_reason"),
+    }
+    if report["rebinding"]["ok"] is not True:
+        raise AssertionError(f"rebinding failed: {report['rebinding']!r}")
+
+    # Step 7: byte-identical undo of the temporary fixture.
+    fixture_path.write_bytes(baseline_bytes)
+    restored_bytes = fixture_path.read_bytes()
+    restored_sha = _sha256_file(fixture_path)
+    report["byte_identical_undo"] = {
+        "baseline_sha256": baseline_sha,
+        "restored_sha256": restored_sha,
+        "matches_baseline": restored_sha == baseline_sha and restored_bytes == baseline_bytes,
+        "patched_differed": post_save_sha != baseline_sha and post_save_bytes != baseline_bytes,
+    }
+    if restored_bytes != baseline_bytes:
+        raise AssertionError("slider byte-identical undo did not restore the baseline")
+    return report

--- a/tests/live_fixtures/renforge_editor_slider_fixture.rpy
+++ b/tests/live_fixtures/renforge_editor_slider_fixture.rpy
@@ -1,0 +1,54 @@
+default renforge_editor_slider_value = 50
+default renforge_editor_slider_computed_x = 520
+default renforge_editor_slider_computed_val = 40
+default renforge_editor_slider_style_val = 40
+default renforge_editor_slider_missing_val = 40
+default renforge_editor_slider_container_val = 40
+default renforge_editor_slider_dupe_val = 40
+default renforge_editor_slider_side_val = 40
+
+
+# Style-driven position without inline xpos/ypos (locked).
+style renforge_slider_style_pos is slider:
+    xpos 700
+    ypos 180
+    xmaximum 200
+    ymaximum 24
+
+
+screen renforge_editor_slider_dupe(left_x):
+    # Measured form: Ren'Py has no screen-language "slider" keyword.
+    # Sliders are authored as bar + style "slider".
+    bar value VariableValue("renforge_editor_slider_dupe_val", range=100) style "slider" id "slider_dupe_target" xpos left_x ypos 430 xsize 160 ysize 24
+
+
+screen renforge_editor_slider_fixture():
+    layer "screens"
+    zorder 640
+
+    fixed:
+        id "slider_root"
+        xfill True
+        yfill True
+
+        bar value VariableValue("renforge_editor_slider_value", range=100) style "slider" id "slider_target" xpos 200 ypos 180 xsize 240 ysize 24
+
+        bar value VariableValue("renforge_editor_slider_computed_val", range=100) style "slider" id "slider_computed" xpos renforge_editor_slider_computed_x ypos 300 xsize 200 ysize 24
+
+        bar value VariableValue("renforge_editor_slider_style_val", range=100) style "renforge_slider_style_pos" id "slider_style"
+
+        bar value VariableValue("renforge_editor_slider_missing_val", range=100) style "slider" id "slider_missing_position" xsize 160 ysize 24
+
+        vbox:
+            id "slider_container_parent"
+            xpos 900
+            ypos 120
+            spacing 12
+
+            bar value VariableValue("renforge_editor_slider_container_val", range=100) style "slider" id "slider_container" xpos 0 ypos 0 xsize 160 ysize 24
+
+        side "c":
+            bar value VariableValue("renforge_editor_slider_side_val", range=100) style "slider" id "slider_side" xpos 100 ypos 520 xsize 200 ysize 24
+
+        use renforge_editor_slider_dupe(520)
+        use renforge_editor_slider_dupe(720)

--- a/tests/test_editor_coordinator.py
+++ b/tests/test_editor_coordinator.py
@@ -1274,6 +1274,219 @@ def test_analyze_vbar_block_header_stays_locked(tmp_path: Path) -> None:
         coordinator.close()
 
 
+def _make_slider_project(tmp_path: Path) -> tuple[RenpyProject, Path]:
+    root = tmp_path / "project_slider"
+    game_dir = root / "game"
+    game_dir.mkdir(parents=True)
+    source = game_dir / "script.rpy"
+    source.write_text(
+        "screen test_screen:\n"
+        '    bar value StaticValue(50) range 100 style "slider" id "start_btn" '
+        "xpos 12 ypos 10 xsize 240 ysize 24\n",
+        encoding="utf-8",
+    )
+    return RenpyProject(root), source
+
+
+def test_analyze_and_commit_slider_statement_uses_source_kind(tmp_path: Path) -> None:
+    project, source = _make_slider_project(tmp_path)
+    observation = _base_observation(script_generation=12)
+    observation["runtime_key"]["ancestry"][1]["type"] = "Bar"
+    observation["runtime_key"]["node_type"] = "bar"
+    probe = _Probe(
+        observe_reply={
+            **json.loads(json.dumps(observation)),
+            "frame_id": "independent-frame-slider",
+            "object_id": "obj-independent-slider",
+        },
+        attest_reply={"ok": True, "state": "all_targets_attested"},
+    )
+    coordinator = EditorCoordinator(project, _make_sdk(tmp_path), attestation_timeout=2.0)
+    coordinator.attach_runtime_probe(probe)
+    endpoint = coordinator.start()
+    try:
+        with socket.create_connection((endpoint.host, endpoint.port), timeout=2.0) as sock:
+            auth = _auth(sock, endpoint)
+            analyzed = _analyze(sock, auth, observation, request_id="an-slider")
+            assert analyzed["ok"] is True
+            result = analyzed["result"]
+            assert result["lock_reason"] is None
+            assert result["capabilities"] == {"move": True}
+            # Adapter identity is style-based; source keyword remains "bar".
+            assert result["source_key"]["statement_kind"] == "slider"
+            assert result["original_position"] == [12, 10]
+
+            committed = _commit(sock, auth, analyzed, x=40, y=50, request_id="co-slider")
+            assert committed["ok"] is True
+            assert committed["result"]["state"] == "published"
+            assert source.read_text(encoding="utf-8") == (
+                "screen test_screen:\n"
+                '    bar value StaticValue(50) range 100 style "slider" id "start_btn" '
+                "xpos 40 ypos 50 xsize 240 ysize 24\n"
+            )
+    finally:
+        coordinator.close()
+
+
+def test_analyze_slider_block_header_stays_locked(tmp_path: Path) -> None:
+    project, source = _make_slider_project(tmp_path)
+    source.write_text(
+        "screen test_screen:\n"
+        '    bar value StaticValue(50) range 100 style "slider" id "start_btn" '
+        "xpos 12 ypos 10 xsize 240 ysize 24:\n"
+        "        null\n",
+        encoding="utf-8",
+    )
+    observation = _base_observation(script_generation=12)
+    observation["runtime_key"]["ancestry"][1]["type"] = "Bar"
+    observation["runtime_key"]["node_type"] = "bar"
+    probe = _Probe(
+        observe_reply={
+            **json.loads(json.dumps(observation)),
+            "frame_id": "independent-frame-slider-block",
+            "object_id": "obj-independent-slider-block",
+        },
+        attest_reply={"ok": True, "state": "all_targets_attested"},
+    )
+    coordinator = EditorCoordinator(project, _make_sdk(tmp_path), attestation_timeout=2.0)
+    coordinator.attach_runtime_probe(probe)
+    endpoint = coordinator.start()
+    try:
+        with socket.create_connection((endpoint.host, endpoint.port), timeout=2.0) as sock:
+            auth = _auth(sock, endpoint)
+            analyzed = _analyze(sock, auth, observation, request_id="an-slider-block")
+            assert analyzed["ok"] is True
+            assert analyzed["result"]["capabilities"] == {"move": False}
+            assert analyzed["result"]["lock_reason"]["code"] == "MULTILINE_STATEMENT_REJECTED"
+    finally:
+        coordinator.close()
+
+
+def test_analyze_slider_locks_computed_style_container_without_runtime_type_inference(
+    tmp_path: Path,
+) -> None:
+    project, source = _make_slider_project(tmp_path)
+    cases = (
+        (
+            '    bar value StaticValue(50) range 100 style "slider" id "start_btn" '
+            "xpos base_x ypos 10\n",
+            "XPOS_LITERAL_REQUIRED",
+            "slider",
+            False,
+            [
+                {
+                    "index": 0,
+                    "type": "ScreenDisplayable",
+                    "source_location": ["script.rpy", 1],
+                    "screen_owner": "game",
+                    "crop_state": "none",
+                    "editor_owned": False,
+                },
+                {
+                    "index": 1,
+                    "type": "Bar",
+                    "source_location": ["script.rpy", 2],
+                    "screen_owner": "game",
+                    "crop_state": "none",
+                    "editor_owned": False,
+                },
+            ],
+        ),
+        (
+            '    bar value StaticValue(50) range 100 style "slider" id "start_btn"\n',
+            "BAR_STYLE_POSITION_UNSUPPORTED",
+            "slider",
+            False,
+            [
+                {
+                    "index": 0,
+                    "type": "ScreenDisplayable",
+                    "source_location": ["script.rpy", 1],
+                    "screen_owner": "game",
+                    "crop_state": "none",
+                    "editor_owned": False,
+                },
+                {
+                    "index": 1,
+                    "type": "Bar",
+                    "source_location": ["script.rpy", 2],
+                    "screen_owner": "game",
+                    "crop_state": "none",
+                    "editor_owned": False,
+                },
+            ],
+        ),
+        (
+            '    bar value StaticValue(50) range 100 style "slider" id "start_btn" '
+            "xpos 12 ypos 10\n",
+            "CONTAINER_POSITION_UNSUPPORTED",
+            "slider",
+            True,
+            [
+                {
+                    "index": 0,
+                    "type": "ScreenDisplayable",
+                    "source_location": ["script.rpy", 1],
+                    "screen_owner": "game",
+                    "crop_state": "none",
+                    "editor_owned": False,
+                },
+                {
+                    "index": 1,
+                    "type": "VBox",
+                    "source_location": ["script.rpy", 2],
+                    "screen_owner": "game",
+                    "crop_state": "none",
+                    "editor_owned": False,
+                    "layout": "vertical",
+                },
+                {
+                    "index": 2,
+                    "type": "Bar",
+                    "source_location": ["script.rpy", 3],
+                    "screen_owner": "game",
+                    "crop_state": "none",
+                    "editor_owned": False,
+                },
+            ],
+        ),
+    )
+    sdk = _make_sdk(tmp_path)
+    for index, (line, expected_code, expected_kind, source_key_present, ancestry) in enumerate(
+        cases
+    ):
+        # Source keyword is always "bar"; adapter kind is style-specialized "slider".
+        assert peek_statement_kind(line) == "bar"
+        source.write_text("screen test_screen:\n" + line, encoding="utf-8")
+        observation = _base_observation(script_generation=30 + index)
+        observation["runtime_key"]["ancestry"] = ancestry
+        observation["runtime_key"]["node_type"] = "bar"
+        probe = _Probe(
+            observe_reply={
+                **json.loads(json.dumps(observation)),
+                "frame_id": f"independent-frame-slider-lock-{index}",
+                "object_id": f"obj-independent-slider-lock-{index}",
+            }
+        )
+        coordinator = EditorCoordinator(project, sdk)
+        coordinator.attach_runtime_probe(probe)
+        endpoint = coordinator.start()
+        try:
+            with socket.create_connection((endpoint.host, endpoint.port), timeout=2.0) as sock:
+                auth = _auth(sock, endpoint)
+                reply = _analyze(sock, auth, observation, request_id=f"an-slider-lock-{index}")
+                assert reply["ok"] is True
+                assert reply["result"]["capabilities"] == {"move": False}
+                assert reply["result"]["lock_reason"]["code"] == expected_code
+                source_key = reply["result"].get("source_key")
+                if source_key_present:
+                    assert source_key is not None
+                    assert source_key["statement_kind"] == expected_kind
+                else:
+                    assert source_key is None
+        finally:
+            coordinator.close()
+
 
 def test_analyze_bar_locks_computed_style_container_without_runtime_type_inference(
     tmp_path: Path,

--- a/tests/test_editor_slider_live.py
+++ b/tests/test_editor_slider_live.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import os
+import shutil
+import time
+from pathlib import Path
+
+import pytest
+
+from renforge.editor_slider_runner import (
+    FIXTURE_SCREEN,
+    inject_editor_slider_resources,
+    run_editor_slider_live_scenario,
+)
+
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("RENFORGE_SLIDER_LIVE"),
+    reason="set RENFORGE_SLIDER_LIVE=1 to run slider seven-step live proof",
+)
+
+_DEMO = Path(__file__).resolve().parents[1] / "examples" / "demo_game"
+
+
+@pytest.fixture
+def demo_copy(tmp_path: Path) -> Path:
+    destination = tmp_path / "demo"
+    shutil.copytree(_DEMO, destination, ignore=shutil.ignore_patterns("*.rpyc", "cache"))
+    inject_editor_slider_resources(destination)
+    return destination
+
+
+def test_slider_seven_step_live_proof(demo_copy: Path) -> None:
+    from renforge.bridge.launcher import launch_with_bridge
+    from renforge.project import RenpyProject
+    from renforge.sdk import get_or_install_sdk
+
+    sdk = get_or_install_sdk("8.5.3", project_root=demo_copy)
+    project = RenpyProject(demo_copy)
+    fixture_path = demo_copy / "game" / "zz_renforge_editor_slider_fixture.rpy"
+
+    with launch_with_bridge(
+        sdk,
+        project,
+        startup_timeout=120,
+        editor=True,
+    ) as session:
+        for _ in range(40):
+            launcher = session.client.inspect_screen("_renforge_editor_launcher")
+            if launcher.get("active") is True:
+                break
+            time.sleep(0.25)
+        else:
+            pytest.fail("editor launcher never became active")
+
+        launcher_click = session.client.click_element(
+            text="RF",
+            exact=True,
+            screen="_renforge_editor_launcher",
+        )
+        assert launcher_click.get("ok") is True, launcher_click
+        for _ in range(40):
+            overlay = session.client.inspect_screen("_renforge_editor_overlay")
+            if overlay.get("active") is True:
+                break
+            time.sleep(0.05)
+        else:
+            pytest.fail("editor overlay never became active")
+
+        for _ in range(20):
+            available = session.client.eval_expr(f'renpy.has_screen("{FIXTURE_SCREEN}")')
+            if available is True:
+                break
+            time.sleep(0.1)
+        else:
+            pytest.fail("slider fixture screen never became available")
+
+        report = run_editor_slider_live_scenario(
+            session.client,
+            fixture_path=fixture_path,
+        )
+
+    assert report["resolve"]["statement_kind"] == "slider"
+    assert report["resolve"]["lock_reason"] in (None, "")
+    assert report["resolve"]["move"] is True
+    assert report["resolve"]["measurement_method"] == "focus_list"
+    assert report["resolve"]["frame_id"]
+
+    preview = report["preview"]
+    assert preview["bounds_before"] != preview["bounds_after"]
+    assert all(
+        abs(preview["observed_delta"][axis] - preview["requested_delta"][axis]) <= 1
+        for axis in (0, 1)
+    )
+    assert preview["measurement_method"] == "focus_list"
+    assert preview["measurement_method_before"] == "focus_list"
+    assert preview["measurement_method_after"] == "focus_list"
+    assert preview["frame_id_before"]
+    assert preview["frame_id_after"]
+    assert preview["frame_id_before"] != preview["frame_id_after"]
+
+    patch = report["patch"]
+    assert patch["outside_coordinate_spans_identical"] is True
+    assert patch["matches_independent_expected"] is True
+    assert patch["after_sha256"] != patch["before_sha256"]
+    assert patch["source_position_after"] == {
+        "x": preview["requested_after"][0],
+        "y": preview["requested_after"][1],
+    }
+
+    assert report["reload"]["ok"] is True
+    assert report["reload"]["status_text"] == "Reload committed"
+    assert report["reload"]["generation_delta"] == 1
+    assert report["reload"]["frame_id"]
+
+    assert all(abs(int(value)) <= 1 for value in report["pixel_agreement"]["delta"])
+    assert report["pixel_agreement"]["measurement_method"] == "focus_list"
+    assert report["pixel_agreement"]["measurement_method_preview"] == "focus_list"
+    assert report["pixel_agreement"]["measurement_method_reload"] == "focus_list"
+    assert report["pixel_agreement"]["frame_id_preview"]
+    assert report["pixel_agreement"]["frame_id_reload"]
+    assert report["pixel_agreement"]["frame_id_preview"] != report["pixel_agreement"]["frame_id_reload"]
+
+    value_invariance = report["value_invariance"]
+    assert value_invariance["preview"] == value_invariance["baseline"]
+    assert value_invariance["reload"] == value_invariance["baseline"]
+
+    assert report["rebinding"]["ok"] is True
+    assert report["rebinding"]["widget_id"] == "slider_target"
+    assert (report["rebinding"]["source_key"] or {}).get("statement_kind") == "slider"
+
+    locks = report["locks"]
+    assert locks["computed"] == "XPOS_LITERAL_REQUIRED"
+    assert locks["style"] == "BAR_STYLE_POSITION_UNSUPPORTED"
+    assert locks["missing_position"] == "BAR_STYLE_POSITION_UNSUPPORTED"
+    assert locks["container"] == "CONTAINER_POSITION_UNSUPPORTED"
+    assert locks["ambiguous"] == "SYNTHETIC_WIDGET_ID"
+    assert locks["unproven"] == "UNKNOWN_ANCESTRY_TYPE"
+
+    undo = report["byte_identical_undo"]
+    assert undo["matches_baseline"] is True
+    assert undo["patched_differed"] is True

--- a/tests/test_editor_source.py
+++ b/tests/test_editor_source.py
@@ -668,6 +668,30 @@ def test_analyze_slider_dispatch_uses_bar_plus_style_slider() -> None:
     assert not is_slider_style_bar_line(
         '    bar value StaticValue(1) range 10 style "bar" id "b" xpos 1 ypos 2\n'
     )
+    # Computed style expressions must not masquerade as the slider adapter.
+    assert not is_slider_style_bar_line(
+        '    bar value StaticValue(1) range 10 style "slider" if flag else "bar" '
+        'id "sl" xpos 1 ypos 2\n'
+    )
+    assert not is_slider_style_bar_line(
+        '    bar value StaticValue(1) range 10 style "slider" or "bar" '
+        'id "sl" xpos 1 ypos 2\n'
+    )
+    with pytest.raises(EditorSourceError) as excinfo:
+        analyze_slider_statement(
+            '    bar value StaticValue(1) range 10 style "slider" if flag else "bar" '
+            'id "sl" xpos 1 ypos 2\n',
+            expected_widget_id="sl",
+        )
+    assert excinfo.value.code == "STATEMENT_KIND_MISMATCH"
+    # Dispatch falls through to plain bar, not slider, for style expressions.
+    kind_expr, stmt_expr = analyze_editable_statement(
+        '    bar value StaticValue(1) range 10 style "slider" if flag else "bar" '
+        'id "sl" xpos 1 ypos 2\n',
+        expected_widget_id="sl",
+    )
+    assert kind_expr == "bar"
+    assert isinstance(stmt_expr, BarStatement)
     # Bare keyword "slider" is not a supported statement form.
     with pytest.raises(EditorSourceError) as excinfo:
         analyze_slider_statement(

--- a/tests/test_editor_source.py
+++ b/tests/test_editor_source.py
@@ -7,21 +7,25 @@ import pytest
 from renforge.editor.paths import EditorPathError, resolve_game_path
 from renforge.editor.source import (
     BarStatement,
-    VbarStatement,
     ButtonStatement,
     EditorSourceError,
+    SliderStatement,
+    VbarStatement,
     analyze_bar_statement,
-    analyze_vbar_statement,
     analyze_button_statement,
     analyze_editable_statement,
     analyze_imagebutton_statement,
+    analyze_slider_statement,
     analyze_textbutton_statement,
+    analyze_vbar_statement,
     apply_bar_patch,
-    apply_vbar_patch,
     apply_button_patch,
     apply_editable_statement_patch,
     apply_imagebutton_patch,
+    apply_slider_patch,
     apply_textbutton_patch,
+    apply_vbar_patch,
+    is_slider_style_bar_line,
     peek_statement_kind,
 )
 
@@ -406,6 +410,40 @@ def test_analyze_editable_statement_routes_kinds() -> None:
         )
     assert excinfo.value.code == "STATEMENT_KIND_MISMATCH"
 
+    slider_line = (
+        '    bar value StaticValue(50) range 100 style "slider" id "sl" '
+        "xpos 1 ypos 2 xsize 40 ysize 10\n"
+    )
+    kind_slider, stmt_slider = analyze_editable_statement(
+        slider_line,
+        expected_widget_id="sl",
+    )
+    assert kind_slider == "slider"
+    assert isinstance(stmt_slider, SliderStatement)
+    patched_slider = apply_editable_statement_patch(
+        slider_line.encode("utf-8"),
+        kind_slider,
+        stmt_slider,
+        x=11,
+        y=22,
+    ).decode("utf-8")
+    assert patched_slider == (
+        '    bar value StaticValue(50) range 100 style "slider" id "sl" '
+        "xpos 11 ypos 22 xsize 40 ysize 10\n"
+    )
+    with pytest.raises(EditorSourceError) as excinfo:
+        apply_editable_statement_patch(
+            slider_line.encode("utf-8"),
+            "slider",
+            analyze_bar_statement(
+                '    bar value StaticValue(50) range 100 id "b" xpos 1 ypos 2 xsize 10 ysize 40\n',
+                expected_widget_id="b",
+            ),
+            x=1,
+            y=2,
+        )
+    assert excinfo.value.code == "STATEMENT_KIND_MISMATCH"
+
 
 def test_analyze_editable_statement_reports_missing_statement_kind() -> None:
     with pytest.raises(EditorSourceError, match="does not contain a supported statement kind") as excinfo:
@@ -592,6 +630,150 @@ def test_analyze_vbar_statement_rejects_id_and_coordinate_problems() -> None:
         analyze_vbar_statement(
             '    vbar value StaticValue(1) range 10 id "vb" xpos 1 ypos 2 ypos 3\n',
             expected_widget_id="vb",
+        )
+    assert excinfo.value.code == "YPOS_DUPLICATE"
+
+
+def test_analyze_slider_statement_accepts_single_line_and_preserves_other_bytes() -> None:
+    line = (
+        '    bar value StaticValue(50) range 100 style "slider" id "slider_target" '
+        "xpos -10 ypos -20 xsize 240 ysize 24 # keep\n"
+    )
+    assert is_slider_style_bar_line(line)
+    parsed = analyze_slider_statement(line, expected_widget_id="slider_target")
+    assert isinstance(parsed, SliderStatement)
+    assert (parsed.xpos, parsed.ypos) == (-10, -20)
+
+    patched = apply_slider_patch(line.encode("utf-8"), parsed, x=30, y=40).decode("utf-8")
+    assert patched == (
+        '    bar value StaticValue(50) range 100 style "slider" id "slider_target" '
+        "xpos 30 ypos 40 xsize 240 ysize 24 # keep\n"
+    )
+
+
+def test_analyze_slider_dispatch_uses_bar_plus_style_slider() -> None:
+    # Ren'Py has no screen-language "slider" keyword; peeks as bar.
+    assert (
+        peek_statement_kind(
+            '    bar value StaticValue(1) range 10 style "slider" id "sl" xpos 1 ypos 2\n'
+        )
+        == "bar"
+    )
+    assert is_slider_style_bar_line(
+        '    bar value StaticValue(1) range 10 style "slider" id "sl" xpos 1 ypos 2\n'
+    )
+    assert not is_slider_style_bar_line(
+        '    bar value StaticValue(1) range 10 id "b" xpos 1 ypos 2\n'
+    )
+    assert not is_slider_style_bar_line(
+        '    bar value StaticValue(1) range 10 style "bar" id "b" xpos 1 ypos 2\n'
+    )
+    # Bare keyword "slider" is not a supported statement form.
+    with pytest.raises(EditorSourceError) as excinfo:
+        analyze_slider_statement(
+            '    slider value StaticValue(1) range 10 id "sl" xpos 1 ypos 2\n',
+            expected_widget_id="sl",
+        )
+    assert excinfo.value.code == "STATEMENT_KIND_MISMATCH"
+    # bar without style "slider" is not the slider adapter.
+    with pytest.raises(EditorSourceError) as excinfo:
+        analyze_slider_statement(
+            '    bar value StaticValue(1) range 10 id "b" xpos 1 ypos 2\n',
+            expected_widget_id="b",
+        )
+    assert excinfo.value.code == "STATEMENT_KIND_MISMATCH"
+    # Dispatch routes bar+style "slider" to dedicated slider path.
+    kind, stmt = analyze_editable_statement(
+        '    bar value StaticValue(1) range 10 style "slider" id "sl" xpos 1 ypos 2\n',
+        expected_widget_id="sl",
+    )
+    assert kind == "slider"
+    assert isinstance(stmt, SliderStatement)
+    # Plain bar stays on the bar path.
+    kind_bar, stmt_bar = analyze_editable_statement(
+        '    bar value StaticValue(1) range 10 id "b" xpos 1 ypos 2\n',
+        expected_widget_id="b",
+    )
+    assert kind_bar == "bar"
+    assert isinstance(stmt_bar, BarStatement)
+
+
+@pytest.mark.parametrize(
+    ("line", "expected_code"),
+    (
+        (
+            '    bar value StaticValue(1) range 10 style "slider" id "sl" xpos base_x ypos 10\n',
+            "XPOS_LITERAL_REQUIRED",
+        ),
+        (
+            '    bar value StaticValue(1) range 10 style "slider" id "sl" xpos 10 ypos base_y\n',
+            "YPOS_LITERAL_REQUIRED",
+        ),
+        (
+            '    bar value StaticValue(1) range 10 style "slider" id "sl"\n',
+            "BAR_STYLE_POSITION_UNSUPPORTED",
+        ),
+        (
+            '    bar value StaticValue(1) range 10 style "slider" id "sl" xsize 240 ysize 24\n',
+            "BAR_STYLE_POSITION_UNSUPPORTED",
+        ),
+        (
+            # Block form is rejected before the slider-style identity check.
+            '    bar value StaticValue(1) range 10 style "slider" id "sl" xpos 1 ypos 2:\n',
+            "STATEMENT_KIND_MISMATCH",
+        ),
+        (
+            '    bar value StaticValue(1) range 10 style "slider" id "sl" xpos 100-20 ypos 10\n',
+            "XPOS_LITERAL_REQUIRED",
+        ),
+        (
+            '    bar value StaticValue(1) range 10 style "slider" id "sl" xpos 10 ypos 10+4\n',
+            "YPOS_LITERAL_REQUIRED",
+        ),
+    ),
+)
+def test_analyze_slider_statement_reuses_proven_position_lock_contract(
+    line: str,
+    expected_code: str,
+) -> None:
+    with pytest.raises(EditorSourceError) as excinfo:
+        analyze_slider_statement(line, expected_widget_id="sl")
+    assert excinfo.value.code == expected_code
+
+
+def test_analyze_slider_statement_rejects_id_and_coordinate_problems() -> None:
+    with pytest.raises(EditorSourceError) as excinfo:
+        analyze_slider_statement(
+            '    bar value StaticValue(1) range 10 style "slider" xpos 1 ypos 2\n',
+            expected_widget_id="sl",
+        )
+    assert excinfo.value.code == "ID_LITERAL_REQUIRED"
+
+    with pytest.raises(EditorSourceError) as excinfo:
+        analyze_slider_statement(
+            '    bar value StaticValue(1) range 10 style "slider" id "a" id "sl" xpos 1 ypos 2\n',
+            expected_widget_id="sl",
+        )
+    assert excinfo.value.code == "ID_LITERAL_REQUIRED"
+
+    with pytest.raises(EditorSourceError) as excinfo:
+        analyze_slider_statement(
+            '    bar value StaticValue(1) range 10 style "slider" id "other" xpos 1 ypos 2\n',
+            expected_widget_id="sl",
+        )
+    assert excinfo.value.code == "ID_MISMATCH"
+
+    with pytest.raises(EditorSourceError) as excinfo:
+        analyze_slider_statement(
+            '    bar value StaticValue(1) range 10 style "slider" id "sl" xpos 1 xpos 2 ypos 3\n',
+            expected_widget_id="sl",
+        )
+    assert excinfo.value.code == "XPOS_DUPLICATE"
+
+    with pytest.raises(EditorSourceError) as excinfo:
+        analyze_slider_statement(
+            '    bar value StaticValue(1) range 10 style "slider" id "sl" xpos 1 ypos 2 ypos 3\n',
+            expected_widget_id="sl",
         )
     assert excinfo.value.code == "YPOS_DUPLICATE"
 


### PR DESCRIPTION
## Summary

Implements [#36](https://github.com/alex-jordan547/renforge-mcp/issues/36): a **dedicated slider adapter** for the visual editor, with its own seven-step live proof on Ren'Py **8.5.3**.

### Measured Ren'Py fact

Screen language has **no `slider` keyword** on Ren'Py 8.5.3:

```
'slider' is not a keyword argument or valid child of the screen/fixed statement.
```

Games author sliders as single-line `bar` statements that select the `slider` style. Adapter identity is therefore **`bar` + literal `style "slider"`**, not a first-word keyword (unlike `bar` / `vbar`).

### Supported source form

```renpy
bar value VariableValue("some_var", range=100) style "slider" id "slider_target" xpos 200 ypos 180 xsize 240 ysize 24
```

Requirements:

- single physical source line (`bar` keyword)
- exactly one literal `style "slider"`
- exactly one literal string `id` matching the runtime widget id
- exactly one literal integer `xpos` and one literal integer `ypos`
- patch replaces only those two numeric spans; all other bytes stay identical

### Architecture

| Piece | Change |
|---|---|
| `src/renforge/editor/source.py` | `SliderStatement`, `is_slider_style_bar_line`, `analyze_slider_statement`, `apply_slider_patch`; `bar` dispatch routes style `"slider"` to the slider path |
| `src/renforge/editor/coordinator.py` | commit kind-drift accepts `statement_kind == "slider"` when the line is still `bar` + style `"slider"` |
| Live path | dedicated fixture + runner + opt-in `RENFORGE_SLIDER_LIVE=1` |
| Bridge | no change — runtime class remains `Bar` (already allowlisted by #34) |

### Lock matrix (measured, exact equality)

| Case | Lock code |
|---|---|
| Computed `xpos` | `XPOS_LITERAL_REQUIRED` |
| Style-driven / missing position with style | `BAR_STYLE_POSITION_UNSUPPORTED` |
| Layout container ancestry (`vbox`) | `CONTAINER_POSITION_UNSUPPORTED` |
| Ambiguous duplicate `use` instances | `SYNTHETIC_WIDGET_ID` |
| Real unproven ancestor (`Side`) | `UNKNOWN_ANCESTRY_TYPE` |

### Seven-step live proof

```bash
RENFORGE_SLIDER_LIVE=1 \
  PYTHONPATH=src python -m pytest -q tests/test_editor_slider_live.py
```

| Step | What is proven |
|---|---|
| 1 Resolve | `source_key.statement_kind == "slider"`, empty lock, host unlocks move, `measurement_method` from bridge |
| 2 Preview | Fresh focus rects before/after nudge; delta ≤ 1 logical px; distinct real `frame_id`s |
| 3 Patch | Save via real overlay; only xpos/ypos tokens change; independent expected bytes |
| 4 Reload | Generation +1, real `Reload committed` status |
| 5 Pixel agreement | Post-preview vs post-reload focus rect (≤ 1 px) |
| 6 Rebinding | New analysis id, same widget id / source identity, no lock |
| 7 Byte-identical undo | Baseline bytes and SHA-256 restored exactly |

Value invariance: `renforge_editor_slider_value` unchanged across preview and reload.

## Test plan

- [x] Unit / host:
  ```bash
  PYTHONPATH=src python -m pytest -q \
    tests/test_editor_source.py \
    tests/test_editor_coordinator.py \
    tests/test_editor_slider_live.py
  ```
  → **88 passed, 1 skipped**
- [x] Live proof on Ren'Py **8.5.3**:
  ```bash
  RENFORGE_SLIDER_LIVE=1 PYTHONPATH=src python -m pytest -q tests/test_editor_slider_live.py
  ```
  → **1 passed**
- [x] Docs updated only after live green (`v1-scope`, `vfull-roadmap`)
- [x] No contamination of `examples/demo_game` (fixture injected into a temp demo copy only)

## Explicit non-goals

- `vslider` adapter (still pending)
- inventing a screen-language `slider` keyword
- multi-line / block statements
- style editing, resize, container editing

Closes #36

## Summary by Sourcery

Introduire un adaptateur dédié pour les sliders dans l’éditeur visuel, en traitant les barres de style slider comme un type d’énoncé éditable distinct, avec une preuve en direct en sept étapes complète sur Ren'Py 8.5.3.

New Features:
- Ajouter un adaptateur `SliderStatement` qui reconnaît les énoncés de barre sur une seule ligne avec le style littéral `"slider"` et les expose avec `statement_kind "slider"` pour l’édition des mouvements.
- Fournir un exécuteur de slider en direct et un écran de fixture afin de valider l’adaptateur de slider de bout en bout sur Ren'Py 8.5.3 via un scénario de preuve en sept étapes.

Enhancements:
- Étendre la logique de dispatch et de commit des énoncés éditables afin que les barres de style `"slider"` soient acheminées vers l’adaptateur de slider, tout en préservant le comportement des barres pour les styles non-slider.
- Réutiliser les contrats de verrouillage de position existants pour les sliders, en garantissant que les coordonnées calculées, le positionnement basé uniquement sur le style, l’ascendance de conteneur, les doublons et les ascendances inconnues soient explicitement verrouillés avec des codes mesurés.
- Mettre à jour la gestion de la dérive de type du coordinateur afin que les énoncés enregistrés `"slider"` restent valides par rapport aux lignes sources écrites comme `bar + style "slider"`.
- Documenter la forme source prise en charge par l’adaptateur de slider, la matrice de verrous et la preuve en direct dans le périmètre v1 et les spécifications complètes de la feuille de route.

Tests:
- Ajouter des tests unitaires pour l’analyse des énoncés de slider, le dispatch, le patch et le comportement de verrouillage sur divers cas non pris en charge et d’erreur.
- Ajouter un test de preuve en direct en sept étapes pour l’adaptateur de slider qui s’exécute sur une copie temporaire du jeu de démo et vérifie le mouvement, l’intégrité des patchs, le comportement de rechargement, le rebinding, les verrous et l’annulation byte-identical.
- Introduire un écran de fixture en direct dédié définissant plusieurs variantes de slider pour couvrir des scénarios éditables et verrouillés dans la preuve en direct.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a dedicated slider adapter for the visual editor, treating slider-styled bars as a distinct editable statement kind with a full seven-step live proof on Ren'Py 8.5.3.

New Features:
- Add a SliderStatement adapter that recognizes single-line bar statements with literal style "slider" and exposes them as statement_kind "slider" for movement editing.
- Provide a live slider runner and fixture screen to validate the slider adapter end-to-end on Ren'Py 8.5.3 via a seven-step proof scenario.

Enhancements:
- Extend editable statement dispatch and commit logic so style "slider" bars are routed to the slider adapter while preserving bar behavior for non-slider styles.
- Reuse existing position lock contracts for sliders, ensuring computed coordinates, style-only positioning, container ancestry, duplicates, and unknown ancestry are explicitly locked with measured codes.
- Update coordinator kind drift handling so recorded "slider" statements still validate against source lines authored as bar + style "slider".
- Document the slider adapter’s supported source form, lock matrix, and live proof in the v1 scope and full roadmap specs.

Tests:
- Add unit tests for slider statement analysis, dispatch, patching, and lock behavior across various unsupported and error cases.
- Add a seven-step live proof test for the slider adapter that runs against a temporary copy of the demo game and verifies movement, patch integrity, reload behavior, rebinding, locks, and byte-identical undo.
- Introduce a dedicated live fixture screen defining multiple slider variants to exercise editable and locked scenarios in the live proof.

</details>