### PR TITLE
Support multi-line textbutton blocks without rewriting them

### DIFF
--- a/docs/superpowers/specs/2026-07-30-renforge-visual-editor-v1-scope.md
+++ b/docs/superpowers/specs/2026-07-30-renforge-visual-editor-v1-scope.md
@@ -33,7 +33,7 @@ requires it — none is arbitrary.
 |---|---|---|
 | 1 | Displayable is **focusable** | Selection and every save-bearing measurement read `renpy.display.focus.focus_list` |
 | 2 | Source statement carries one **literal `id`** matching the runtime widget id | Runtime preview uses `_widget_properties`, keyed by the authored widget id; synthetic observation IDs do not qualify |
-| 3 | A proven adapter statement (`textbutton`, `imagebutton`, single-line `bar`/`vbar`, slider-styled `bar`) or an explicit-block `button`, with one literal integer **`xpos` and `ypos`** | The token-aware patcher replaces only the coordinate spans; the button adapter preserves child block bytes |
+| 3 | A proven adapter statement (`textbutton` single-line or multi-line block, `imagebutton`, single-line `bar`/`vbar`, slider-styled `bar`) or an explicit-block `button`, with one literal integer **`xpos` and `ypos`** | The token-aware patcher replaces only the coordinate spans; block forms preserve every non-position byte |
 | 4 | Exactly one runtime instance with a fully classified, static ancestry outside **`viewport` / `Crop` / `Transform(crop=)`**, loop and repeated `use` cases | Only a unique static instance under proven clipping can be rebound unambiguously |
 
 **A failing gate is a first-class UI state, never a silent no-op.** The overlay must name which gate
@@ -55,7 +55,7 @@ V1 ships an explicit allowlist, extended one adapter at a time, each backed by a
 
 | Adapter | Selection | Write chain | Status |
 |---|---|---|---|
-| `textbutton` | Spike C `pass` | Spike D `pass` | **Shipped in V1** |
+| `textbutton` | Spike C `pass` | Spike D + multi-line block form (issue #37) | **Shipped in V1**; multi-line block live via `RENFORGE_MULTILINE_TEXTBUTTON_LIVE=1` |
 | `imagebutton` | Spike C `pass` (focusable) | dedicated analyzer + coordinator path + seven-step live proof | **Implemented** (live proof green via `RENFORGE_IMAGEBUTTON_LIVE=1`) |
 | `button` | focusable by construction | Seven-step live proof (explicit block) | **Shipped in V1** |
 | `bar` | focusable when adjustable (measured on Ren'Py 8.5.3) | dedicated single-line analyzer + seven-step live proof | **Implemented** (live proof green via `RENFORGE_BAR_LIVE=1`) |
@@ -66,6 +66,29 @@ V1 ships an explicit allowlist, extended one adapter at a time, each backed by a
 `imagebutton` has a dedicated single-line adapter (issue #32) rather than a textbutton allowlist widen.
 Host unit/coordinator coverage lands in default CI; the seven-step live proof is opt-in in CI but was
 executed green locally against Ren'Py 8.5.3 (`RENFORGE_IMAGEBUTTON_LIVE=1 pytest tests/test_editor_imagebutton_live.py`).
+
+### Multi-line textbutton blocks (issue #37)
+
+In addition to the single-line form, V1 supports one multi-line shape for the already-proven
+`textbutton` adapter — position tokens live in the child block, not on the header:
+
+```renpy
+textbutton "MOVE ME":
+    id "ml_tb_target"
+    xpos 200
+    ypos 180
+    action NullAction()
+```
+
+Requirements: header ends with `:`; header carries no `id`/`xpos`/`ypos`; exactly one literal string
+`id` and one literal integer `xpos`/`ypos` each among direct children at the block indent; patch
+replaces only those two integer tokens (absolute spans in the full file); every other block byte is
+preserved. Computed coordinates, container ancestry, ambiguous `use` instances, and unproven ancestry
+remain locked with the measured codes (`XPOS_LITERAL_REQUIRED`, `CONTAINER_POSITION_UNSUPPORTED`,
+`SYNTHETIC_WIDGET_ID`, `UNKNOWN_ANCESTRY_TYPE`, …).
+
+Live proof: `RENFORGE_MULTILINE_TEXTBUTTON_LIVE=1 uv run --extra test python -m pytest -q tests/test_editor_multiline_textbutton_live.py`
+against Ren'Py **8.5.3**.
 
 The `button` adapter is intentionally limited to `button id "..." xpos N ypos N:` headers. Computed
 coordinates, direct child `xpos`/`ypos`, layout-container ancestry, and ambiguous or unproven runtime

--- a/docs/superpowers/specs/2026-07-30-renforge-visual-editor-vfull-roadmap.md
+++ b/docs/superpowers/specs/2026-07-30-renforge-visual-editor-vfull-roadmap.md
@@ -63,7 +63,7 @@ Real screens are messier.
 
 | Form | Problem | Possible approach |
 |---|---|---|
-| Multi-line statement with a block | Position keywords may sit on any line of the block | Parse the statement span, not one line |
+| Multi-line statement with a block | Position keywords may sit on any line of the block | **Partially implemented (issue #37):** multi-line `textbutton` with `id`/`xpos`/`ypos` in the child block only; seven-step live proof green via `RENFORGE_MULTILINE_TEXTBUTTON_LIVE=1`. Other adapters remain single-line or header-only (`button`). |
 | `pos (x, y)` / `align` / `anchor` / `offset` | Different property, same intent | Normalise to a position model; write back in the form the author used |
 | Position from a **variable or expression** | Cannot be rewritten without changing semantics | **Stays locked.** Offer to show the computed value, never to overwrite the expression |
 | Element inside `hbox` / `vbox` / `grid` | Position is computed by the layout, not authored | **Stays locked** for direct move. A layout-aware edit is a different feature |

--- a/src/renforge/editor/coordinator.py
+++ b/src/renforge/editor/coordinator.py
@@ -33,9 +33,12 @@ from .source import (
     EditorSourceError,
     analyze_button_statement,
     analyze_editable_statement,
+    analyze_textbutton_block_statement,
     apply_button_patch,
     apply_editable_statement_patch,
+    apply_textbutton_patch,
     is_slider_style_bar_line,
+    is_textbutton_block_header,
     peek_statement_kind,
 )
 
@@ -533,16 +536,25 @@ class EditorCoordinator:
             if source_line < 1 or source_line > len(lines):
                 raise EditorError("SOURCE_LINE_INVALID", "source line is out of range")
             widget_id = self._require_runtime_widget_id(runtime_key)
-            if peek_statement_kind(lines[source_line - 1]) == "button":
+            header_line = lines[source_line - 1]
+            header_kind = peek_statement_kind(header_line)
+            if header_kind == "button":
                 statement = analyze_button_statement(
                     source_text,
                     source_line=source_line,
                     expected_widget_id=widget_id,
                 )
                 statement_kind = "button"
+            elif header_kind == "textbutton" and is_textbutton_block_header(header_line):
+                statement = analyze_textbutton_block_statement(
+                    source_text,
+                    source_line=source_line,
+                    expected_widget_id=widget_id,
+                )
+                statement_kind = "textbutton"
             else:
                 statement_kind, statement = analyze_editable_statement(
-                    lines[source_line - 1],
+                    header_line,
                     expected_widget_id=widget_id,
                 )
             original_position = [statement.xpos, statement.ypos]
@@ -1010,6 +1022,18 @@ class EditorCoordinator:
                     expected_widget_id=widget_id,
                 )
                 lines = apply_button_patch(
+                    "".join(lines).encode("utf-8"),
+                    statement,
+                    x=x,
+                    y=y,
+                ).decode("utf-8").splitlines(keepends=True)
+            elif actual_kind == "textbutton" and is_textbutton_block_header(lines[line_no - 1]):
+                statement = analyze_textbutton_block_statement(
+                    source_text,
+                    source_line=line_no,
+                    expected_widget_id=widget_id,
+                )
+                lines = apply_textbutton_patch(
                     "".join(lines).encode("utf-8"),
                     statement,
                     x=x,

--- a/src/renforge/editor/source.py
+++ b/src/renforge/editor/source.py
@@ -18,7 +18,10 @@ class TextbuttonStatement:
     ypos: int
     xpos_span: tuple[int, int]
     ypos_span: tuple[int, int]
-
+    # "single_line" keeps spans relative to the statement line.
+    # "block" keeps absolute character spans in the full source file.
+    form: str = "single_line"
+    source_line: int | None = None
 
 
 @dataclass(frozen=True)
@@ -296,11 +299,179 @@ def _analyze_positioned_kind_statement(
 
 
 def analyze_textbutton_statement(line: str, *, expected_widget_id: str) -> TextbuttonStatement:
+    if is_textbutton_block_header(line):
+        raise EditorSourceError(
+            "MULTILINE_STATEMENT_REJECTED",
+            "textbutton block headers require analyze_textbutton_block_statement",
+        )
     return _analyze_positioned_kind_statement(
         line,
         expected_widget_id=expected_widget_id,
         expected_kind="textbutton",
         statement_cls=TextbuttonStatement,
+    )
+
+
+def is_textbutton_block_header(line: str) -> bool:
+    """True when the line is a textbutton header ending with an explicit block colon."""
+    try:
+        statement_text = _statement_text(line)
+    except EditorSourceError:
+        return False
+    tokens = _lex_single_line(statement_text)
+    top_level = [token for token in tokens if token.depth == 0]
+    if not top_level or top_level[0].kind != "WORD" or top_level[0].text != "textbutton":
+        return False
+    colon_tokens = [token for token in top_level if token.kind == "SYMBOL" and token.text == ":"]
+    return len(colon_tokens) == 1 and top_level[-1] is colon_tokens[0]
+
+
+def analyze_textbutton_block_statement(
+    source_text: str,
+    *,
+    source_line: int,
+    expected_widget_id: str,
+) -> TextbuttonStatement:
+    """Analyze multi-line textbutton with id/xpos/ypos authored in the child block.
+
+    Supported shape (one physical form, already-proven adapter)::
+
+        textbutton "Label":
+            id "widget_id"
+            xpos 100
+            ypos 200
+            action NullAction()
+
+    Header must not carry id/xpos/ypos. Only direct child properties at the block
+    indent are considered. Patch spans are absolute within ``source_text``.
+    """
+    lines = source_text.splitlines(keepends=True)
+    if source_line < 1 or source_line > len(lines):
+        raise EditorSourceError("SOURCE_LINE_INVALID", "textbutton source line is outside the source file")
+
+    header_line = lines[source_line - 1]
+    if not is_textbutton_block_header(header_line):
+        raise EditorSourceError(
+            "MULTILINE_STATEMENT_REJECTED",
+            "textbutton statement is not a supported multi-line block header",
+        )
+
+    header_text = header_line.rstrip("\r\n")
+    header_tokens = _lex_single_line(header_text)
+    for token in header_tokens:
+        if token.depth == 0 and token.kind == "WORD" and token.text in {"id", "xpos", "ypos"}:
+            raise EditorSourceError(
+                "POSITION_ON_HEADER_UNSUPPORTED",
+                "textbutton block form requires id/xpos/ypos in the child block only",
+            )
+
+    header_indent = len(header_line) - len(header_line.lstrip(" \t"))
+    try:
+        child_indexes = _button_child_line_indexes(lines, source_line, header_indent)
+    except EditorSourceError as exc:
+        if exc.code == "BUTTON_BLOCK_REQUIRED":
+            raise EditorSourceError(
+                "MULTILINE_STATEMENT_REJECTED",
+                "textbutton block must contain a child block",
+            ) from exc
+        raise
+    child_indent = min(
+        len(lines[index]) - len(lines[index].lstrip(" \t")) for index in child_indexes
+    )
+
+    keyword_counts = {"id": 0, "xpos": 0, "ypos": 0}
+    widget_id: str | None = None
+    xpos_value: int | None = None
+    ypos_value: int | None = None
+    xpos_span: tuple[int, int] | None = None
+    ypos_span: tuple[int, int] | None = None
+    invalid_literals: set[str] = set()
+
+    for child_index in child_indexes:
+        child_line = lines[child_index]
+        child_indent_value = len(child_line) - len(child_line.lstrip(" \t"))
+        if child_indent_value != child_indent:
+            # Nested deeper (e.g. inside a child container) is ignored for identity.
+            continue
+        child_text = child_line.rstrip("\r\n")
+        tokens = _lex_single_line(child_text)
+        top_level = [token for token in tokens if token.depth == 0]
+        if not top_level or top_level[0].kind != "WORD":
+            continue
+        keyword = top_level[0].text
+        if keyword not in keyword_counts:
+            continue
+        keyword_counts[keyword] += 1
+        value_index = _next_top_level_index(tokens, 0)
+        line_offset = sum(len(line) for line in lines[:child_index])
+        if value_index is None:
+            invalid_literals.add(keyword)
+            continue
+        value_token = tokens[value_index]
+        if keyword == "id":
+            if value_token.kind != "STRING":
+                invalid_literals.add(keyword)
+                continue
+            widget_id = _parse_string_token(value_token)
+            continue
+        if value_token.kind != "NUMBER":
+            invalid_literals.add(keyword)
+            continue
+        following_index = _next_top_level_index(tokens, value_index)
+        if following_index is not None and tokens[following_index].kind != "WORD":
+            invalid_literals.add(keyword)
+            continue
+        value = int(value_token.text)
+        absolute_span = (line_offset + value_token.start, line_offset + value_token.end)
+        if keyword == "xpos":
+            xpos_value = value
+            xpos_span = absolute_span
+        else:
+            ypos_value = value
+            ypos_span = absolute_span
+
+    if keyword_counts["id"] != 1:
+        raise EditorSourceError(
+            "ID_LITERAL_REQUIRED",
+            "textbutton block must contain exactly one literal id",
+        )
+    if "id" in invalid_literals or widget_id is None:
+        raise EditorSourceError("ID_LITERAL_REQUIRED", "id must be a literal string")
+    if widget_id != expected_widget_id:
+        raise EditorSourceError("ID_MISMATCH", "literal id does not match runtime widget id")
+    if keyword_counts["xpos"] == 0:
+        raise EditorSourceError(
+            "XPOS_LITERAL_REQUIRED",
+            "textbutton block must author a literal xpos",
+        )
+    if keyword_counts["xpos"] != 1:
+        raise EditorSourceError(
+            "XPOS_DUPLICATE",
+            "textbutton block must contain exactly one xpos",
+        )
+    if keyword_counts["ypos"] == 0:
+        raise EditorSourceError(
+            "YPOS_LITERAL_REQUIRED",
+            "textbutton block must author a literal ypos",
+        )
+    if keyword_counts["ypos"] != 1:
+        raise EditorSourceError(
+            "YPOS_DUPLICATE",
+            "textbutton block must contain exactly one ypos",
+        )
+    if "xpos" in invalid_literals or xpos_value is None or xpos_span is None:
+        raise EditorSourceError("XPOS_LITERAL_REQUIRED", "xpos must be a literal integer")
+    if "ypos" in invalid_literals or ypos_value is None or ypos_span is None:
+        raise EditorSourceError("YPOS_LITERAL_REQUIRED", "ypos must be a literal integer")
+
+    return TextbuttonStatement(
+        widget_id=widget_id,
+        xpos=xpos_value,
+        ypos=ypos_value,
+        xpos_span=xpos_span,
+        ypos_span=ypos_span,
+        form="block",
+        source_line=source_line,
     )
 
 
@@ -582,6 +753,8 @@ def _apply_integer_span_patch(
 
 
 def apply_textbutton_patch(source_bytes: bytes, statement: TextbuttonStatement, *, x: int, y: int) -> bytes:
+    # Block form spans are absolute in the full source; single-line spans are
+    # relative to the single line bytes passed by the coordinator.
     return _apply_integer_span_patch(
         source_bytes,
         xpos_span=statement.xpos_span,
@@ -639,7 +812,13 @@ def analyze_editable_statement(
     str,
     TextbuttonStatement | ImagebuttonStatement | BarStatement | VbarStatement | SliderStatement,
 ]:
-    """Dispatch to a dedicated analyzer. Not a merged grammar."""
+    """Dispatch to a dedicated analyzer. Not a merged grammar.
+
+    Multi-line textbutton blocks are handled by
+    :func:`analyze_textbutton_block_statement` via the coordinator (needs full
+    source text). A block header alone is rejected here with
+    ``MULTILINE_STATEMENT_REJECTED``.
+    """
     kind = peek_statement_kind(line)
     if kind == "textbutton":
         return kind, analyze_textbutton_statement(line, expected_widget_id=expected_widget_id)

--- a/src/renforge/editor_multiline_textbutton_runner.py
+++ b/src/renforge/editor_multiline_textbutton_runner.py
@@ -218,7 +218,7 @@ def run_editor_multiline_textbutton_live_scenario(client: Any, *, fixture_path: 
     """Seven-step live proof for multi-line textbutton block form (issue #37)."""
     report: dict[str, Any] = {}
     baseline_bytes = fixture_path.read_bytes()
-    baseline_sha = hashlib.sha256(baseline_bytes).hexdigest()
+    baseline_sha = _sha256_file(fixture_path)
     baseline_text = baseline_bytes.decode("utf-8")
     # Prove analyzer accepts the authored multi-line shape before any UI work.
     header_line = _target_header_source_line(baseline_text)
@@ -419,7 +419,7 @@ def run_editor_multiline_textbutton_live_scenario(client: Any, *, fixture_path: 
 
     # Step 3: patch via real Save overlay control.
     pre_save_bytes = fixture_path.read_bytes()
-    pre_save_sha = hashlib.sha256(pre_save_bytes).hexdigest()
+    pre_save_sha = _sha256_file(fixture_path)
     pre_save_text = pre_save_bytes.decode("utf-8")
     generation_before = _source_generation(analysis_status)
     save_request = _require_ok(
@@ -435,7 +435,7 @@ def run_editor_multiline_textbutton_live_scenario(client: Any, *, fixture_path: 
         poll_name="ml tb save complete",
     )
     post_save_bytes = fixture_path.read_bytes()
-    post_save_sha = hashlib.sha256(post_save_bytes).hexdigest()
+    post_save_sha = _sha256_file(fixture_path)
     post_save_text = post_save_bytes.decode("utf-8")
     source_position_after = _parse_xy_from_target_line(post_save_text)
     expected_source_position = {"x": requested_after[0], "y": requested_after[1]}

--- a/src/renforge/editor_multiline_textbutton_runner.py
+++ b/src/renforge/editor_multiline_textbutton_runner.py
@@ -1,0 +1,558 @@
+from __future__ import annotations
+
+import hashlib
+import re
+import shutil
+import time
+from pathlib import Path
+from typing import Any
+
+from renforge.editor.source import analyze_textbutton_block_statement
+from renforge.editor_task0_runner import (
+    _require_ok,
+    _source_generation,
+    _wait_for_status,
+)
+
+FIXTURE_SCREEN = "renforge_editor_multiline_textbutton_fixture"
+TARGET_ID = "ml_tb_target"
+EDITOR_RESOURCE = Path(__file__).resolve().parent / "bridge" / "editor.rpy"
+FIXTURE_RESOURCE = (
+    Path(__file__).resolve().parents[2]
+    / "tests"
+    / "live_fixtures"
+    / "renforge_editor_multiline_textbutton_fixture.rpy"
+)
+
+
+def inject_editor_multiline_textbutton_resources(project_root: Path) -> dict[str, str]:
+    game_dir = project_root / "game"
+    game_dir.mkdir(parents=True, exist_ok=True)
+    editor_target = game_dir / "zz_renforge_editor_multiline_textbutton.rpy"
+    fixture_target = game_dir / "zz_renforge_editor_multiline_textbutton_fixture.rpy"
+    shutil.copyfile(EDITOR_RESOURCE, editor_target)
+    shutil.copyfile(FIXTURE_RESOURCE, fixture_target)
+    return {
+        "editor": str(editor_target),
+        "fixture": str(fixture_target),
+    }
+
+
+def _find_element(
+    elements: list[dict[str, Any]],
+    wanted_id: str,
+    *,
+    wanted_text: str | None = None,
+) -> dict[str, Any]:
+    for element in elements:
+        element_id = str(element.get("id") or "")
+        if wanted_text is not None:
+            if element_id == wanted_id and str(element.get("text") or "") == wanted_text:
+                return element
+            continue
+        if element_id == wanted_id:
+            return element
+    raise AssertionError(
+        f"missing expected element id {wanted_id!r} text {wanted_text!r}: {elements!r}"
+    )
+
+
+def _center(bounds: dict[str, Any]) -> tuple[int, int]:
+    return (
+        int(bounds["x"]) + int(bounds["width"]) // 2,
+        int(bounds["y"]) + int(bounds["height"]) // 2,
+    )
+
+
+def _sha256_file(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _list_info(client: Any) -> dict[str, Any]:
+    info = client.list_ui_elements_info(screen=FIXTURE_SCREEN)
+    if not isinstance(info, dict):
+        raise AssertionError(f"list_ui_elements_info returned non-dict: {info!r}")
+    return info
+
+
+def _wait_bounds(client: Any, widget_id: str, *, timeout: float = 6.0) -> dict[str, int]:
+    deadline = time.monotonic() + timeout
+    last: list[dict[str, Any]] = []
+    while time.monotonic() < deadline:
+        info = _list_info(client)
+        last = info.get("elements") if isinstance(info.get("elements"), list) else []
+        try:
+            element = _find_element(last, widget_id)
+        except AssertionError:
+            time.sleep(0.05)
+            continue
+        bounds = element.get("bounds")
+        if isinstance(bounds, dict):
+            return {
+                "x": int(bounds["x"]),
+                "y": int(bounds["y"]),
+                "width": int(bounds["width"]),
+                "height": int(bounds["height"]),
+            }
+        time.sleep(0.05)
+    raise AssertionError(f"bounds for {widget_id!r} unavailable: {last!r}")
+
+
+def _target_header_source_line(source_text: str) -> int:
+    """1-based source line of the multi-line textbutton header for TARGET_ID."""
+    lines = source_text.splitlines(keepends=True)
+    for index, line in enumerate(lines):
+        if not line.lstrip().startswith("textbutton "):
+            continue
+        if not line.rstrip().endswith(":"):
+            continue
+        # Validate the block that starts at this header owns TARGET_ID.
+        try:
+            analyze_textbutton_block_statement(
+                source_text,
+                source_line=index + 1,
+                expected_widget_id=TARGET_ID,
+            )
+        except Exception:
+            continue
+        return index + 1
+    raise AssertionError(f"source missing multi-line textbutton block for {TARGET_ID!r}")
+
+
+def _target_block_slice(source_text: str) -> tuple[int, int, str]:
+    """Return (start_offset, end_offset, block_text) for the target statement span."""
+    header_line = _target_header_source_line(source_text)
+    lines = source_text.splitlines(keepends=True)
+    header = lines[header_line - 1]
+    header_indent = len(header) - len(header.lstrip(" \t"))
+    end_index = header_line  # exclusive end line index (0-based end = header_line in 1-based end)
+    for index in range(header_line, len(lines)):
+        line = lines[index]
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            end_index = index + 1
+            continue
+        indent = len(line) - len(line.lstrip(" \t"))
+        if indent <= header_indent:
+            break
+        end_index = index + 1
+    start_offset = sum(len(line) for line in lines[: header_line - 1])
+    end_offset = sum(len(line) for line in lines[:end_index])
+    return start_offset, end_offset, source_text[start_offset:end_offset]
+
+
+def _independent_expected_after_patch(before_text: str, *, x: int, y: int) -> str:
+    """Build expected fixture text without calling apply_textbutton_patch."""
+    start, end, block = _target_block_slice(before_text)
+    # Only rewrite direct child xpos/ypos lines inside the block (not nested).
+    patched_block = re.sub(
+        r"(?m)^(\s*xpos\s+)-?\d+(\s*)$",
+        rf"\g<1>{int(x)}\2",
+        block,
+        count=1,
+    )
+    patched_block = re.sub(
+        r"(?m)^(\s*ypos\s+)-?\d+(\s*)$",
+        rf"\g<1>{int(y)}\2",
+        patched_block,
+        count=1,
+    )
+    if patched_block == block:
+        raise AssertionError("independent patch constructor did not change target block")
+    return f"{before_text[:start]}{patched_block}{before_text[end:]}"
+
+
+def _outside_coordinate_spans_identical(before_text: str, after_text: str) -> bool:
+    before_start, before_end, before_block = _target_block_slice(before_text)
+    after_start, after_end, after_block = _target_block_slice(after_text)
+    before_norm = re.sub(r"(?m)^(\s*xpos\s+)-?\d+(\s*)$", r"\1__X__\2", before_block, count=1)
+    before_norm = re.sub(r"(?m)^(\s*ypos\s+)-?\d+(\s*)$", r"\1__Y__\2", before_norm, count=1)
+    after_norm = re.sub(r"(?m)^(\s*xpos\s+)-?\d+(\s*)$", r"\1__X__\2", after_block, count=1)
+    after_norm = re.sub(r"(?m)^(\s*ypos\s+)-?\d+(\s*)$", r"\1__Y__\2", after_norm, count=1)
+    if before_norm != after_norm:
+        return False
+    return before_text[:before_start] + before_text[before_end:] == after_text[:after_start] + after_text[after_end:]
+
+
+def _parse_xy_from_target_line(source_text: str) -> dict[str, int]:
+    _, _, block = _target_block_slice(source_text)
+    xpos = re.search(r"(?m)^\s*xpos\s+(-?\d+)\s*$", block)
+    ypos = re.search(r"(?m)^\s*ypos\s+(-?\d+)\s*$", block)
+    if xpos is None or ypos is None:
+        raise AssertionError(f"target block missing literal xpos/ypos: {block!r}")
+    return {"x": int(xpos.group(1)), "y": int(ypos.group(1))}
+
+def _select_lock(client: Any, widget_id: str, expected_code: str) -> str:
+    bounds = _wait_bounds(client, widget_id)
+    selection = client.request(
+        "editor_task0_select",
+        {"x": _center(bounds)[0], "y": _center(bounds)[1]},
+    )
+    immediate = selection.get("lock_reason") if isinstance(selection, dict) else None
+    if immediate == expected_code:
+        return expected_code
+    status = _wait_for_status(
+        client,
+        lambda current: current.get("selected_widget_id") == widget_id
+        and current.get("selected_lock_reason") == expected_code,
+        timeout=10.0,
+        poll_name=f"{widget_id} lock",
+    )
+    lock_reason = status.get("selected_lock_reason")
+    if lock_reason != expected_code:
+        raise AssertionError(f"unexpected lock for {widget_id!r}: {status!r}")
+    return str(lock_reason)
+
+
+def _observe_selected(client: Any) -> dict[str, Any]:
+    reply = client.request("editor_task0_observe_selected", {})
+    if not isinstance(reply, dict) or reply.get("ok") is not True:
+        raise AssertionError(f"observe_selected failed: {reply!r}")
+    observation = reply.get("observation")
+    if not isinstance(observation, dict):
+        raise AssertionError(f"observe_selected missing observation: {reply!r}")
+    return observation
+
+
+def run_editor_multiline_textbutton_live_scenario(client: Any, *, fixture_path: Path) -> dict[str, Any]:
+    """Seven-step live proof for multi-line textbutton block form (issue #37)."""
+    report: dict[str, Any] = {}
+    baseline_bytes = fixture_path.read_bytes()
+    baseline_sha = hashlib.sha256(baseline_bytes).hexdigest()
+    baseline_text = baseline_bytes.decode("utf-8")
+    # Prove analyzer accepts the authored multi-line shape before any UI work.
+    header_line = _target_header_source_line(baseline_text)
+    analyze_textbutton_block_statement(
+        baseline_text,
+        source_line=header_line,
+        expected_widget_id=TARGET_ID,
+    )
+    baseline_position = _parse_xy_from_target_line(baseline_text)
+    report["fixture_before"] = {
+        "sha256": baseline_sha,
+        "position": baseline_position,
+        "header_line": header_line,
+    }
+
+    start = _require_ok(
+        client.request("editor_task0_start", {"screen": FIXTURE_SCREEN}),
+        "editor_task0_start",
+    )
+    report["start"] = start
+
+    # Lock matrix first on real focusable widgets (measured codes).
+    report["locks"] = {
+        "computed": _select_lock(client, "ml_tb_computed", "XPOS_LITERAL_REQUIRED"),
+        "container": _select_lock(client, "ml_tb_container", "CONTAINER_POSITION_UNSUPPORTED"),
+    }
+
+    # Measured live: two use-statements share id "ml_tb_dupe_target". The first
+    # instance is still selectable by focus bounds and locks as SYNTHETIC_WIDGET_ID
+    # (list_ui may only name the second instance).
+    dupe_info = _list_info(client)
+    dupe_elements = dupe_info.get("elements") if isinstance(dupe_info, dict) else None
+    # Prefer the unnamed first instance (NullAction-ish id) then fall back to
+    # the named target bounds at the left dupe coordinate.
+    dupe_pick = None
+    for element in dupe_elements if isinstance(dupe_elements, list) else []:
+        bounds = element.get("bounds")
+        if not isinstance(bounds, dict):
+            continue
+        text = str(element.get("text") or "")
+        if text == "DUPE A" or (
+            int(bounds.get("x", -1)) == 520 and int(bounds.get("y", -1)) == 430
+        ):
+            dupe_pick = bounds
+            break
+    if dupe_pick is None:
+        raise AssertionError(f"could not locate first dupe bounds: {dupe_elements!r}")
+    dupe_select = client.request(
+        "editor_task0_select",
+        {
+            "x": int(dupe_pick["x"]) + max(2, int(dupe_pick["width"]) // 4),
+            "y": int(dupe_pick["y"]) + int(dupe_pick["height"]) // 2,
+        },
+    )
+    ambiguous = dupe_select.get("lock_reason") if isinstance(dupe_select, dict) else None
+    if ambiguous in (None, ""):
+        status = _wait_for_status(
+            client,
+            lambda current: current.get("selected_lock_reason") == "SYNTHETIC_WIDGET_ID",
+            timeout=10.0,
+            poll_name="ml tb dupe lock",
+        )
+        ambiguous = status.get("selected_lock_reason")
+    if ambiguous != "SYNTHETIC_WIDGET_ID":
+        raise AssertionError(
+            f"duplicate multiline textbutton lock was not SYNTHETIC_WIDGET_ID: {ambiguous!r}"
+        )
+    report["locks"]["ambiguous"] = ambiguous
+
+    # Measured live: Side is not in the ancestry allowlist → UNKNOWN_ANCESTRY_TYPE.
+    side_bounds = _wait_bounds(client, "ml_tb_side", timeout=3.0)
+    side_select = client.request(
+        "editor_task0_select",
+        {"x": _center(side_bounds)[0], "y": _center(side_bounds)[1]},
+    )
+    unproven = side_select.get("lock_reason") if isinstance(side_select, dict) else None
+    if unproven in (None, ""):
+        status = _wait_for_status(
+            client,
+            lambda current: current.get("selected_lock_reason") == "UNKNOWN_ANCESTRY_TYPE",
+            timeout=10.0,
+            poll_name="ml tb side lock",
+        )
+        unproven = status.get("selected_lock_reason")
+    if unproven != "UNKNOWN_ANCESTRY_TYPE":
+        raise AssertionError(
+            f"side-ancestor multiline textbutton lock was not UNKNOWN_ANCESTRY_TYPE: {unproven!r}"
+        )
+    report["locks"]["unproven"] = unproven
+
+    # Step 1: resolve the editable multi-line textbutton from a fresh focus rect.
+    target_bounds = _wait_bounds(client, TARGET_ID)
+    target_center = _center(target_bounds)
+    select = _require_ok(
+        client.request(
+            "editor_task0_select",
+            {"x": target_center[0], "y": target_center[1]},
+        ),
+        "target select",
+    )
+    observation = select.get("observation") or {}
+    if observation.get("measurement_method") != "focus_list":
+        raise AssertionError(f"select observation not focus_list: {observation!r}")
+
+    analysis_status = _wait_for_status(
+        client,
+        lambda status: bool(status.get("current_analysis_id"))
+        and status.get("selected_widget_id") == TARGET_ID
+        and status.get("selected_lock_reason") in (None, ""),
+        timeout=10.0,
+        poll_name="ml tb analysis",
+    )
+    source_key = analysis_status.get("current_source_key") or {}
+    capabilities = analysis_status.get("current_capabilities") or {}
+    host_move = capabilities.get("move")
+    report["resolve"] = {
+        "statement_kind": source_key.get("statement_kind"),
+        "lock_reason": analysis_status.get("selected_lock_reason"),
+        "move": host_move,
+        "analysis_id": analysis_status.get("current_analysis_id"),
+        "measurement_method": observation.get("measurement_method"),
+        "frame_id": observation.get("frame_id"),
+        "source_key": source_key,
+    }
+    if source_key.get("statement_kind") != "textbutton":
+        raise AssertionError(f"expected textbutton statement_kind: {source_key!r}")
+    if host_move is not True:
+        raise AssertionError(f"host did not unlock move for multiline textbutton: {analysis_status!r}")
+
+    original = analysis_status.get("selected_original_position") or analysis_status.get(
+        "selected_source_position"
+    )
+    if not (isinstance(original, (list, tuple)) and len(original) == 2):
+        original = [int(baseline_position["x"]), int(baseline_position["y"])]
+    requested_before = [int(original[0]), int(original[1])]
+
+    # Fresh focus_list observation before preview movement.
+    value_baseline = client.eval_expr("renforge_editor_ml_tb_clicks")
+    before_obs = _observe_selected(client)
+    before_rect = before_obs.get("rect") or []
+    if len(before_rect) < 2:
+        raise AssertionError(f"pre-preview observation missing rect: {before_obs!r}")
+    bounds_before = [int(before_rect[0]), int(before_rect[1])]
+    frame_before = before_obs.get("frame_id")
+
+    # Step 2: preview.
+    _require_ok(client.request("editor_task0_key", {"key": "right", "repeat": 24}), "nudge right")
+    _require_ok(client.request("editor_task0_key", {"key": "down", "repeat": 16}), "nudge down")
+    preview_status = _wait_for_status(
+        client,
+        lambda status: isinstance(status.get("preview_position"), (list, tuple))
+        and len(status.get("preview_position") or []) == 2
+        and list(status.get("preview_position") or []) != requested_before,
+        timeout=8.0,
+        poll_name="ml tb preview moved",
+    )
+    requested_after = [
+        int(preview_status["preview_position"][0]),
+        int(preview_status["preview_position"][1]),
+    ]
+    after_obs = _observe_selected(client)
+    value_preview = client.eval_expr("renforge_editor_ml_tb_clicks")
+    after_rect = after_obs.get("rect") or []
+    if len(after_rect) < 2:
+        raise AssertionError(f"post-preview observation missing rect: {after_obs!r}")
+    bounds_after = [int(after_rect[0]), int(after_rect[1])]
+    frame_after = after_obs.get("frame_id")
+    if not frame_before or not frame_after or frame_before == frame_after:
+        raise AssertionError(
+            f"preview observations must have distinct real frame_ids: "
+            f"before={frame_before!r}, after={frame_after!r}"
+        )
+    if before_obs.get("measurement_method") != "focus_list" or after_obs.get("measurement_method") != "focus_list":
+        raise AssertionError(
+            "preview observations must report measurement_method from bridge: "
+            f"before={before_obs.get('measurement_method')!r}, after={after_obs.get('measurement_method')!r}"
+        )
+    requested_delta = [requested_after[axis] - requested_before[axis] for axis in (0, 1)]
+    observed_delta = [bounds_after[axis] - bounds_before[axis] for axis in (0, 1)]
+    if any(abs(observed_delta[axis] - requested_delta[axis]) > 1 for axis in (0, 1)):
+        raise AssertionError(
+            "focus_list preview bounds disagree with requested movement: "
+            f"requested={requested_delta!r}, observed={observed_delta!r}"
+        )
+    report["preview"] = {
+        "bounds_before": bounds_before,
+        "bounds_after": bounds_after,
+        "requested_before": requested_before,
+        "requested_after": requested_after,
+        "requested_delta": requested_delta,
+        "observed_delta": observed_delta,
+        "measurement_method_before": before_obs.get("measurement_method"),
+        "measurement_method_after": after_obs.get("measurement_method"),
+        "measurement_method": after_obs.get("measurement_method"),
+        "frame_id_before": frame_before,
+        "frame_id_after": frame_after,
+    }
+
+    # Step 3: patch via real Save overlay control.
+    pre_save_bytes = fixture_path.read_bytes()
+    pre_save_sha = hashlib.sha256(pre_save_bytes).hexdigest()
+    pre_save_text = pre_save_bytes.decode("utf-8")
+    generation_before = _source_generation(analysis_status)
+    save_request = _require_ok(
+        client.click_element(id="rf_save", screen="_renforge_editor_overlay"),
+        "ml tb save",
+    )
+    save_status = _wait_for_status(
+        client,
+        lambda status: not bool(status.get("save_in_progress"))
+        and status.get("status_text") == "Reload committed"
+        and _source_generation(status) == generation_before + 1,
+        timeout=60.0,
+        poll_name="ml tb save complete",
+    )
+    post_save_bytes = fixture_path.read_bytes()
+    post_save_sha = hashlib.sha256(post_save_bytes).hexdigest()
+    post_save_text = post_save_bytes.decode("utf-8")
+    source_position_after = _parse_xy_from_target_line(post_save_text)
+    expected_source_position = {"x": requested_after[0], "y": requested_after[1]}
+    if source_position_after != expected_source_position:
+        raise AssertionError(
+            "source patch disagrees with requested preview position: "
+            f"expected={expected_source_position!r}, observed={source_position_after!r}"
+        )
+    expected_text = _independent_expected_after_patch(
+        pre_save_text,
+        x=requested_after[0],
+        y=requested_after[1],
+    )
+    if post_save_text != expected_text:
+        raise AssertionError("patched fixture bytes disagree with independent expected content")
+    outside_coordinate_spans_identical = _outside_coordinate_spans_identical(
+        pre_save_text,
+        post_save_text,
+    )
+    if not outside_coordinate_spans_identical:
+        raise AssertionError("source patch changed bytes outside xpos/ypos spans")
+    report["patch"] = {
+        "before_sha256": pre_save_sha,
+        "after_sha256": post_save_sha,
+        "source_position_after": source_position_after,
+        "outside_coordinate_spans_identical": outside_coordinate_spans_identical,
+        "matches_independent_expected": True,
+        "save_request": save_request,
+    }
+
+    # Step 4: reload publication cycle (frame_id filled after rebind observation).
+    report["reload"] = {
+        "ok": True,
+        "script_generation": _source_generation(save_status),
+        "status_text": save_status.get("status_text"),
+        "generation_delta": _source_generation(save_status) - generation_before,
+        "pending_handshake_sent": save_status.get("pending_handshake_sent"),
+        "frame_id": None,
+    }
+
+    # Step 5: pixel agreement between post-preview focus rect and post-reload focus rect.
+    successor = _wait_for_status(
+        client,
+        lambda status: bool(status.get("current_analysis_id"))
+        and status.get("selected_widget_id") == TARGET_ID
+        and status.get("selected_lock_reason") in (None, ""),
+        timeout=10.0,
+        poll_name="ml tb post-save rebind analysis",
+    )
+    reload_obs = _observe_selected(client)
+    value_reload = client.eval_expr("renforge_editor_ml_tb_clicks")
+    reload_rect = reload_obs.get("rect") or []
+    if len(reload_rect) < 2:
+        raise AssertionError(f"post-reload observation missing rect: {reload_obs!r}")
+    reload_bounds = [int(reload_rect[0]), int(reload_rect[1])]
+    pixel_delta = [
+        reload_bounds[0] - bounds_after[0],
+        reload_bounds[1] - bounds_after[1],
+    ]
+    if any(abs(value) > 1 for value in pixel_delta):
+        raise AssertionError(
+            "post-reload focus rect disagrees with post-preview focus rect: "
+            f"preview={bounds_after!r}, reload={reload_bounds!r}, delta={pixel_delta!r}"
+        )
+    report["pixel_agreement"] = {
+        "preview_after": bounds_after,
+        "reload_after": reload_bounds,
+        "delta": pixel_delta,
+        "measurement_method": reload_obs.get("measurement_method"),
+        "measurement_method_preview": after_obs.get("measurement_method"),
+        "measurement_method_reload": reload_obs.get("measurement_method"),
+        "frame_id_preview": frame_after,
+        "frame_id_reload": reload_obs.get("frame_id"),
+    }
+    reload_frame = reload_obs.get("frame_id")
+    if not reload_frame or reload_frame == frame_after:
+        raise AssertionError(
+            f"reload observation must have a distinct real frame_id: "
+            f"preview={frame_after!r}, reload={reload_frame!r}"
+        )
+    report["value_invariance"] = {
+        "baseline": value_baseline,
+        "preview": value_preview,
+        "reload": value_reload,
+    }
+    if value_preview != value_baseline or value_reload != value_baseline:
+        raise AssertionError(
+            "textbutton click counter changed during preview/reload: "
+            f"baseline={value_baseline!r}, preview={value_preview!r}, reload={value_reload!r}"
+        )
+    report["reload"]["frame_id"] = reload_obs.get("frame_id")
+
+    # Step 6: rebinding.
+    report["rebinding"] = {
+        "ok": successor.get("selected_widget_id") == TARGET_ID
+        and successor.get("current_analysis_id")
+        not in (None, analysis_status.get("current_analysis_id"))
+        and (successor.get("current_source_key") or {}).get("statement_kind") == "textbutton",
+        "widget_id": successor.get("selected_widget_id"),
+        "analysis_id": successor.get("current_analysis_id"),
+        "previous_analysis_id": analysis_status.get("current_analysis_id"),
+        "source_key": successor.get("current_source_key"),
+        "lock_reason": successor.get("selected_lock_reason"),
+    }
+    if report["rebinding"]["ok"] is not True:
+        raise AssertionError(f"rebinding failed: {report['rebinding']!r}")
+
+    # Step 7: byte-identical undo of the temporary fixture.
+    fixture_path.write_bytes(baseline_bytes)
+    restored_bytes = fixture_path.read_bytes()
+    restored_sha = _sha256_file(fixture_path)
+    report["byte_identical_undo"] = {
+        "baseline_sha256": baseline_sha,
+        "restored_sha256": restored_sha,
+        "matches_baseline": restored_sha == baseline_sha and restored_bytes == baseline_bytes,
+        "patched_differed": post_save_sha != baseline_sha and post_save_bytes != baseline_bytes,
+    }
+    if restored_bytes != baseline_bytes:
+        raise AssertionError("multiline textbutton undo did not restore the baseline")
+    return report

--- a/tests/live_fixtures/renforge_editor_multiline_textbutton_fixture.rpy
+++ b/tests/live_fixtures/renforge_editor_multiline_textbutton_fixture.rpy
@@ -1,0 +1,55 @@
+default renforge_editor_ml_tb_clicks = 0
+default renforge_editor_ml_tb_computed_x = 520
+
+
+screen renforge_editor_ml_tb_dupe(label_text, left_x):
+    textbutton label_text:
+        id "ml_tb_dupe_target"
+        xpos left_x
+        ypos 430
+        action NullAction()
+
+
+screen renforge_editor_multiline_textbutton_fixture():
+    layer "screens"
+    zorder 640
+
+    fixed:
+        id "ml_tb_root"
+        xfill True
+        yfill True
+
+        # Supported multi-line form: id/xpos/ypos in the child block only.
+        textbutton "MOVE ME":
+            id "ml_tb_target"
+            xpos 200
+            ypos 180
+            action SetVariable("renforge_editor_ml_tb_clicks", renforge_editor_ml_tb_clicks + 1)
+
+        textbutton "COMPUTED":
+            id "ml_tb_computed"
+            xpos renforge_editor_ml_tb_computed_x
+            ypos 300
+            action NullAction()
+
+        vbox:
+            id "ml_tb_container_parent"
+            xpos 900
+            ypos 120
+            spacing 12
+
+            textbutton "CONTAINER":
+                id "ml_tb_container"
+                xpos 0
+                ypos 0
+                action NullAction()
+
+        side "c":
+            textbutton "SIDE":
+                id "ml_tb_side"
+                xpos 100
+                ypos 520
+                action NullAction()
+
+        use renforge_editor_ml_tb_dupe("DUPE A", 520)
+        use renforge_editor_ml_tb_dupe("DUPE B", 720)

--- a/tests/test_editor_coordinator.py
+++ b/tests/test_editor_coordinator.py
@@ -1582,3 +1582,95 @@ def test_analyze_bar_locks_computed_style_container_without_runtime_type_inferen
                     assert source_key is None
         finally:
             coordinator.close()
+
+def _make_textbutton_block_project(tmp_path: Path) -> tuple[RenpyProject, Path]:
+    root = tmp_path / "project_tb_block"
+    game_dir = root / "game"
+    game_dir.mkdir(parents=True)
+    source = game_dir / "script.rpy"
+    source.write_text(
+        "screen test_screen:\n"
+        '    textbutton "Play":\n'
+        '        id "start_btn"\n'
+        "        xpos 12\n"
+        "        ypos 10\n"
+        "        action NullAction()\n",
+        encoding="utf-8",
+    )
+    return RenpyProject(root), source
+
+
+def test_analyze_and_commit_textbutton_block_preserves_action_bytes(tmp_path: Path) -> None:
+    project, source = _make_textbutton_block_project(tmp_path)
+    observation = _base_observation(script_generation=12)
+    # Runtime source_location points at the block header (line 2).
+    observation["runtime_key"]["source_location"] = ["script.rpy", 2]
+    probe = _Probe(
+        observe_reply={
+            **json.loads(json.dumps(observation)),
+            "frame_id": "independent-frame-tb-block",
+            "object_id": "obj-independent-tb-block",
+        },
+        attest_reply={"ok": True, "state": "all_targets_attested"},
+    )
+    coordinator = EditorCoordinator(project, _make_sdk(tmp_path), attestation_timeout=2.0)
+    coordinator.attach_runtime_probe(probe)
+    endpoint = coordinator.start()
+    try:
+        with socket.create_connection((endpoint.host, endpoint.port), timeout=2.0) as sock:
+            auth = _auth(sock, endpoint)
+            analyzed = _analyze(sock, auth, observation, request_id="an-tb-block")
+            assert analyzed["ok"] is True
+            result = analyzed["result"]
+            assert result["lock_reason"] is None
+            assert result["capabilities"] == {"move": True}
+            assert result["source_key"]["statement_kind"] == "textbutton"
+            assert result["original_position"] == [12, 10]
+
+            committed = _commit(sock, auth, analyzed, x=40, y=50, request_id="co-tb-block")
+            assert committed["ok"] is True
+            assert committed["result"]["state"] == "published"
+            assert source.read_text(encoding="utf-8") == (
+                "screen test_screen:\n"
+                '    textbutton "Play":\n'
+                '        id "start_btn"\n'
+                "        xpos 40\n"
+                "        ypos 50\n"
+                "        action NullAction()\n"
+            )
+    finally:
+        coordinator.close()
+
+
+def test_analyze_textbutton_block_computed_position_stays_locked(tmp_path: Path) -> None:
+    project, source = _make_textbutton_block_project(tmp_path)
+    source.write_text(
+        "screen test_screen:\n"
+        '    textbutton "Play":\n'
+        '        id "start_btn"\n'
+        "        xpos base_x\n"
+        "        ypos 10\n"
+        "        action NullAction()\n",
+        encoding="utf-8",
+    )
+    observation = _base_observation(script_generation=13)
+    observation["runtime_key"]["source_location"] = ["script.rpy", 2]
+    probe = _Probe(
+        observe_reply={
+            **json.loads(json.dumps(observation)),
+            "frame_id": "independent-frame-tb-block-computed",
+            "object_id": "obj-independent-tb-block-computed",
+        },
+    )
+    coordinator = EditorCoordinator(project, _make_sdk(tmp_path))
+    coordinator.attach_runtime_probe(probe)
+    endpoint = coordinator.start()
+    try:
+        with socket.create_connection((endpoint.host, endpoint.port), timeout=2.0) as sock:
+            auth = _auth(sock, endpoint)
+            analyzed = _analyze(sock, auth, observation, request_id="an-tb-block-computed")
+            assert analyzed["ok"] is True
+            assert analyzed["result"]["capabilities"] == {"move": False}
+            assert analyzed["result"]["lock_reason"]["code"] == "XPOS_LITERAL_REQUIRED"
+    finally:
+        coordinator.close()

--- a/tests/test_editor_multiline_textbutton_live.py
+++ b/tests/test_editor_multiline_textbutton_live.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import os
+import shutil
+import time
+from pathlib import Path
+
+import pytest
+
+from renforge.editor_multiline_textbutton_runner import (
+    FIXTURE_SCREEN,
+    inject_editor_multiline_textbutton_resources,
+    run_editor_multiline_textbutton_live_scenario,
+)
+
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("RENFORGE_MULTILINE_TEXTBUTTON_LIVE"),
+    reason="set RENFORGE_MULTILINE_TEXTBUTTON_LIVE=1 to run multi-line textbutton live proof",
+)
+
+_DEMO = Path(__file__).resolve().parents[1] / "examples" / "demo_game"
+
+
+@pytest.fixture
+def demo_copy(tmp_path: Path) -> Path:
+    destination = tmp_path / "demo"
+    shutil.copytree(_DEMO, destination, ignore=shutil.ignore_patterns("*.rpyc", "cache"))
+    inject_editor_multiline_textbutton_resources(destination)
+    return destination
+
+
+def test_multiline_textbutton_seven_step_live_proof(demo_copy: Path) -> None:
+    from renforge.bridge.launcher import launch_with_bridge
+    from renforge.project import RenpyProject
+    from renforge.sdk import get_or_install_sdk
+
+    sdk = get_or_install_sdk("8.5.3", project_root=demo_copy)
+    project = RenpyProject(demo_copy)
+    fixture_path = demo_copy / "game" / "zz_renforge_editor_multiline_textbutton_fixture.rpy"
+
+    with launch_with_bridge(
+        sdk,
+        project,
+        startup_timeout=120,
+        editor=True,
+    ) as session:
+        for _ in range(40):
+            launcher = session.client.inspect_screen("_renforge_editor_launcher")
+            if launcher.get("active") is True:
+                break
+            time.sleep(0.25)
+        else:
+            pytest.fail("editor launcher never became active")
+
+        launcher_click = session.client.click_element(
+            text="RF",
+            exact=True,
+            screen="_renforge_editor_launcher",
+        )
+        assert launcher_click.get("ok") is True, launcher_click
+        for _ in range(40):
+            overlay = session.client.inspect_screen("_renforge_editor_overlay")
+            if overlay.get("active") is True:
+                break
+            time.sleep(0.05)
+        else:
+            pytest.fail("editor overlay never became active")
+
+        for _ in range(20):
+            available = session.client.eval_expr(f'renpy.has_screen("{FIXTURE_SCREEN}")')
+            if available is True:
+                break
+            time.sleep(0.1)
+        else:
+            pytest.fail("multiline textbutton fixture screen never became available")
+
+        report = run_editor_multiline_textbutton_live_scenario(
+            session.client,
+            fixture_path=fixture_path,
+        )
+
+    assert report["resolve"]["statement_kind"] == "textbutton"
+    assert report["resolve"]["lock_reason"] in (None, "")
+    assert report["resolve"]["move"] is True
+    assert report["resolve"]["measurement_method"] == "focus_list"
+    assert report["resolve"]["frame_id"]
+
+    preview = report["preview"]
+    assert preview["bounds_before"] != preview["bounds_after"]
+    assert all(
+        abs(preview["observed_delta"][axis] - preview["requested_delta"][axis]) <= 1
+        for axis in (0, 1)
+    )
+    assert preview["measurement_method"] == "focus_list"
+    assert preview["frame_id_before"] != preview["frame_id_after"]
+
+    patch = report["patch"]
+    assert patch["outside_coordinate_spans_identical"] is True
+    assert patch["matches_independent_expected"] is True
+    assert patch["after_sha256"] != patch["before_sha256"]
+    assert patch["source_position_after"] == {
+        "x": preview["requested_after"][0],
+        "y": preview["requested_after"][1],
+    }
+
+    assert report["reload"]["ok"] is True
+    assert report["reload"]["status_text"] == "Reload committed"
+    assert report["reload"]["generation_delta"] == 1
+
+    assert all(abs(int(value)) <= 1 for value in report["pixel_agreement"]["delta"])
+    assert report["pixel_agreement"]["frame_id_preview"] != report["pixel_agreement"]["frame_id_reload"]
+
+    value_invariance = report["value_invariance"]
+    assert value_invariance["preview"] == value_invariance["baseline"]
+    assert value_invariance["reload"] == value_invariance["baseline"]
+
+    assert report["rebinding"]["ok"] is True
+    assert report["rebinding"]["widget_id"] == "ml_tb_target"
+    assert (report["rebinding"]["source_key"] or {}).get("statement_kind") == "textbutton"
+
+    locks = report["locks"]
+    assert locks["computed"] == "XPOS_LITERAL_REQUIRED"
+    assert locks["container"] == "CONTAINER_POSITION_UNSUPPORTED"
+    assert locks["ambiguous"] == "SYNTHETIC_WIDGET_ID"
+    assert locks["unproven"] == "UNKNOWN_ANCESTRY_TYPE"
+
+    undo = report["byte_identical_undo"]
+    assert undo["matches_baseline"] is True
+    assert undo["patched_differed"] is True

--- a/tests/test_editor_source.py
+++ b/tests/test_editor_source.py
@@ -10,12 +10,14 @@ from renforge.editor.source import (
     ButtonStatement,
     EditorSourceError,
     SliderStatement,
+    TextbuttonStatement,
     VbarStatement,
     analyze_bar_statement,
     analyze_button_statement,
     analyze_editable_statement,
     analyze_imagebutton_statement,
     analyze_slider_statement,
+    analyze_textbutton_block_statement,
     analyze_textbutton_statement,
     analyze_vbar_statement,
     apply_bar_patch,
@@ -26,6 +28,7 @@ from renforge.editor.source import (
     apply_textbutton_patch,
     apply_vbar_patch,
     is_slider_style_bar_line,
+    is_textbutton_block_header,
     peek_statement_kind,
 )
 
@@ -133,6 +136,83 @@ def test_analyze_rejects_compound_numeric_position_expressions() -> None:
             expected_widget_id="icon",
         )
     assert excinfo.value.code == "YPOS_LITERAL_REQUIRED"
+
+
+def test_analyze_textbutton_block_preserves_bytes_outside_coordinate_spans() -> None:
+    source = (
+        "screen test_screen:\n"
+        '    textbutton "MOVE ME":\n'
+        '        id "ml_target"\n'
+        "        xpos 180\n"
+        "        ypos 210\n"
+        "        action NullAction()\n"
+        '        # keep comment\n'
+    )
+    assert is_textbutton_block_header('    textbutton "MOVE ME":\n')
+    parsed = analyze_textbutton_block_statement(
+        source,
+        source_line=2,
+        expected_widget_id="ml_target",
+    )
+    assert isinstance(parsed, TextbuttonStatement)
+    assert parsed.form == "block"
+    assert parsed.source_line == 2
+    assert (parsed.xpos, parsed.ypos) == (180, 210)
+    patched = apply_textbutton_patch(source.encode("utf-8"), parsed, x=240, y=196).decode("utf-8")
+    assert patched == (
+        "screen test_screen:\n"
+        '    textbutton "MOVE ME":\n'
+        '        id "ml_target"\n'
+        "        xpos 240\n"
+        "        ypos 196\n"
+        "        action NullAction()\n"
+        '        # keep comment\n'
+    )
+
+
+def test_analyze_textbutton_block_rejects_header_positions_and_expressions() -> None:
+    with pytest.raises(EditorSourceError) as excinfo:
+        analyze_textbutton_block_statement(
+            "screen s:\n"
+            '    textbutton "X" id "ml" xpos 1 ypos 2:\n'
+            "        action NullAction()\n",
+            source_line=2,
+            expected_widget_id="ml",
+        )
+    assert excinfo.value.code == "POSITION_ON_HEADER_UNSUPPORTED"
+
+    with pytest.raises(EditorSourceError) as excinfo:
+        analyze_textbutton_block_statement(
+            "screen s:\n"
+            '    textbutton "X":\n'
+            '        id "ml"\n'
+            "        xpos base_x\n"
+            "        ypos 10\n"
+            "        action NullAction()\n",
+            source_line=2,
+            expected_widget_id="ml",
+        )
+    assert excinfo.value.code == "XPOS_LITERAL_REQUIRED"
+
+    with pytest.raises(EditorSourceError) as excinfo:
+        analyze_textbutton_block_statement(
+            "screen s:\n"
+            '    textbutton "X":\n'
+            '        id "ml"\n'
+            "        xpos 10+4\n"
+            "        ypos 10\n"
+            "        action NullAction()\n",
+            source_line=2,
+            expected_widget_id="ml",
+        )
+    assert excinfo.value.code == "XPOS_LITERAL_REQUIRED"
+
+    with pytest.raises(EditorSourceError) as excinfo:
+        analyze_textbutton_statement(
+            '    textbutton "MOVE ME":\n',
+            expected_widget_id="ml",
+        )
+    assert excinfo.value.code == "MULTILINE_STATEMENT_REJECTED"
 
 
 def test_analyze_button_statement_rejects_compound_numeric_position_expressions() -> None:

--- a/tests/test_editor_source.py
+++ b/tests/test_editor_source.py
@@ -215,6 +215,60 @@ def test_analyze_textbutton_block_rejects_header_positions_and_expressions() -> 
     assert excinfo.value.code == "MULTILINE_STATEMENT_REJECTED"
 
 
+@pytest.mark.parametrize(
+    ("block_body", "expected_code"),
+    (
+        (
+            '        xpos 1\n        ypos 2\n        action NullAction()\n',
+            "ID_LITERAL_REQUIRED",
+        ),
+        (
+            '        id "a"\n        id "ml"\n        xpos 1\n        ypos 2\n'
+            "        action NullAction()\n",
+            "ID_LITERAL_REQUIRED",
+        ),
+        (
+            '        id "other"\n        xpos 1\n        ypos 2\n        action NullAction()\n',
+            "ID_MISMATCH",
+        ),
+        (
+            '        id "ml"\n        ypos 2\n        action NullAction()\n',
+            "XPOS_LITERAL_REQUIRED",
+        ),
+        (
+            '        id "ml"\n        xpos 1\n        action NullAction()\n',
+            "YPOS_LITERAL_REQUIRED",
+        ),
+        (
+            '        id "ml"\n        xpos 1\n        xpos 2\n        ypos 3\n'
+            "        action NullAction()\n",
+            "XPOS_DUPLICATE",
+        ),
+        (
+            '        id "ml"\n        xpos 1\n        ypos 2\n        ypos 3\n'
+            "        action NullAction()\n",
+            "YPOS_DUPLICATE",
+        ),
+        (
+            '        id "ml"\n        xpos 1\n        ypos base_y\n        action NullAction()\n',
+            "YPOS_LITERAL_REQUIRED",
+        ),
+    ),
+)
+def test_analyze_textbutton_block_rejects_id_and_coordinate_problems(
+    block_body: str,
+    expected_code: str,
+) -> None:
+    source = 'screen s:\n    textbutton "X":\n' + block_body
+    with pytest.raises(EditorSourceError) as excinfo:
+        analyze_textbutton_block_statement(
+            source,
+            source_line=2,
+            expected_widget_id="ml",
+        )
+    assert excinfo.value.code == expected_code
+
+
 def test_analyze_button_statement_rejects_compound_numeric_position_expressions() -> None:
     invalid_headers = (
         (


### PR DESCRIPTION
## Summary

Implements [#37](https://github.com/alex-jordan547/renforge-mcp/issues/37): **one multi-line statement shape** for an already-proven adapter (`textbutton`), patching only position tokens and preserving the rest of the block.

### Supported multi-line form

```renpy
textbutton "MOVE ME":
    id "ml_tb_target"
    xpos 200
    ypos 180
    action NullAction()
```

Requirements:

- header ends with `:` and carries **no** `id` / `xpos` / `ypos`
- exactly one literal string `id` and one literal integer `xpos` / `ypos` among direct children
- patch replaces only those two integer tokens (absolute spans in the full file)
- every other block byte is preserved (labels, action, comments, nesting)

Single-line `textbutton` remains unchanged.

### Architecture

| Piece | Change |
|---|---|
| `source.py` | `is_textbutton_block_header`, `analyze_textbutton_block_statement`, `TextbuttonStatement.form/source_line` |
| `coordinator.py` | route block headers through full-source analyze/patch (like `button`) |
| Live | fixture + runner + `RENFORGE_MULTILINE_TEXTBUTTON_LIVE=1` |

### Lock matrix (live-measured)

| Case | Lock code |
|---|---|
| Computed `xpos` in block | `XPOS_LITERAL_REQUIRED` |
| Layout container ancestry | `CONTAINER_POSITION_UNSUPPORTED` |
| Ambiguous repeated `use` | `SYNTHETIC_WIDGET_ID` |
| Unproven `Side` ancestry | `UNKNOWN_ANCESTRY_TYPE` |

### Seven-step live proof

```bash
RENFORGE_MULTILINE_TEXTBUTTON_LIVE=1 \
  PYTHONPATH=src python -m pytest -q tests/test_editor_multiline_textbutton_live.py
```

→ **1 passed** on Ren'Py **8.5.3**

## Test plan

- [x] `PYTHONPATH=src python -m pytest -q tests/test_editor_source.py tests/test_editor_coordinator.py tests/test_editor_multiline_textbutton_live.py` → **92 passed, 1 skipped**
- [x] Live green with `RENFORGE_MULTILINE_TEXTBUTTON_LIVE=1`
- [x] Docs updated after live green

## Explicit non-goals

- Multi-line `bar` / `imagebutton` / `slider` (still single-line)
- Positions on the `textbutton` header of a block form (`POSITION_ON_HEADER_UNSUPPORTED`)
- `pos` / `align` / `anchor` / `offset` forms (later Stage 2 issues)

Closes #37

## Summary by Sourcery

Prise en charge des blocs de textbutton multilignes dans l’éditeur visuel tout en préservant tous les octets non liés à la position et en les intégrant aux flux d’analyse, de patch et de preuve en direct.

Nouvelles fonctionnalités :
- Ajouter la prise en charge des blocs de textbutton multilignes avec `id`/`xpos`/`ypos` définis dans le bloc enfant et un patch de position basé sur les étendues de source absolues.
- Introduire un exécuteur en direct et un fixture pour les textbuttons multilignes, et intégrer une preuve en direct en sept étapes dans la suite de tests derrière `RENFORGE_MULTILINE_TEXTBUTTON_LIVE`.

Améliorations :
- Étendre la logique du coordinateur pour faire passer les en-têtes de blocs de textbutton par l’analyse et le patching de la source complète plutôt que par des analyseurs monolignes.
- Renforcer l’analyse de la source en rejetant les en-têtes de textbutton multilignes non pris en charge et les positions définies dans l’en-tête avec des codes de verrou explicites.
- Mettre à jour les spécifications de l’éditeur visuel et les documents de feuille de route pour décrire les nouvelles capacités des blocs de textbutton multilignes et le comportement de verrouillage.

Documentation :
- Documenter la prise en charge des blocs de textbutton multilignes, ses contraintes et le processus de preuve en direct dans le périmètre de l’éditeur visuel et les spécifications de feuille de route.

Tests :
- Ajouter des tests unitaires couvrant l’analyse, le patching et les conditions de verrouillage des blocs de textbutton multilignes pour les positions calculées et les formes d’en-tête non prises en charge.
- Ajouter un test en direct optionnel qui exerce le flux complet des textbuttons multilignes sur un jeu de démonstration, y compris la prévisualisation, la sauvegarde, le rechargement, le rebinding et l’annulation byte-identique.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Support multi-line textbutton block statements in the visual editor while preserving all non-position bytes and integrating them into analysis, patch, and live proof flows.

New Features:
- Add support for multi-line textbutton blocks with id/xpos/ypos authored in the child block and position patching based on absolute source spans.
- Introduce a live runner and fixture for multi-line textbutton textbuttons and wire a seven-step live proof into the test suite behind RENFORGE_MULTILINE_TEXTBUTTON_LIVE.

Enhancements:
- Extend coordinator logic to route textbutton block headers through full-source analysis and patching rather than single-line analyzers.
- Tighten source analysis by rejecting unsupported multi-line textbutton headers and header-authored positions with explicit lock codes.
- Update visual editor specs and roadmap docs to describe the new multi-line textbutton block capabilities and lock behavior.

Documentation:
- Document multi-line textbutton block support, its constraints, and live proof process in the visual editor scope and roadmap specifications.

Tests:
- Add unit tests covering multi-line textbutton block analysis, patching, and lock conditions for computed positions and unsupported header forms.
- Add an opt-in live test that exercises the full multi-line textbutton workflow against a demo game, including preview, save, reload, rebinding, and byte-identical undo.

</details>