### PR TITLE
Preserve authored pos (x, y) on textbutton visual moves

### DIFF
--- a/docs/superpowers/specs/2026-07-30-renforge-visual-editor-v1-scope.md
+++ b/docs/superpowers/specs/2026-07-30-renforge-visual-editor-v1-scope.md
@@ -90,6 +90,22 @@ remain locked with the measured codes (`XPOS_LITERAL_REQUIRED`, `CONTAINER_POSIT
 Live proof: `RENFORGE_MULTILINE_TEXTBUTTON_LIVE=1 uv run --extra test python -m pytest -q tests/test_editor_multiline_textbutton_live.py`
 against Ren'Py **8.5.3**.
 
+### Literal `pos (x, y)` on textbutton (issue #38)
+
+Single-line textbuttons may author position as a pure integer pair:
+
+```renpy
+textbutton "MOVE ME" id "pos_target" pos (200, 180) action NullAction()
+```
+
+The analyzer records `position_mode == "pos"` and patches only the two integer tokens inside
+the tuple, preserving `pos (...)` and never converting the statement to `xpos`/`ypos`. Non-literal
+pairs (`pos (base_x, 10)`), mixed forms (`pos` + `xpos`/`ypos`), and duplicate `pos` keywords are
+locked with exact codes (`POS_LITERAL_REQUIRED`, `POSITION_FORM_MIXED`, `POS_DUPLICATE`).
+
+Live proof: `RENFORGE_POS_LIVE=1 uv run --extra test python -m pytest -q tests/test_editor_pos_live.py`
+against Ren'Py **8.5.3**.
+
 The `button` adapter is intentionally limited to `button id "..." xpos N ypos N:` headers. Computed
 coordinates, direct child `xpos`/`ypos`, layout-container ancestry, and ambiguous or unproven runtime
 instances remain selectable but locked with an exact reason.

--- a/docs/superpowers/specs/2026-07-30-renforge-visual-editor-vfull-roadmap.md
+++ b/docs/superpowers/specs/2026-07-30-renforge-visual-editor-vfull-roadmap.md
@@ -64,7 +64,7 @@ Real screens are messier.
 | Form | Problem | Possible approach |
 |---|---|---|
 | Multi-line statement with a block | Position keywords may sit on any line of the block | **Partially implemented (issue #37):** multi-line `textbutton` with `id`/`xpos`/`ypos` in the child block only; seven-step live proof green via `RENFORGE_MULTILINE_TEXTBUTTON_LIVE=1`. Other adapters remain single-line or header-only (`button`). |
-| `pos (x, y)` / `align` / `anchor` / `offset` | Different property, same intent | Normalise to a position model; write back in the form the author used |
+| `pos (x, y)` / `align` / `anchor` / `offset` | Different property, same intent | **`pos` implemented (issue #38)** for single-line `textbutton` with pure `pos (x, y)`; write-back preserves `pos` (never rewrites to xpos/ypos). Live: `RENFORGE_POS_LIVE=1`. `align` / `anchor` / `offset` still pending. |
 | Position from a **variable or expression** | Cannot be rewritten without changing semantics | **Stays locked.** Offer to show the computed value, never to overwrite the expression |
 | Element inside `hbox` / `vbox` / `grid` | Position is computed by the layout, not authored | **Stays locked** for direct move. A layout-aware edit is a different feature |
 | Multiple instances from one loop / `use` | One source line, N runtime widgets | Needs a disambiguation UI; the stable key already carries `ordinal` |

--- a/src/renforge/editor/source.py
+++ b/src/renforge/editor/source.py
@@ -22,6 +22,8 @@ class TextbuttonStatement:
     # "block" keeps absolute character spans in the full source file.
     form: str = "single_line"
     source_line: int | None = None
+    # "xy" = authored xpos/ypos; "pos" = authored pos (x, y). Write-back preserves form.
+    position_mode: str = "xy"
 
 
 @dataclass(frozen=True)
@@ -298,12 +300,116 @@ def _analyze_positioned_kind_statement(
     )
 
 
+def _parse_literal_pos_pair(
+    tokens: list[_Token],
+    pos_index: int,
+) -> tuple[int, int, tuple[int, int], tuple[int, int]] | None:
+    """Parse ``pos (X, Y)`` with pure integer literals; return values and number spans."""
+    open_index = pos_index + 1
+    if open_index >= len(tokens):
+        return None
+    open_token = tokens[open_index]
+    if open_token.kind != "SYMBOL" or open_token.text != "(":
+        return None
+    # Inside the tuple: NUMBER , NUMBER )
+    x_index = open_index + 1
+    comma_index = open_index + 2
+    y_index = open_index + 3
+    close_index = open_index + 4
+    if close_index >= len(tokens):
+        return None
+    x_token = tokens[x_index]
+    comma_token = tokens[comma_index]
+    y_token = tokens[y_index]
+    close_token = tokens[close_index]
+    if x_token.kind != "NUMBER" or y_token.kind != "NUMBER":
+        return None
+    if comma_token.kind != "SYMBOL" or comma_token.text != ",":
+        return None
+    if close_token.kind != "SYMBOL" or close_token.text != ")":
+        return None
+    # Reject trailing junk still inside the paren depth (e.g. third component).
+    # The next token after ')' must be top-level WORD or EOS (same purity as xpos).
+    following = close_index + 1
+    if following < len(tokens):
+        next_token = tokens[following]
+        if next_token.depth != 0 or next_token.kind != "WORD":
+            return None
+    return (
+        int(x_token.text),
+        int(y_token.text),
+        (x_token.start, x_token.end),
+        (y_token.start, y_token.end),
+    )
+
+
 def analyze_textbutton_statement(line: str, *, expected_widget_id: str) -> TextbuttonStatement:
     if is_textbutton_block_header(line):
         raise EditorSourceError(
             "MULTILINE_STATEMENT_REJECTED",
             "textbutton block headers require analyze_textbutton_block_statement",
         )
+    statement_text = _statement_text(line)
+    tokens = _lex_single_line(statement_text)
+    top_level = [token for token in tokens if token.depth == 0]
+    if not top_level or top_level[0].kind != "WORD" or top_level[0].text != "textbutton":
+        raise EditorSourceError("STATEMENT_KIND_MISMATCH", "source statement is not a textbutton")
+
+    has_xy = any(
+        token.depth == 0 and token.kind == "WORD" and token.text in {"xpos", "ypos"}
+        for token in tokens
+    )
+    pos_indexes = [
+        index
+        for index, token in enumerate(tokens)
+        if token.depth == 0 and token.kind == "WORD" and token.text == "pos"
+    ]
+    if pos_indexes and has_xy:
+        raise EditorSourceError(
+            "POSITION_FORM_MIXED",
+            "textbutton cannot mix pos with xpos/ypos",
+        )
+    if len(pos_indexes) > 1:
+        raise EditorSourceError("POS_DUPLICATE", "textbutton statement must contain exactly one pos")
+    if len(pos_indexes) == 1:
+        # id required + pure pos pair; do not fall through to xpos/ypos analyzer.
+        keyword_counts_id = 0
+        widget_id: str | None = None
+        id_invalid = False
+        for index, token in enumerate(tokens):
+            if token.depth != 0 or token.kind != "WORD" or token.text != "id":
+                continue
+            keyword_counts_id += 1
+            value_index = _next_top_level_index(tokens, index)
+            if value_index is None or tokens[value_index].kind != "STRING":
+                id_invalid = True
+                continue
+            widget_id = _parse_string_token(tokens[value_index])
+        if keyword_counts_id != 1 or id_invalid or widget_id is None:
+            raise EditorSourceError(
+                "ID_LITERAL_REQUIRED",
+                "textbutton statement must contain exactly one literal id",
+            )
+        if widget_id != expected_widget_id:
+            raise EditorSourceError("ID_MISMATCH", "literal id does not match runtime widget id")
+        parsed_pos = _parse_literal_pos_pair(tokens, pos_indexes[0])
+        if parsed_pos is None:
+            raise EditorSourceError(
+                "POS_LITERAL_REQUIRED",
+                "pos must be a pure literal pair of integers: pos (x, y)",
+            )
+        xpos_value, ypos_value, xpos_span, ypos_span = parsed_pos
+        return TextbuttonStatement(
+            widget_id=widget_id,
+            xpos=xpos_value,
+            ypos=ypos_value,
+            xpos_span=xpos_span,
+            ypos_span=ypos_span,
+            form="single_line",
+            source_line=None,
+            position_mode="pos",
+        )
+
     return _analyze_positioned_kind_statement(
         line,
         expected_widget_id=expected_widget_id,

--- a/src/renforge/editor/source.py
+++ b/src/renforge/editor/source.py
@@ -300,11 +300,44 @@ def _analyze_positioned_kind_statement(
     )
 
 
+def _require_single_literal_id(
+    tokens: list[_Token],
+    *,
+    expected_widget_id: str,
+    human_kind: str,
+) -> str:
+    """Return the single top-level literal id string, or raise a shared id error."""
+    keyword_counts_id = 0
+    widget_id: str | None = None
+    id_invalid = False
+    for index, token in enumerate(tokens):
+        if token.depth != 0 or token.kind != "WORD" or token.text != "id":
+            continue
+        keyword_counts_id += 1
+        value_index = _next_top_level_index(tokens, index)
+        if value_index is None or tokens[value_index].kind != "STRING":
+            id_invalid = True
+            continue
+        widget_id = _parse_string_token(tokens[value_index])
+    if keyword_counts_id != 1 or id_invalid or widget_id is None:
+        raise EditorSourceError(
+            "ID_LITERAL_REQUIRED",
+            f"{human_kind} statement must contain exactly one literal id",
+        )
+    if widget_id != expected_widget_id:
+        raise EditorSourceError("ID_MISMATCH", "literal id does not match runtime widget id")
+    return widget_id
+
+
 def _parse_literal_pos_pair(
     tokens: list[_Token],
     pos_index: int,
 ) -> tuple[int, int, tuple[int, int], tuple[int, int]] | None:
-    """Parse ``pos (X, Y)`` with pure integer literals; return values and number spans."""
+    """Parse ``pos (X, Y)`` with pure integer literals; return values and number spans.
+
+    A pure pair is either end-of-statement after ``)``, or followed by a top-level
+    property/action WORD (same purity rule as literal xpos/ypos followers).
+    """
     open_index = pos_index + 1
     if open_index >= len(tokens):
         return None
@@ -328,11 +361,10 @@ def _parse_literal_pos_pair(
         return None
     if close_token.kind != "SYMBOL" or close_token.text != ")":
         return None
-    # Reject trailing junk still inside the paren depth (e.g. third component).
-    # The next token after ')' must be top-level WORD or EOS (same purity as xpos).
     following = close_index + 1
     if following < len(tokens):
         next_token = tokens[following]
+        # EOS is allowed (no following token). Otherwise require a top-level WORD.
         if next_token.depth != 0 or next_token.kind != "WORD":
             return None
     return (
@@ -372,26 +404,11 @@ def analyze_textbutton_statement(line: str, *, expected_widget_id: str) -> Textb
     if len(pos_indexes) > 1:
         raise EditorSourceError("POS_DUPLICATE", "textbutton statement must contain exactly one pos")
     if len(pos_indexes) == 1:
-        # id required + pure pos pair; do not fall through to xpos/ypos analyzer.
-        keyword_counts_id = 0
-        widget_id: str | None = None
-        id_invalid = False
-        for index, token in enumerate(tokens):
-            if token.depth != 0 or token.kind != "WORD" or token.text != "id":
-                continue
-            keyword_counts_id += 1
-            value_index = _next_top_level_index(tokens, index)
-            if value_index is None or tokens[value_index].kind != "STRING":
-                id_invalid = True
-                continue
-            widget_id = _parse_string_token(tokens[value_index])
-        if keyword_counts_id != 1 or id_invalid or widget_id is None:
-            raise EditorSourceError(
-                "ID_LITERAL_REQUIRED",
-                "textbutton statement must contain exactly one literal id",
-            )
-        if widget_id != expected_widget_id:
-            raise EditorSourceError("ID_MISMATCH", "literal id does not match runtime widget id")
+        widget_id = _require_single_literal_id(
+            tokens,
+            expected_widget_id=expected_widget_id,
+            human_kind="textbutton",
+        )
         parsed_pos = _parse_literal_pos_pair(tokens, pos_indexes[0])
         if parsed_pos is None:
             raise EditorSourceError(

--- a/src/renforge/editor/source.py
+++ b/src/renforge/editor/source.py
@@ -329,6 +329,64 @@ def _require_single_literal_id(
     return widget_id
 
 
+# Property keywords that may follow a pure ``pos (x, y)`` on a textbutton line.
+# Expression operators (if/or/else/and) are intentionally absent so
+# ``pos (1, 2) if flag else (3, 4)`` is rejected rather than half-patched.
+_TEXTBUTTON_POS_FOLLOWER_WORDS = frozenset(
+    {
+        "id",
+        "xpos",
+        "ypos",
+        "action",
+        "style",
+        "xsize",
+        "ysize",
+        "xmaximum",
+        "ymaximum",
+        "xminimum",
+        "yminimum",
+        "xfill",
+        "yfill",
+        "xalign",
+        "yalign",
+        "xanchor",
+        "yanchor",
+        "xoffset",
+        "yoffset",
+        "xcenter",
+        "ycenter",
+        "tooltip",
+        "sensitive",
+        "focus",
+        "keyboard_focus",
+        "hovered",
+        "unhovered",
+        "selected",
+        "alternate",
+        "keysym",
+        "alternate_keysym",
+    }
+)
+
+
+def _pos_property_indexes(tokens: list[_Token]) -> list[int]:
+    """Indexes of top-level ``pos`` used as a property keyword (value starts with ``(``).
+
+    Distinguishes ``pos (1, 2)`` from expression identifiers such as ``action pos``.
+    """
+    indexes: list[int] = []
+    for index, token in enumerate(tokens):
+        if token.depth != 0 or token.kind != "WORD" or token.text != "pos":
+            continue
+        next_index = index + 1
+        if next_index >= len(tokens):
+            continue
+        next_token = tokens[next_index]
+        if next_token.kind == "SYMBOL" and next_token.text == "(":
+            indexes.append(index)
+    return indexes
+
+
 def _parse_literal_pos_pair(
     tokens: list[_Token],
     pos_index: int,
@@ -336,7 +394,7 @@ def _parse_literal_pos_pair(
     """Parse ``pos (X, Y)`` with pure integer literals; return values and number spans.
 
     A pure pair is either end-of-statement after ``)``, or followed by a top-level
-    property/action WORD (same purity rule as literal xpos/ypos followers).
+    textbutton property WORD (not expression operators like ``if`` / ``or``).
     """
     open_index = pos_index + 1
     if open_index >= len(tokens):
@@ -364,8 +422,12 @@ def _parse_literal_pos_pair(
     following = close_index + 1
     if following < len(tokens):
         next_token = tokens[following]
-        # EOS is allowed (no following token). Otherwise require a top-level WORD.
-        if next_token.depth != 0 or next_token.kind != "WORD":
+        # EOS is allowed (no following token). Otherwise require a property keyword.
+        if (
+            next_token.depth != 0
+            or next_token.kind != "WORD"
+            or next_token.text not in _TEXTBUTTON_POS_FOLLOWER_WORDS
+        ):
             return None
     return (
         int(x_token.text),
@@ -391,11 +453,7 @@ def analyze_textbutton_statement(line: str, *, expected_widget_id: str) -> Textb
         token.depth == 0 and token.kind == "WORD" and token.text in {"xpos", "ypos"}
         for token in tokens
     )
-    pos_indexes = [
-        index
-        for index, token in enumerate(tokens)
-        if token.depth == 0 and token.kind == "WORD" and token.text == "pos"
-    ]
+    pos_indexes = _pos_property_indexes(tokens)
     if pos_indexes and has_xy:
         raise EditorSourceError(
             "POSITION_FORM_MIXED",

--- a/src/renforge/editor_pos_runner.py
+++ b/src/renforge/editor_pos_runner.py
@@ -1,0 +1,530 @@
+from __future__ import annotations
+
+import hashlib
+import re
+import shutil
+import time
+from pathlib import Path
+from typing import Any
+
+from renforge.editor.source import analyze_textbutton_statement
+from renforge.editor_task0_runner import (
+    _require_ok,
+    _source_generation,
+    _wait_for_status,
+)
+
+FIXTURE_SCREEN = "renforge_editor_pos_fixture"
+TARGET_ID = "pos_target"
+EDITOR_RESOURCE = Path(__file__).resolve().parent / "bridge" / "editor.rpy"
+FIXTURE_RESOURCE = (
+    Path(__file__).resolve().parents[2]
+    / "tests"
+    / "live_fixtures"
+    / "renforge_editor_pos_fixture.rpy"
+)
+
+
+def inject_editor_pos_resources(project_root: Path) -> dict[str, str]:
+    game_dir = project_root / "game"
+    game_dir.mkdir(parents=True, exist_ok=True)
+    editor_target = game_dir / "zz_renforge_editor_pos.rpy"
+    fixture_target = game_dir / "zz_renforge_editor_pos_fixture.rpy"
+    shutil.copyfile(EDITOR_RESOURCE, editor_target)
+    shutil.copyfile(FIXTURE_RESOURCE, fixture_target)
+    return {
+        "editor": str(editor_target),
+        "fixture": str(fixture_target),
+    }
+
+
+def _find_element(
+    elements: list[dict[str, Any]],
+    wanted_id: str,
+    *,
+    wanted_text: str | None = None,
+) -> dict[str, Any]:
+    for element in elements:
+        element_id = str(element.get("id") or "")
+        if wanted_text is not None:
+            if element_id == wanted_id and str(element.get("text") or "") == wanted_text:
+                return element
+            continue
+        if element_id == wanted_id:
+            return element
+    raise AssertionError(
+        f"missing expected element id {wanted_id!r} text {wanted_text!r}: {elements!r}"
+    )
+
+
+def _center(bounds: dict[str, Any]) -> tuple[int, int]:
+    return (
+        int(bounds["x"]) + int(bounds["width"]) // 2,
+        int(bounds["y"]) + int(bounds["height"]) // 2,
+    )
+
+
+def _sha256_file(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _list_info(client: Any) -> dict[str, Any]:
+    info = client.list_ui_elements_info(screen=FIXTURE_SCREEN)
+    if not isinstance(info, dict):
+        raise AssertionError(f"list_ui_elements_info returned non-dict: {info!r}")
+    return info
+
+
+def _wait_bounds(client: Any, widget_id: str, *, timeout: float = 6.0) -> dict[str, int]:
+    deadline = time.monotonic() + timeout
+    last: list[dict[str, Any]] = []
+    while time.monotonic() < deadline:
+        info = _list_info(client)
+        last = info.get("elements") if isinstance(info.get("elements"), list) else []
+        try:
+            element = _find_element(last, widget_id)
+        except AssertionError:
+            time.sleep(0.05)
+            continue
+        bounds = element.get("bounds")
+        if isinstance(bounds, dict):
+            return {
+                "x": int(bounds["x"]),
+                "y": int(bounds["y"]),
+                "width": int(bounds["width"]),
+                "height": int(bounds["height"]),
+            }
+        time.sleep(0.05)
+    raise AssertionError(f"bounds for {widget_id!r} unavailable: {last!r}")
+
+
+def _target_line_with_offset(source_text: str) -> tuple[str, int]:
+    offset = 0
+    for line in source_text.splitlines(keepends=True):
+        if (
+            f'id "{TARGET_ID}"' in line
+            and line.lstrip().startswith("textbutton ")
+            and " pos " in f" {line}"
+        ):
+            analyze_textbutton_statement(line, expected_widget_id=TARGET_ID)
+            return line, offset
+        offset += len(line)
+    raise AssertionError(f"source missing pos textbutton line for {TARGET_ID!r}")
+
+
+def _independent_expected_after_patch(before_text: str, *, x: int, y: int) -> str:
+    """Build expected fixture text without calling apply_textbutton_patch."""
+    line, offset = _target_line_with_offset(before_text)
+    patched_line = re.sub(
+        r"(\bpos\s*\(\s*)-?\d+(\s*,\s*)-?\d+(\s*\))",
+        rf"\g<1>{int(x)}\g<2>{int(y)}\3",
+        line,
+        count=1,
+    )
+    if patched_line == line:
+        raise AssertionError("independent patch constructor did not change target pos pair")
+    if "xpos" in patched_line or "ypos" in patched_line:
+        raise AssertionError("independent constructor must not introduce xpos/ypos")
+    return f"{before_text[:offset]}{patched_line}{before_text[offset + len(line) :]}"
+
+
+def _outside_coordinate_spans_identical(before_text: str, after_text: str) -> bool:
+    before_line, _ = _target_line_with_offset(before_text)
+    after_line, _ = _target_line_with_offset(after_text)
+    before_norm = re.sub(
+        r"(\bpos\s*\(\s*)-?\d+(\s*,\s*)-?\d+(\s*\))",
+        r"\1__X__\2__Y__\3",
+        before_line,
+        count=1,
+    )
+    after_norm = re.sub(
+        r"(\bpos\s*\(\s*)-?\d+(\s*,\s*)-?\d+(\s*\))",
+        r"\1__X__\2__Y__\3",
+        after_line,
+        count=1,
+    )
+    if before_norm != after_norm:
+        return False
+    return before_text.replace(before_line, "", 1) == after_text.replace(after_line, "", 1)
+
+
+def _parse_xy_from_target_line(source_text: str) -> dict[str, int]:
+    line, _ = _target_line_with_offset(source_text)
+    match = re.search(r"\bpos\s*\(\s*(-?\d+)\s*,\s*(-?\d+)\s*\)", line)
+    if match is None:
+        raise AssertionError(f"target line missing literal pos pair: {line!r}")
+    return {"x": int(match.group(1)), "y": int(match.group(2))}
+
+
+def _select_lock(client: Any, widget_id: str, expected_code: str) -> str:
+    bounds = _wait_bounds(client, widget_id)
+    selection = client.request(
+        "editor_task0_select",
+        {"x": _center(bounds)[0], "y": _center(bounds)[1]},
+    )
+    immediate = selection.get("lock_reason") if isinstance(selection, dict) else None
+    if immediate == expected_code:
+        return expected_code
+    status = _wait_for_status(
+        client,
+        lambda current: current.get("selected_widget_id") == widget_id
+        and current.get("selected_lock_reason") == expected_code,
+        timeout=10.0,
+        poll_name=f"{widget_id} lock",
+    )
+    lock_reason = status.get("selected_lock_reason")
+    if lock_reason != expected_code:
+        raise AssertionError(f"unexpected lock for {widget_id!r}: {status!r}")
+    return str(lock_reason)
+
+
+def _observe_selected(client: Any) -> dict[str, Any]:
+    reply = client.request("editor_task0_observe_selected", {})
+    if not isinstance(reply, dict) or reply.get("ok") is not True:
+        raise AssertionError(f"observe_selected failed: {reply!r}")
+    observation = reply.get("observation")
+    if not isinstance(observation, dict):
+        raise AssertionError(f"observe_selected missing observation: {reply!r}")
+    return observation
+
+
+def run_editor_pos_live_scenario(client: Any, *, fixture_path: Path) -> dict[str, Any]:
+    """Seven-step live proof for literal pos (x, y) textbutton form (issue #38)."""
+    report: dict[str, Any] = {}
+    baseline_bytes = fixture_path.read_bytes()
+    baseline_sha = _sha256_file(fixture_path)
+    baseline_text = baseline_bytes.decode("utf-8")
+    # Prove analyzer accepts the authored pos form before any UI work.
+    target_line, _ = _target_line_with_offset(baseline_text)
+    parsed = analyze_textbutton_statement(target_line, expected_widget_id=TARGET_ID)
+    if parsed.position_mode != "pos":
+        raise AssertionError(f"expected position_mode pos, got {parsed.position_mode!r}")
+    baseline_position = _parse_xy_from_target_line(baseline_text)
+    report["fixture_before"] = {
+        "sha256": baseline_sha,
+        "position": baseline_position,
+        "position_mode": parsed.position_mode,
+    }
+
+    start = _require_ok(
+        client.request("editor_task0_start", {"screen": FIXTURE_SCREEN}),
+        "editor_task0_start",
+    )
+    report["start"] = start
+
+    # Lock matrix first on real focusable widgets (measured codes).
+    report["locks"] = {
+        "computed": _select_lock(client, "pos_computed", "POS_LITERAL_REQUIRED"),
+        "container": _select_lock(client, "pos_container", "CONTAINER_POSITION_UNSUPPORTED"),
+    }
+
+    # Measured live: two use-statements share id "pos_dupe_target". The first
+    # instance is still selectable by focus bounds and locks as SYNTHETIC_WIDGET_ID
+    # (list_ui may only name the second instance).
+    dupe_info = _list_info(client)
+    dupe_elements = dupe_info.get("elements") if isinstance(dupe_info, dict) else None
+    # Prefer the unnamed first instance (NullAction-ish id) then fall back to
+    # the named target bounds at the left dupe coordinate.
+    dupe_pick = None
+    for element in dupe_elements if isinstance(dupe_elements, list) else []:
+        bounds = element.get("bounds")
+        if not isinstance(bounds, dict):
+            continue
+        text = str(element.get("text") or "")
+        if text == "DUPE A" or (
+            int(bounds.get("x", -1)) == 520 and int(bounds.get("y", -1)) == 430
+        ):
+            dupe_pick = bounds
+            break
+    if dupe_pick is None:
+        raise AssertionError(f"could not locate first dupe bounds: {dupe_elements!r}")
+    dupe_select = client.request(
+        "editor_task0_select",
+        {
+            "x": int(dupe_pick["x"]) + max(2, int(dupe_pick["width"]) // 4),
+            "y": int(dupe_pick["y"]) + int(dupe_pick["height"]) // 2,
+        },
+    )
+    ambiguous = dupe_select.get("lock_reason") if isinstance(dupe_select, dict) else None
+    if ambiguous in (None, ""):
+        status = _wait_for_status(
+            client,
+            lambda current: current.get("selected_lock_reason") == "SYNTHETIC_WIDGET_ID",
+            timeout=10.0,
+            poll_name="pos dupe lock",
+        )
+        ambiguous = status.get("selected_lock_reason")
+    if ambiguous != "SYNTHETIC_WIDGET_ID":
+        raise AssertionError(
+            f"duplicate pos textbutton lock was not SYNTHETIC_WIDGET_ID: {ambiguous!r}"
+        )
+    report["locks"]["ambiguous"] = ambiguous
+
+    # Measured live: Side is not in the ancestry allowlist → UNKNOWN_ANCESTRY_TYPE.
+    side_bounds = _wait_bounds(client, "pos_side", timeout=3.0)
+    side_select = client.request(
+        "editor_task0_select",
+        {"x": _center(side_bounds)[0], "y": _center(side_bounds)[1]},
+    )
+    unproven = side_select.get("lock_reason") if isinstance(side_select, dict) else None
+    if unproven in (None, ""):
+        status = _wait_for_status(
+            client,
+            lambda current: current.get("selected_lock_reason") == "UNKNOWN_ANCESTRY_TYPE",
+            timeout=10.0,
+            poll_name="pos side lock",
+        )
+        unproven = status.get("selected_lock_reason")
+    if unproven != "UNKNOWN_ANCESTRY_TYPE":
+        raise AssertionError(
+            f"side-ancestor pos textbutton lock was not UNKNOWN_ANCESTRY_TYPE: {unproven!r}"
+        )
+    report["locks"]["unproven"] = unproven
+
+    # Step 1: resolve the editable pos textbutton from a fresh focus rect.
+    target_bounds = _wait_bounds(client, TARGET_ID)
+    target_center = _center(target_bounds)
+    select = _require_ok(
+        client.request(
+            "editor_task0_select",
+            {"x": target_center[0], "y": target_center[1]},
+        ),
+        "target select",
+    )
+    observation = select.get("observation") or {}
+    if observation.get("measurement_method") != "focus_list":
+        raise AssertionError(f"select observation not focus_list: {observation!r}")
+
+    analysis_status = _wait_for_status(
+        client,
+        lambda status: bool(status.get("current_analysis_id"))
+        and status.get("selected_widget_id") == TARGET_ID
+        and status.get("selected_lock_reason") in (None, ""),
+        timeout=10.0,
+        poll_name="pos analysis",
+    )
+    source_key = analysis_status.get("current_source_key") or {}
+    capabilities = analysis_status.get("current_capabilities") or {}
+    host_move = capabilities.get("move")
+    report["resolve"] = {
+        "statement_kind": source_key.get("statement_kind"),
+        "lock_reason": analysis_status.get("selected_lock_reason"),
+        "move": host_move,
+        "analysis_id": analysis_status.get("current_analysis_id"),
+        "measurement_method": observation.get("measurement_method"),
+        "frame_id": observation.get("frame_id"),
+        "source_key": source_key,
+    }
+    if source_key.get("statement_kind") != "textbutton":
+        raise AssertionError(f"expected textbutton statement_kind: {source_key!r}")
+    if host_move is not True:
+        raise AssertionError(f"host did not unlock move for pos textbutton: {analysis_status!r}")
+
+    original = analysis_status.get("selected_original_position") or analysis_status.get(
+        "selected_source_position"
+    )
+    if not (isinstance(original, (list, tuple)) and len(original) == 2):
+        original = [int(baseline_position["x"]), int(baseline_position["y"])]
+    requested_before = [int(original[0]), int(original[1])]
+
+    # Fresh focus_list observation before preview movement.
+    value_baseline = client.eval_expr("renforge_editor_pos_clicks")
+    before_obs = _observe_selected(client)
+    before_rect = before_obs.get("rect") or []
+    if len(before_rect) < 2:
+        raise AssertionError(f"pre-preview observation missing rect: {before_obs!r}")
+    bounds_before = [int(before_rect[0]), int(before_rect[1])]
+    frame_before = before_obs.get("frame_id")
+
+    # Step 2: preview.
+    _require_ok(client.request("editor_task0_key", {"key": "right", "repeat": 24}), "nudge right")
+    _require_ok(client.request("editor_task0_key", {"key": "down", "repeat": 16}), "nudge down")
+    preview_status = _wait_for_status(
+        client,
+        lambda status: isinstance(status.get("preview_position"), (list, tuple))
+        and len(status.get("preview_position") or []) == 2
+        and list(status.get("preview_position") or []) != requested_before,
+        timeout=8.0,
+        poll_name="pos preview moved",
+    )
+    requested_after = [
+        int(preview_status["preview_position"][0]),
+        int(preview_status["preview_position"][1]),
+    ]
+    after_obs = _observe_selected(client)
+    value_preview = client.eval_expr("renforge_editor_pos_clicks")
+    after_rect = after_obs.get("rect") or []
+    if len(after_rect) < 2:
+        raise AssertionError(f"post-preview observation missing rect: {after_obs!r}")
+    bounds_after = [int(after_rect[0]), int(after_rect[1])]
+    frame_after = after_obs.get("frame_id")
+    if not frame_before or not frame_after or frame_before == frame_after:
+        raise AssertionError(
+            f"preview observations must have distinct real frame_ids: "
+            f"before={frame_before!r}, after={frame_after!r}"
+        )
+    if before_obs.get("measurement_method") != "focus_list" or after_obs.get("measurement_method") != "focus_list":
+        raise AssertionError(
+            "preview observations must report measurement_method from bridge: "
+            f"before={before_obs.get('measurement_method')!r}, after={after_obs.get('measurement_method')!r}"
+        )
+    requested_delta = [requested_after[axis] - requested_before[axis] for axis in (0, 1)]
+    observed_delta = [bounds_after[axis] - bounds_before[axis] for axis in (0, 1)]
+    if any(abs(observed_delta[axis] - requested_delta[axis]) > 1 for axis in (0, 1)):
+        raise AssertionError(
+            "focus_list preview bounds disagree with requested movement: "
+            f"requested={requested_delta!r}, observed={observed_delta!r}"
+        )
+    report["preview"] = {
+        "bounds_before": bounds_before,
+        "bounds_after": bounds_after,
+        "requested_before": requested_before,
+        "requested_after": requested_after,
+        "requested_delta": requested_delta,
+        "observed_delta": observed_delta,
+        "measurement_method_before": before_obs.get("measurement_method"),
+        "measurement_method_after": after_obs.get("measurement_method"),
+        "measurement_method": after_obs.get("measurement_method"),
+        "frame_id_before": frame_before,
+        "frame_id_after": frame_after,
+    }
+
+    # Step 3: patch via real Save overlay control.
+    pre_save_bytes = fixture_path.read_bytes()
+    pre_save_sha = _sha256_file(fixture_path)
+    pre_save_text = pre_save_bytes.decode("utf-8")
+    generation_before = _source_generation(analysis_status)
+    save_request = _require_ok(
+        client.click_element(id="rf_save", screen="_renforge_editor_overlay"),
+        "pos save",
+    )
+    save_status = _wait_for_status(
+        client,
+        lambda status: not bool(status.get("save_in_progress"))
+        and status.get("status_text") == "Reload committed"
+        and _source_generation(status) == generation_before + 1,
+        timeout=60.0,
+        poll_name="pos save complete",
+    )
+    post_save_bytes = fixture_path.read_bytes()
+    post_save_sha = _sha256_file(fixture_path)
+    post_save_text = post_save_bytes.decode("utf-8")
+    source_position_after = _parse_xy_from_target_line(post_save_text)
+    expected_source_position = {"x": requested_after[0], "y": requested_after[1]}
+    if source_position_after != expected_source_position:
+        raise AssertionError(
+            "source patch disagrees with requested preview position: "
+            f"expected={expected_source_position!r}, observed={source_position_after!r}"
+        )
+    expected_text = _independent_expected_after_patch(
+        pre_save_text,
+        x=requested_after[0],
+        y=requested_after[1],
+    )
+    if post_save_text != expected_text:
+        raise AssertionError("patched fixture bytes disagree with independent expected content")
+    outside_coordinate_spans_identical = _outside_coordinate_spans_identical(
+        pre_save_text,
+        post_save_text,
+    )
+    if not outside_coordinate_spans_identical:
+        raise AssertionError("source patch changed bytes outside xpos/ypos spans")
+    report["patch"] = {
+        "before_sha256": pre_save_sha,
+        "after_sha256": post_save_sha,
+        "source_position_after": source_position_after,
+        "outside_coordinate_spans_identical": outside_coordinate_spans_identical,
+        "matches_independent_expected": True,
+        "save_request": save_request,
+    }
+
+    # Step 4: reload publication cycle (frame_id filled after rebind observation).
+    report["reload"] = {
+        "ok": True,
+        "script_generation": _source_generation(save_status),
+        "status_text": save_status.get("status_text"),
+        "generation_delta": _source_generation(save_status) - generation_before,
+        "pending_handshake_sent": save_status.get("pending_handshake_sent"),
+        "frame_id": None,
+    }
+
+    # Step 5: pixel agreement between post-preview focus rect and post-reload focus rect.
+    successor = _wait_for_status(
+        client,
+        lambda status: bool(status.get("current_analysis_id"))
+        and status.get("selected_widget_id") == TARGET_ID
+        and status.get("selected_lock_reason") in (None, ""),
+        timeout=10.0,
+        poll_name="pos post-save rebind analysis",
+    )
+    reload_obs = _observe_selected(client)
+    value_reload = client.eval_expr("renforge_editor_pos_clicks")
+    reload_rect = reload_obs.get("rect") or []
+    if len(reload_rect) < 2:
+        raise AssertionError(f"post-reload observation missing rect: {reload_obs!r}")
+    reload_bounds = [int(reload_rect[0]), int(reload_rect[1])]
+    pixel_delta = [
+        reload_bounds[0] - bounds_after[0],
+        reload_bounds[1] - bounds_after[1],
+    ]
+    if any(abs(value) > 1 for value in pixel_delta):
+        raise AssertionError(
+            "post-reload focus rect disagrees with post-preview focus rect: "
+            f"preview={bounds_after!r}, reload={reload_bounds!r}, delta={pixel_delta!r}"
+        )
+    report["pixel_agreement"] = {
+        "preview_after": bounds_after,
+        "reload_after": reload_bounds,
+        "delta": pixel_delta,
+        "measurement_method": reload_obs.get("measurement_method"),
+        "measurement_method_preview": after_obs.get("measurement_method"),
+        "measurement_method_reload": reload_obs.get("measurement_method"),
+        "frame_id_preview": frame_after,
+        "frame_id_reload": reload_obs.get("frame_id"),
+    }
+    reload_frame = reload_obs.get("frame_id")
+    if not reload_frame or reload_frame == frame_after:
+        raise AssertionError(
+            f"reload observation must have a distinct real frame_id: "
+            f"preview={frame_after!r}, reload={reload_frame!r}"
+        )
+    report["value_invariance"] = {
+        "baseline": value_baseline,
+        "preview": value_preview,
+        "reload": value_reload,
+    }
+    if value_preview != value_baseline or value_reload != value_baseline:
+        raise AssertionError(
+            "textbutton click counter changed during preview/reload: "
+            f"baseline={value_baseline!r}, preview={value_preview!r}, reload={value_reload!r}"
+        )
+    report["reload"]["frame_id"] = reload_obs.get("frame_id")
+
+    # Step 6: rebinding.
+    report["rebinding"] = {
+        "ok": successor.get("selected_widget_id") == TARGET_ID
+        and successor.get("current_analysis_id")
+        not in (None, analysis_status.get("current_analysis_id"))
+        and (successor.get("current_source_key") or {}).get("statement_kind") == "textbutton",
+        "widget_id": successor.get("selected_widget_id"),
+        "analysis_id": successor.get("current_analysis_id"),
+        "previous_analysis_id": analysis_status.get("current_analysis_id"),
+        "source_key": successor.get("current_source_key"),
+        "lock_reason": successor.get("selected_lock_reason"),
+    }
+    if report["rebinding"]["ok"] is not True:
+        raise AssertionError(f"rebinding failed: {report['rebinding']!r}")
+
+    # Step 7: byte-identical undo of the temporary fixture.
+    fixture_path.write_bytes(baseline_bytes)
+    restored_bytes = fixture_path.read_bytes()
+    restored_sha = _sha256_file(fixture_path)
+    report["byte_identical_undo"] = {
+        "baseline_sha256": baseline_sha,
+        "restored_sha256": restored_sha,
+        "matches_baseline": restored_sha == baseline_sha and restored_bytes == baseline_bytes,
+        "patched_differed": post_save_sha != baseline_sha and post_save_bytes != baseline_bytes,
+    }
+    if restored_bytes != baseline_bytes:
+        raise AssertionError("pos textbutton undo did not restore the baseline")
+    return report

--- a/tests/live_fixtures/renforge_editor_pos_fixture.rpy
+++ b/tests/live_fixtures/renforge_editor_pos_fixture.rpy
@@ -1,0 +1,35 @@
+default renforge_editor_pos_clicks = 0
+default renforge_editor_pos_computed_x = 520
+
+
+screen renforge_editor_pos_dupe(label_text, left_x):
+    textbutton label_text id "pos_dupe_target" pos (left_x, 430) action NullAction()
+
+
+screen renforge_editor_pos_fixture():
+    layer "screens"
+    zorder 640
+
+    fixed:
+        id "pos_root"
+        xfill True
+        yfill True
+
+        # Supported form: single-line textbutton with literal pos (x, y).
+        textbutton "MOVE ME" id "pos_target" pos (200, 180) action SetVariable("renforge_editor_pos_clicks", renforge_editor_pos_clicks + 1)
+
+        textbutton "COMPUTED" id "pos_computed" pos (renforge_editor_pos_computed_x, 300) action NullAction()
+
+        vbox:
+            id "pos_container_parent"
+            xpos 900
+            ypos 120
+            spacing 12
+
+            textbutton "CONTAINER" id "pos_container" pos (0, 0) action NullAction()
+
+        side "c":
+            textbutton "SIDE" id "pos_side" pos (100, 520) action NullAction()
+
+        use renforge_editor_pos_dupe("DUPE A", 520)
+        use renforge_editor_pos_dupe("DUPE B", 720)

--- a/tests/test_editor_coordinator.py
+++ b/tests/test_editor_coordinator.py
@@ -1674,3 +1674,83 @@ def test_analyze_textbutton_block_computed_position_stays_locked(tmp_path: Path)
             assert analyzed["result"]["lock_reason"]["code"] == "XPOS_LITERAL_REQUIRED"
     finally:
         coordinator.close()
+
+
+def test_analyze_and_commit_textbutton_pos_preserves_form(tmp_path: Path) -> None:
+    root = tmp_path / "project_pos"
+    game_dir = root / "game"
+    game_dir.mkdir(parents=True)
+    source = game_dir / "script.rpy"
+    source.write_text(
+        "screen test_screen:\n"
+        '    textbutton "Play" id "start_btn" pos (12, 10) action NullAction()\n',
+        encoding="utf-8",
+    )
+    project = RenpyProject(root)
+    observation = _base_observation(script_generation=12)
+    probe = _Probe(
+        observe_reply={
+            **json.loads(json.dumps(observation)),
+            "frame_id": "independent-frame-pos",
+            "object_id": "obj-independent-pos",
+        },
+        attest_reply={"ok": True, "state": "all_targets_attested"},
+    )
+    coordinator = EditorCoordinator(project, _make_sdk(tmp_path), attestation_timeout=2.0)
+    coordinator.attach_runtime_probe(probe)
+    endpoint = coordinator.start()
+    try:
+        with socket.create_connection((endpoint.host, endpoint.port), timeout=2.0) as sock:
+            auth = _auth(sock, endpoint)
+            analyzed = _analyze(sock, auth, observation, request_id="an-pos")
+            assert analyzed["ok"] is True
+            result = analyzed["result"]
+            assert result["lock_reason"] is None
+            assert result["capabilities"] == {"move": True}
+            assert result["source_key"]["statement_kind"] == "textbutton"
+            assert result["original_position"] == [12, 10]
+
+            committed = _commit(sock, auth, analyzed, x=40, y=50, request_id="co-pos")
+            assert committed["ok"] is True
+            assert committed["result"]["state"] == "published"
+            text = source.read_text(encoding="utf-8")
+            assert text == (
+                "screen test_screen:\n"
+                '    textbutton "Play" id "start_btn" pos (40, 50) action NullAction()\n'
+            )
+            assert "xpos" not in text and "ypos" not in text
+    finally:
+        coordinator.close()
+
+
+def test_analyze_textbutton_pos_non_literal_stays_locked(tmp_path: Path) -> None:
+    root = tmp_path / "project_pos_lock"
+    game_dir = root / "game"
+    game_dir.mkdir(parents=True)
+    source = game_dir / "script.rpy"
+    source.write_text(
+        "screen test_screen:\n"
+        '    textbutton "Play" id "start_btn" pos (base_x, 10) action NullAction()\n',
+        encoding="utf-8",
+    )
+    project = RenpyProject(root)
+    observation = _base_observation(script_generation=13)
+    probe = _Probe(
+        observe_reply={
+            **json.loads(json.dumps(observation)),
+            "frame_id": "independent-frame-pos-lock",
+            "object_id": "obj-independent-pos-lock",
+        },
+    )
+    coordinator = EditorCoordinator(project, _make_sdk(tmp_path))
+    coordinator.attach_runtime_probe(probe)
+    endpoint = coordinator.start()
+    try:
+        with socket.create_connection((endpoint.host, endpoint.port), timeout=2.0) as sock:
+            auth = _auth(sock, endpoint)
+            analyzed = _analyze(sock, auth, observation, request_id="an-pos-lock")
+            assert analyzed["ok"] is True
+            assert analyzed["result"]["capabilities"] == {"move": False}
+            assert analyzed["result"]["lock_reason"]["code"] == "POS_LITERAL_REQUIRED"
+    finally:
+        coordinator.close()

--- a/tests/test_editor_pos_live.py
+++ b/tests/test_editor_pos_live.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import os
+import shutil
+import time
+from pathlib import Path
+
+import pytest
+
+from renforge.editor_pos_runner import (
+    FIXTURE_SCREEN,
+    inject_editor_pos_resources,
+    run_editor_pos_live_scenario,
+)
+
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("RENFORGE_POS_LIVE"),
+    reason="set RENFORGE_POS_LIVE=1 to run pos (x, y) seven-step live proof",
+)
+
+_DEMO = Path(__file__).resolve().parents[1] / "examples" / "demo_game"
+
+
+@pytest.fixture
+def demo_copy(tmp_path: Path) -> Path:
+    destination = tmp_path / "demo"
+    shutil.copytree(_DEMO, destination, ignore=shutil.ignore_patterns("*.rpyc", "cache"))
+    inject_editor_pos_resources(destination)
+    return destination
+
+
+def test_pos_seven_step_live_proof(demo_copy: Path) -> None:
+    from renforge.bridge.launcher import launch_with_bridge
+    from renforge.project import RenpyProject
+    from renforge.sdk import get_or_install_sdk
+
+    sdk = get_or_install_sdk("8.5.3", project_root=demo_copy)
+    project = RenpyProject(demo_copy)
+    fixture_path = demo_copy / "game" / "zz_renforge_editor_pos_fixture.rpy"
+
+    with launch_with_bridge(
+        sdk,
+        project,
+        startup_timeout=120,
+        editor=True,
+    ) as session:
+        for _ in range(40):
+            launcher = session.client.inspect_screen("_renforge_editor_launcher")
+            if launcher.get("active") is True:
+                break
+            time.sleep(0.25)
+        else:
+            pytest.fail("editor launcher never became active")
+
+        launcher_click = session.client.click_element(
+            text="RF",
+            exact=True,
+            screen="_renforge_editor_launcher",
+        )
+        assert launcher_click.get("ok") is True, launcher_click
+        for _ in range(40):
+            overlay = session.client.inspect_screen("_renforge_editor_overlay")
+            if overlay.get("active") is True:
+                break
+            time.sleep(0.05)
+        else:
+            pytest.fail("editor overlay never became active")
+
+        for _ in range(20):
+            available = session.client.eval_expr(f'renpy.has_screen("{FIXTURE_SCREEN}")')
+            if available is True:
+                break
+            time.sleep(0.1)
+        else:
+            pytest.fail("pos fixture screen never became available")
+
+        report = run_editor_pos_live_scenario(
+            session.client,
+            fixture_path=fixture_path,
+        )
+
+    assert report["resolve"]["statement_kind"] == "textbutton"
+    assert report["resolve"]["lock_reason"] in (None, "")
+    assert report["resolve"]["move"] is True
+    assert report["resolve"]["measurement_method"] == "focus_list"
+    assert report["fixture_before"]["position_mode"] == "pos"
+
+    preview = report["preview"]
+    assert preview["bounds_before"] != preview["bounds_after"]
+    assert all(
+        abs(preview["observed_delta"][axis] - preview["requested_delta"][axis]) <= 1
+        for axis in (0, 1)
+    )
+
+    patch = report["patch"]
+    assert patch["outside_coordinate_spans_identical"] is True
+    assert patch["matches_independent_expected"] is True
+    assert patch["after_sha256"] != patch["before_sha256"]
+    assert patch["source_position_after"] == {
+        "x": preview["requested_after"][0],
+        "y": preview["requested_after"][1],
+    }
+
+    assert report["reload"]["ok"] is True
+    assert report["reload"]["status_text"] == "Reload committed"
+    assert report["reload"]["generation_delta"] == 1
+
+    assert all(abs(int(value)) <= 1 for value in report["pixel_agreement"]["delta"])
+
+    value_invariance = report["value_invariance"]
+    assert value_invariance["preview"] == value_invariance["baseline"]
+    assert value_invariance["reload"] == value_invariance["baseline"]
+
+    assert report["rebinding"]["ok"] is True
+    assert report["rebinding"]["widget_id"] == "pos_target"
+
+    locks = report["locks"]
+    assert locks["computed"] == "POS_LITERAL_REQUIRED"
+    assert locks["container"] == "CONTAINER_POSITION_UNSUPPORTED"
+    assert locks["ambiguous"] == "SYNTHETIC_WIDGET_ID"
+    assert locks["unproven"] == "UNKNOWN_ANCESTRY_TYPE"
+
+    undo = report["byte_identical_undo"]
+    assert undo["matches_baseline"] is True
+    assert undo["patched_differed"] is True

--- a/tests/test_editor_source.py
+++ b/tests/test_editor_source.py
@@ -122,6 +122,73 @@ def test_apply_textbutton_patch_preserves_non_ascii_bytes_outside_coordinate_spa
     )
 
 
+def test_analyze_textbutton_pos_literal_accepts_and_patches_pair_only() -> None:
+    line = '    textbutton "Play" id "start" pos (12, 10) action NullAction()\n'
+    parsed = analyze_textbutton_statement(line, expected_widget_id="start")
+    assert isinstance(parsed, TextbuttonStatement)
+    assert parsed.position_mode == "pos"
+    assert (parsed.xpos, parsed.ypos) == (12, 10)
+    patched = apply_textbutton_patch(line.encode("utf-8"), parsed, x=301, y=409).decode("utf-8")
+    assert patched == '    textbutton "Play" id "start" pos (301, 409) action NullAction()\n'
+    # Form preserved — never rewritten to xpos/ypos.
+    assert "xpos" not in patched
+    assert "ypos" not in patched
+    assert "pos (" in patched
+
+    negative = '    textbutton "Play" id "start" pos (-12, -10) action NullAction()\n'
+    neg_parsed = analyze_textbutton_statement(negative, expected_widget_id="start")
+    assert (neg_parsed.xpos, neg_parsed.ypos) == (-12, -10)
+    neg_patched = apply_textbutton_patch(
+        negative.encode("utf-8"), neg_parsed, x=-1, y=2
+    ).decode("utf-8")
+    assert neg_patched == '    textbutton "Play" id "start" pos (-1, 2) action NullAction()\n'
+
+
+def test_analyze_textbutton_pos_rejects_non_literal_mixed_and_duplicate() -> None:
+    with pytest.raises(EditorSourceError) as excinfo:
+        analyze_textbutton_statement(
+            '    textbutton "Play" id "start" pos (base_x, 10) action NullAction()\n',
+            expected_widget_id="start",
+        )
+    assert excinfo.value.code == "POS_LITERAL_REQUIRED"
+
+    with pytest.raises(EditorSourceError) as excinfo:
+        analyze_textbutton_statement(
+            '    textbutton "Play" id "start" pos (10+1, 10) action NullAction()\n',
+            expected_widget_id="start",
+        )
+    assert excinfo.value.code == "POS_LITERAL_REQUIRED"
+
+    with pytest.raises(EditorSourceError) as excinfo:
+        analyze_textbutton_statement(
+            '    textbutton "Play" id "start" pos (1, 2) xpos 3 ypos 4 action NullAction()\n',
+            expected_widget_id="start",
+        )
+    assert excinfo.value.code == "POSITION_FORM_MIXED"
+
+    with pytest.raises(EditorSourceError) as excinfo:
+        analyze_textbutton_statement(
+            '    textbutton "Play" id "start" pos (1, 2) pos (3, 4) action NullAction()\n',
+            expected_widget_id="start",
+        )
+    assert excinfo.value.code == "POS_DUPLICATE"
+
+    with pytest.raises(EditorSourceError) as excinfo:
+        analyze_textbutton_statement(
+            '    textbutton "Play" id "other" pos (1, 2) action NullAction()\n',
+            expected_widget_id="start",
+        )
+    assert excinfo.value.code == "ID_MISMATCH"
+
+    kind, stmt = analyze_editable_statement(
+        '    textbutton "Play" id "start" pos (8, 9) action NullAction()\n',
+        expected_widget_id="start",
+    )
+    assert kind == "textbutton"
+    assert isinstance(stmt, TextbuttonStatement)
+    assert stmt.position_mode == "pos"
+
+
 def test_analyze_rejects_compound_numeric_position_expressions() -> None:
     with pytest.raises(EditorSourceError) as excinfo:
         analyze_textbutton_statement(

--- a/tests/test_editor_source.py
+++ b/tests/test_editor_source.py
@@ -159,6 +159,21 @@ def test_analyze_textbutton_pos_rejects_non_literal_mixed_and_duplicate() -> Non
         )
     assert excinfo.value.code == "POS_LITERAL_REQUIRED"
 
+    # Expression continues after a leading literal tuple (Codex P1).
+    with pytest.raises(EditorSourceError) as excinfo:
+        analyze_textbutton_statement(
+            '    textbutton "Play" id "start" pos (1, 2) if flag else (3, 4) action NullAction()\n',
+            expected_widget_id="start",
+        )
+    assert excinfo.value.code == "POS_LITERAL_REQUIRED"
+
+    with pytest.raises(EditorSourceError) as excinfo:
+        analyze_textbutton_statement(
+            '    textbutton "Play" id "start" pos (1, 2) or (3, 4) action NullAction()\n',
+            expected_widget_id="start",
+        )
+    assert excinfo.value.code == "POS_LITERAL_REQUIRED"
+
     with pytest.raises(EditorSourceError) as excinfo:
         analyze_textbutton_statement(
             '    textbutton "Play" id "start" pos (1, 2) xpos 3 ypos 4 action NullAction()\n',
@@ -179,6 +194,12 @@ def test_analyze_textbutton_pos_rejects_non_literal_mixed_and_duplicate() -> Non
             expected_widget_id="start",
         )
     assert excinfo.value.code == "ID_MISMATCH"
+
+    # ``pos`` as an action value must not be treated as the position property (Codex P2).
+    xy_line = '    textbutton "Play" id "start" xpos 1 ypos 2 action pos\n'
+    xy_parsed = analyze_textbutton_statement(xy_line, expected_widget_id="start")
+    assert xy_parsed.position_mode == "xy"
+    assert (xy_parsed.xpos, xy_parsed.ypos) == (1, 2)
 
     kind, stmt = analyze_editable_statement(
         '    textbutton "Play" id "start" pos (8, 9) action NullAction()\n',


### PR DESCRIPTION
## Summary

Implements [#38](https://github.com/alex-jordan547/renforge-mcp/issues/38): literal **`pos (x, y)`** positioning for the proven `textbutton` adapter, writing back as `pos` without converting to `xpos`/`ypos`.

### Supported form

```renpy
textbutton "MOVE ME" id "pos_target" pos (200, 180) action NullAction()
```

- pure integer pair only (negatives allowed)
- patch replaces only the two integer tokens inside the tuple
- all other bytes preserved (`pos`, parentheses, commas, spacing, action, …)
- never rewritten to `xpos`/`ypos`

### Locks

| Case | Code |
|---|---|
| Non-literal pair | `POS_LITERAL_REQUIRED` |
| Mix `pos` + `xpos`/`ypos` | `POSITION_FORM_MIXED` |
| Duplicate `pos` | `POS_DUPLICATE` |
| Container ancestry | `CONTAINER_POSITION_UNSUPPORTED` |
| Ambiguous `use` | `SYNTHETIC_WIDGET_ID` |
| Unproven ancestry | `UNKNOWN_ANCESTRY_TYPE` |

### Live proof

```bash
RENFORGE_POS_LIVE=1 PYTHONPATH=src python -m pytest -q tests/test_editor_pos_live.py
```

→ **1 passed** on Ren'Py **8.5.3** (resolve → preview → patch → reload → pixel agreement → rebinding → undo)

## Test plan

- [x] Unit/coordinator: **104 passed, 1 skipped**
- [x] Live green with `RENFORGE_POS_LIVE=1`
- [x] Docs updated after live green

## Non-goals

- `align` / `anchor` / `offset` (issues #39–#41)
- `pos` on bar/imagebutton/slider (not claimed)
- Multi-line block `pos` (not claimed)

Closes #38

## Summary by Sourcery

Prise en charge des déplacements visuels sur les `textbutton` mono‑ligne définis avec un littéral `pos (x, y)` tout en préservant la forme de positionnement d’origine.

Nouvelles fonctionnalités :
- Permettre l’analyse et la modification des `textbutton` mono‑ligne définis avec des positions littérales `pos (x, y)`, en préservant `pos` au lieu de réécrire en `xpos`/`ypos`.
- Ajouter un scénario d’éditeur live et un écran de fixture pour valider de bout en bout le déplacement visuel des `textbutton` en `pos (x, y)` dans un jeu Ren’Py en cours d’exécution.

Améliorations :
- Étendre l’analyse des instructions `textbutton` avec un indicateur `position_mode` pour distinguer les positions définies via `pos (x, y)` de celles définies via `xpos`/`ypos`.
- Introduire des codes d’erreurs et des règles de verrouillage pour les usages invalides ou mixtes de `pos`, notamment les paires non littérales, les formes mixtes `pos`/`xpos`, les `pos` dupliqués, les ascendances `use` ambiguës et les ascendances de conteneur/side non prises en charge.

Documentation :
- Documenter la prise en charge de `pos (x, y)` littéral pour les `textbutton` mono‑ligne dans le périmètre de l’éditeur visuel, y compris les comportements de verrouillage et la configuration de la preuve live.
- Mettre à jour la feuille de route pour marquer `pos (x, y)` pour les `textbutton` comme implémenté et clarifier le travail restant pour les autres propriétés de positionnement.

Tests :
- Ajouter des tests unitaires pour l’analyse, la modification et les conditions d’erreur liées au `pos (x, y)` littéral sur les instructions `textbutton`.
- Ajouter des tests au niveau coordinateur pour garantir que les commits préservent la forme `pos` d’origine et verrouillent les usages non littéraux de `pos`.
- Ajouter un test de preuve live en sept étapes utilisant un projet de démonstration comme fixture pour vérifier l’aperçu, le patch, le rechargement, la concordance de pixels, le rebinding et l’annulation pour les `textbutton` en `pos (x, y)`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Support visual moves on single-line textbuttons authored with literal `pos (x, y)` while preserving the original positioning form.

New Features:
- Enable analysis and patching of single-line textbuttons authored with literal `pos (x, y)` positions, preserving `pos` instead of rewriting to `xpos`/`ypos`.
- Add a live editor scenario and fixture screen to validate end-to-end visual movement for `pos (x, y)` textbuttons in a running Ren'Py game.

Enhancements:
- Extend textbutton statement analysis with a `position_mode` flag to distinguish `pos (x, y)` from `xpos`/`ypos`-authored positions.
- Introduce error codes and locking rules for invalid or mixed `pos` usage, including non-literal pairs, mixed `pos`/`xpos` forms, duplicate `pos`, ambiguous `use` ancestry, and unsupported container/side ancestry.

Documentation:
- Document literal `pos (x, y)` support for single-line textbuttons in the visual editor scope, including locking behaviors and live proof configuration.
- Update the roadmap to mark `pos (x, y)` for textbuttons as implemented and clarify remaining work for other positioning properties.

Tests:
- Add unit tests for literal `pos (x, y)` parsing, patching, and error conditions on textbutton statements.
- Add coordinator-level tests to ensure commits preserve the authored `pos` form and lock non-literal `pos` usage.
- Add a seven-step live proof test using a demo project fixture to verify preview, patch, reload, pixel agreement, rebinding, and undo for `pos (x, y)` textbuttons.

</details>