### PR TITLE
Preserve textbutton align and anchor positioning (issues #39–#40)

### DIFF
--- a/docs/superpowers/specs/2026-07-30-renforge-visual-editor-v1-scope.md
+++ b/docs/superpowers/specs/2026-07-30-renforge-visual-editor-v1-scope.md
@@ -113,9 +113,12 @@ textbutton "MOVE ME" id "align_target" align (0.2, 0.25) action NullAction()
 ```
 
 Host analysis records `position_mode == "align"` and stores authored fractions plus the measured
-focus baseline. Preview uses absolute xpos overrides so focus_list tracks the pixel delta; write-back
-applies `authored + Δpixel / parent_size` (parent **1280×720**) and preserves the `align` form.
-Attestation allows a **2 px** residual for align fraction round-trips on textbutton styles.
+focus baseline and widget size from the **independent** `focus_list` observation. Parent size is
+unlocked only when that geometry matches the proven full-screen **1280×720** model. Preview uses
+absolute xpos/ypos (with align/anchor/offset neutralized) so focus_list tracks the pixel delta;
+write-back applies `authored + Δpixel / (parent − widget)` because Ren'Py `align` also sets the
+anchor, and preserves the `align` form. Attestation requires agreement within **1 px**. Zero
+placement extent on an axis is locked; concurrent `offset` / axis-split properties are locked.
 
 Live: `RENFORGE_ALIGN_LIVE=1 … tests/test_editor_align_live.py` on Ren'Py **8.5.3**.
 

--- a/docs/superpowers/specs/2026-07-30-renforge-visual-editor-v1-scope.md
+++ b/docs/superpowers/specs/2026-07-30-renforge-visual-editor-v1-scope.md
@@ -106,6 +106,31 @@ locked with exact codes (`POS_LITERAL_REQUIRED`, `POSITION_FORM_MIXED`, `POS_DUP
 Live proof: `RENFORGE_POS_LIVE=1 uv run --extra test python -m pytest -q tests/test_editor_pos_live.py`
 against Ren'Py **8.5.3**.
 
+### Literal `align (x, y)` on textbutton (issue #39)
+
+```renpy
+textbutton "MOVE ME" id "align_target" align (0.2, 0.25) action NullAction()
+```
+
+Host analysis records `position_mode == "align"` and stores authored fractions plus the measured
+focus baseline. Preview uses absolute xpos overrides so focus_list tracks the pixel delta; write-back
+applies `authored + Δpixel / parent_size` (parent **1280×720**) and preserves the `align` form.
+Attestation allows a **2 px** residual for align fraction round-trips on textbutton styles.
+
+Live: `RENFORGE_ALIGN_LIVE=1 … tests/test_editor_align_live.py` on Ren'Py **8.5.3**.
+
+### Literal `anchor` with xpos/ypos (issue #40)
+
+```renpy
+textbutton "MOVE ME" id "anchor_target" xpos 400 ypos 300 anchor (0.5, 0.5) action NullAction()
+```
+
+Pure `anchor (fx, fy)` is required when present (`ANCHOR_LITERAL_REQUIRED` otherwise). Moves patch
+only `xpos`/`ypos`; **anchor bytes are preserved**. Live proof measures focus_list independently of
+the anchor point.
+
+Live: `RENFORGE_ANCHOR_LIVE=1 … tests/test_editor_anchor_live.py` on Ren'Py **8.5.3**.
+
 The `button` adapter is intentionally limited to `button id "..." xpos N ypos N:` headers. Computed
 coordinates, direct child `xpos`/`ypos`, layout-container ancestry, and ambiguous or unproven runtime
 instances remain selectable but locked with an exact reason.

--- a/docs/superpowers/specs/2026-07-30-renforge-visual-editor-vfull-roadmap.md
+++ b/docs/superpowers/specs/2026-07-30-renforge-visual-editor-vfull-roadmap.md
@@ -64,7 +64,7 @@ Real screens are messier.
 | Form | Problem | Possible approach |
 |---|---|---|
 | Multi-line statement with a block | Position keywords may sit on any line of the block | **Partially implemented (issue #37):** multi-line `textbutton` with `id`/`xpos`/`ypos` in the child block only; seven-step live proof green via `RENFORGE_MULTILINE_TEXTBUTTON_LIVE=1`. Other adapters remain single-line or header-only (`button`). |
-| `pos (x, y)` / `align` / `anchor` / `offset` | Different property, same intent | **`pos` implemented (issue #38)** for single-line `textbutton` with pure `pos (x, y)`; write-back preserves `pos` (never rewrites to xpos/ypos). Live: `RENFORGE_POS_LIVE=1`. `align` / `anchor` / `offset` still pending. |
+| `pos (x, y)` / `align` / `anchor` / `offset` | Different property, same intent | **`pos` (#38)**, **`align` (#39)**, **`anchor` (#40)** implemented for single-line `textbutton`. Write-back preserves form. Lives: `RENFORGE_POS_LIVE=1`, `RENFORGE_ALIGN_LIVE=1`, `RENFORGE_ANCHOR_LIVE=1`. `offset` still pending. |
 | Position from a **variable or expression** | Cannot be rewritten without changing semantics | **Stays locked.** Offer to show the computed value, never to overwrite the expression |
 | Element inside `hbox` / `vbox` / `grid` | Position is computed by the layout, not authored | **Stays locked** for direct move. A layout-aware edit is a different feature |
 | Multiple instances from one loop / `use` | One source line, N runtime widgets | Needs a disambiguation UI; the stable key already carries `ordinal` |

--- a/src/renforge/bridge/editor.rpy
+++ b/src/renforge/bridge/editor.rpy
@@ -1139,6 +1139,8 @@ init 1100 python:
             # tracks the requested pixel delta 1:1. Source write-back still uses
             # align fractions (host apply converts using the measured baseline).
             if position_mode == "align":
+                # Absolute placement for preview; neutralize align/anchor/offset so
+                # concurrent axis props cannot stack on top of the requested TL.
                 properties[str(widget_id)] = {
                     "xpos": next_x,
                     "ypos": next_y,
@@ -1146,6 +1148,8 @@ init 1100 python:
                     "yalign": 0.0,
                     "xanchor": 0.0,
                     "yanchor": 0.0,
+                    "xoffset": 0,
+                    "yoffset": 0,
                 }
             else:
                 properties[str(widget_id)] = {
@@ -2611,11 +2615,8 @@ init 1100 python:
                 expected_x = int(expected_position[0])
                 expected_y = int(expected_position[1])
                 rect = observation.get("rect") or []
-                # Align fraction round-trips can be off by 1–2 logical px on textbutton
-                # styles after reload; keep 1px for all other position modes.
-                position_mode = source_key.get("position_mode") if builtins.isinstance(source_key, builtins.dict) else None
-                tolerance = 2 if position_mode == "align" else 1
-                if not (abs(int(rect[0]) - expected_x) <= tolerance and abs(int(rect[1]) - expected_y) <= tolerance):
+                # Issue #39 requires pixel agreement within one logical pixel.
+                if not (abs(int(rect[0]) - expected_x) <= 1 and abs(int(rect[1]) - expected_y) <= 1):
                     return {
                         "ok": False,
                         "error": "TARGET_POSITION_MISMATCH",

--- a/src/renforge/bridge/editor.rpy
+++ b/src/renforge/bridge/editor.rpy
@@ -1131,10 +1131,27 @@ init 1100 python:
                 and widget_id
             ):
                 continue
-            properties[str(widget_id)] = {
-                "xpos": int(source_position[0]) + int(position[0]) - int(runtime_baseline[0]),
-                "ypos": int(source_position[1]) + int(position[1]) - int(runtime_baseline[1]),
-            }
+            next_x = int(source_position[0]) + int(position[0]) - int(runtime_baseline[0])
+            next_y = int(source_position[1]) + int(position[1]) - int(runtime_baseline[1])
+            source_key = target.get("source_key") or {}
+            position_mode = source_key.get("position_mode") if builtins.isinstance(source_key, builtins.dict) else None
+            # Align-authored targets: preview with absolute xpos/ypos so focus_list
+            # tracks the requested pixel delta 1:1. Source write-back still uses
+            # align fractions (host apply converts using the measured baseline).
+            if position_mode == "align":
+                properties[str(widget_id)] = {
+                    "xpos": next_x,
+                    "ypos": next_y,
+                    "xalign": 0.0,
+                    "yalign": 0.0,
+                    "xanchor": 0.0,
+                    "yanchor": 0.0,
+                }
+            else:
+                properties[str(widget_id)] = {
+                    "xpos": next_x,
+                    "ypos": next_y,
+                }
         return properties
 
 
@@ -2594,7 +2611,11 @@ init 1100 python:
                 expected_x = int(expected_position[0])
                 expected_y = int(expected_position[1])
                 rect = observation.get("rect") or []
-                if not (abs(int(rect[0]) - expected_x) <= 1 and abs(int(rect[1]) - expected_y) <= 1):
+                # Align fraction round-trips can be off by 1–2 logical px on textbutton
+                # styles after reload; keep 1px for all other position modes.
+                position_mode = source_key.get("position_mode") if builtins.isinstance(source_key, builtins.dict) else None
+                tolerance = 2 if position_mode == "align" else 1
+                if not (abs(int(rect[0]) - expected_x) <= tolerance and abs(int(rect[1]) - expected_y) <= tolerance):
                     return {
                         "ok": False,
                         "error": "TARGET_POSITION_MISMATCH",

--- a/src/renforge/editor/coordinator.py
+++ b/src/renforge/editor/coordinator.py
@@ -30,7 +30,9 @@ from .paths import EditorPathError, atomic_write_file, fsync_directory, resolve_
 from .runtime import RuntimeProbe
 from .shadow import ShadowLintResult, build_shadow_project, run_shadow_lint
 from .source import (
+    DEFAULT_ALIGN_PARENT_SIZE,
     EditorSourceError,
+    align_geometry_matches_parent,
     analyze_button_statement,
     analyze_editable_statement,
     analyze_textbutton_block_statement,
@@ -598,8 +600,10 @@ class EditorCoordinator:
                 "position_mode": position_mode,
             }
             if position_mode == "align":
-                # Authored fractions + measured baseline/size: Ren'Py align also
-                # sets anchor, so TL moves over (parent - widget) extent.
+                # Authored fractions + independent geometry: Ren'Py align also
+                # sets anchor, so TL moves over (parent − widget) extent.
+                # Parent size is only unlocked when independent focus proves the
+                # full-screen 1280×720 placement model (issue #39).
                 source_key["align_authored"] = [
                     float(statement.xpos),
                     float(statement.ypos),
@@ -608,17 +612,49 @@ class EditorCoordinator:
                     int(runtime_position[0]),
                     int(runtime_position[1]),
                 ]
-                source_key["align_parent_size"] = list(
-                    getattr(statement, "align_parent_size", (1280, 720))
+                parent_size = tuple(
+                    getattr(statement, "align_parent_size", DEFAULT_ALIGN_PARENT_SIZE)
                 )
-                # observation rect is [x, y, w, h] when available on the input
-                # observation used for analysis (stored on runtime_position only
-                # as x,y). Prefer full rect from the analyze payload when present.
-                rect = observation.get("rect") if isinstance(observation, dict) else None
-                if isinstance(rect, list) and len(rect) >= 4:
-                    source_key["align_widget_size"] = [int(rect[2]), int(rect[3])]
+                source_key["align_parent_size"] = list(parent_size)
+                # Widget size must come from the independent focus_list rect —
+                # never fall back to a missing/stale input observation.
+                ind_rect = independent.get("rect") if isinstance(independent, dict) else None
+                if (
+                    isinstance(ind_rect, list)
+                    and len(ind_rect) >= 4
+                    and type(ind_rect[2]) is int
+                    and type(ind_rect[3]) is int
+                    and int(ind_rect[2]) > 0
+                    and int(ind_rect[3]) > 0
+                ):
+                    widget_size = (int(ind_rect[2]), int(ind_rect[3]))
+                    source_key["align_widget_size"] = list(widget_size)
+                    if lock_reason is None:
+                        extent_w = int(parent_size[0]) - widget_size[0]
+                        extent_h = int(parent_size[1]) - widget_size[1]
+                        if extent_w == 0 and extent_h == 0:
+                            lock_reason = self._lock_reason(
+                                "ALIGN_EXTENT_ZERO",
+                                "align placement extent is zero on both axes",
+                            )
+                        elif not align_geometry_matches_parent(
+                            authored=(float(statement.xpos), float(statement.ypos)),
+                            runtime_xy=(int(runtime_position[0]), int(runtime_position[1])),
+                            widget_size=widget_size,
+                            parent_size=parent_size,
+                            tolerance=1,
+                        ):
+                            lock_reason = self._lock_reason(
+                                "ALIGN_PARENT_UNPROVEN",
+                                "independent geometry does not match proven full-screen align parent",
+                            )
                 else:
                     source_key["align_widget_size"] = [0, 0]
+                    if lock_reason is None:
+                        lock_reason = self._lock_reason(
+                            "ALIGN_WIDGET_SIZE_UNPROVEN",
+                            "independent observation must provide positive widget width and height",
+                        )
             if lock_reason is None:
                 if observation.get("measurement_method") != "focus_list":
                     lock_reason = self._lock_reason(

--- a/src/renforge/editor/coordinator.py
+++ b/src/renforge/editor/coordinator.py
@@ -557,7 +557,13 @@ class EditorCoordinator:
                     header_line,
                     expected_widget_id=widget_id,
                 )
-            original_position = [statement.xpos, statement.ypos]
+            # Align is fractional in source; the editor delta formula works in
+            # logical pixels, so original_position is the measured runtime rect.
+            position_mode = getattr(statement, "position_mode", "xy")
+            if position_mode == "align":
+                original_position = list(runtime_position)
+            else:
+                original_position = [int(statement.xpos), int(statement.ypos)]
             ancestry = runtime_key.get("ancestry")
             normalized_ancestry = (
                 [
@@ -589,7 +595,22 @@ class EditorCoordinator:
                 "ancestry": normalized_ancestry,
                 "statement_kind": statement_kind,
                 "baseline_sha256": source_sha,
+                "position_mode": position_mode,
             }
+            if position_mode == "align":
+                # Authored fractions + runtime baseline let preview/write apply a
+                # pure pixel delta without assuming focus TL == align*parent.
+                source_key["align_authored"] = [
+                    float(statement.xpos),
+                    float(statement.ypos),
+                ]
+                source_key["align_runtime_baseline"] = [
+                    int(runtime_position[0]),
+                    int(runtime_position[1]),
+                ]
+                source_key["align_parent_size"] = list(
+                    getattr(statement, "align_parent_size", (1280, 720))
+                )
             if lock_reason is None:
                 if observation.get("measurement_method") != "focus_list":
                     lock_reason = self._lock_reason(
@@ -1044,13 +1065,27 @@ class EditorCoordinator:
                     lines[line_no - 1],
                     expected_widget_id=widget_id,
                 )
-                lines[line_no - 1] = apply_editable_statement_patch(
-                    lines[line_no - 1].encode("utf-8"),
-                    kind,
-                    statement,
-                    x=x,
-                    y=y,
-                ).decode("utf-8")
+                align_baseline = source_key.get("align_runtime_baseline")
+                if kind == "textbutton" and getattr(statement, "position_mode", "xy") == "align":
+                    lines[line_no - 1] = apply_textbutton_patch(
+                        lines[line_no - 1].encode("utf-8"),
+                        statement,
+                        x=x,
+                        y=y,
+                        align_runtime_baseline=(
+                            tuple(align_baseline)
+                            if isinstance(align_baseline, (list, tuple)) and len(align_baseline) == 2
+                            else None
+                        ),
+                    ).decode("utf-8")
+                else:
+                    lines[line_no - 1] = apply_editable_statement_patch(
+                        lines[line_no - 1].encode("utf-8"),
+                        kind,
+                        statement,
+                        x=x,
+                        y=y,
+                    ).decode("utf-8")
 
         return "".join(lines).encode("utf-8")
 

--- a/src/renforge/editor/coordinator.py
+++ b/src/renforge/editor/coordinator.py
@@ -598,8 +598,8 @@ class EditorCoordinator:
                 "position_mode": position_mode,
             }
             if position_mode == "align":
-                # Authored fractions + runtime baseline let preview/write apply a
-                # pure pixel delta without assuming focus TL == align*parent.
+                # Authored fractions + measured baseline/size: Ren'Py align also
+                # sets anchor, so TL moves over (parent - widget) extent.
                 source_key["align_authored"] = [
                     float(statement.xpos),
                     float(statement.ypos),
@@ -611,6 +611,14 @@ class EditorCoordinator:
                 source_key["align_parent_size"] = list(
                     getattr(statement, "align_parent_size", (1280, 720))
                 )
+                # observation rect is [x, y, w, h] when available on the input
+                # observation used for analysis (stored on runtime_position only
+                # as x,y). Prefer full rect from the analyze payload when present.
+                rect = observation.get("rect") if isinstance(observation, dict) else None
+                if isinstance(rect, list) and len(rect) >= 4:
+                    source_key["align_widget_size"] = [int(rect[2]), int(rect[3])]
+                else:
+                    source_key["align_widget_size"] = [0, 0]
             if lock_reason is None:
                 if observation.get("measurement_method") != "focus_list":
                     lock_reason = self._lock_reason(
@@ -1066,6 +1074,7 @@ class EditorCoordinator:
                     expected_widget_id=widget_id,
                 )
                 align_baseline = source_key.get("align_runtime_baseline")
+                align_size = source_key.get("align_widget_size")
                 if kind == "textbutton" and getattr(statement, "position_mode", "xy") == "align":
                     lines[line_no - 1] = apply_textbutton_patch(
                         lines[line_no - 1].encode("utf-8"),
@@ -1075,6 +1084,11 @@ class EditorCoordinator:
                         align_runtime_baseline=(
                             tuple(align_baseline)
                             if isinstance(align_baseline, (list, tuple)) and len(align_baseline) == 2
+                            else None
+                        ),
+                        align_widget_size=(
+                            tuple(align_size)
+                            if isinstance(align_size, (list, tuple)) and len(align_size) == 2
                             else None
                         ),
                     ).decode("utf-8")

--- a/src/renforge/editor/source.py
+++ b/src/renforge/editor/source.py
@@ -11,19 +11,28 @@ class EditorSourceError(ValueError):
         self.code = code
 
 
+# Logical parent size used to convert between align fractions and pixels for the
+# evidence-gated full-screen fixed fixtures (demo game is 1280×720).
+DEFAULT_ALIGN_PARENT_SIZE: tuple[int, int] = (1280, 720)
+
+
 @dataclass(frozen=True)
 class TextbuttonStatement:
     widget_id: str
-    xpos: int
-    ypos: int
+    # Pixel integers for xy/pos; fractional floats for align components.
+    xpos: int | float
+    ypos: int | float
     xpos_span: tuple[int, int]
     ypos_span: tuple[int, int]
     # "single_line" keeps spans relative to the statement line.
     # "block" keeps absolute character spans in the full source file.
     form: str = "single_line"
     source_line: int | None = None
-    # "xy" = authored xpos/ypos; "pos" = authored pos (x, y). Write-back preserves form.
+    # xy | pos | align — write-back preserves the authored form.
     position_mode: str = "xy"
+    # When True, a pure literal anchor (fx, fy) is present and must be preserved.
+    has_anchor: bool = False
+    align_parent_size: tuple[int, int] = DEFAULT_ALIGN_PARENT_SIZE
 
 
 @dataclass(frozen=True)
@@ -329,14 +338,16 @@ def _require_single_literal_id(
     return widget_id
 
 
-# Property keywords that may follow a pure ``pos (x, y)`` on a textbutton line.
-# Expression operators (if/or/else/and) are intentionally absent so
-# ``pos (1, 2) if flag else (3, 4)`` is rejected rather than half-patched.
-_TEXTBUTTON_POS_FOLLOWER_WORDS = frozenset(
+# Property keywords that may follow pure pair forms on a textbutton line.
+# Expression operators (if/or/else/and) are intentionally absent.
+_TEXTBUTTON_PAIR_FOLLOWER_WORDS = frozenset(
     {
         "id",
         "xpos",
         "ypos",
+        "pos",
+        "align",
+        "anchor",
         "action",
         "style",
         "xsize",
@@ -369,14 +380,11 @@ _TEXTBUTTON_POS_FOLLOWER_WORDS = frozenset(
 )
 
 
-def _pos_property_indexes(tokens: list[_Token]) -> list[int]:
-    """Indexes of top-level ``pos`` used as a property keyword (value starts with ``(``).
-
-    Distinguishes ``pos (1, 2)`` from expression identifiers such as ``action pos``.
-    """
+def _tuple_property_indexes(tokens: list[_Token], keyword: str) -> list[int]:
+    """Indexes of top-level ``keyword`` used as a property (value starts with ``(``)."""
     indexes: list[int] = []
     for index, token in enumerate(tokens):
-        if token.depth != 0 or token.kind != "WORD" or token.text != "pos":
+        if token.depth != 0 or token.kind != "WORD" or token.text != keyword:
             continue
         next_index = index + 1
         if next_index >= len(tokens):
@@ -387,46 +395,94 @@ def _pos_property_indexes(tokens: list[_Token]) -> list[int]:
     return indexes
 
 
+def _pos_property_indexes(tokens: list[_Token]) -> list[int]:
+    return _tuple_property_indexes(tokens, "pos")
+
+
+def _parse_float_at(
+    tokens: list[_Token], start_index: int
+) -> tuple[float, int, tuple[int, int]] | None:
+    """Parse a pure float or integer token run starting at start_index.
+
+    Accepts ``N``, ``N.M``, and ``-N.M`` (lexer may emit NUMBER / . / NUMBER).
+    Returns (value, index_after_last_token, full_span).
+    """
+    if start_index >= len(tokens) or tokens[start_index].kind != "NUMBER":
+        return None
+    first = tokens[start_index]
+    if (
+        start_index + 2 < len(tokens)
+        and tokens[start_index + 1].kind == "SYMBOL"
+        and tokens[start_index + 1].text == "."
+        and tokens[start_index + 2].kind == "NUMBER"
+    ):
+        text = f"{first.text}.{tokens[start_index + 2].text}"
+        end = tokens[start_index + 2].end
+        return float(text), start_index + 3, (first.start, end)
+    return float(first.text), start_index + 1, (first.start, first.end)
+
+
+def _parse_literal_float_pair(
+    tokens: list[_Token],
+    keyword_index: int,
+) -> tuple[float, float, tuple[int, int], tuple[int, int]] | None:
+    """Parse ``keyword (X, Y)`` with pure float/int literals."""
+    open_index = keyword_index + 1
+    if open_index >= len(tokens):
+        return None
+    if tokens[open_index].kind != "SYMBOL" or tokens[open_index].text != "(":
+        return None
+    x_parsed = _parse_float_at(tokens, open_index + 1)
+    if x_parsed is None:
+        return None
+    x_value, after_x, x_span = x_parsed
+    if after_x >= len(tokens) or tokens[after_x].kind != "SYMBOL" or tokens[after_x].text != ",":
+        return None
+    y_parsed = _parse_float_at(tokens, after_x + 1)
+    if y_parsed is None:
+        return None
+    y_value, after_y, y_span = y_parsed
+    if after_y >= len(tokens) or tokens[after_y].kind != "SYMBOL" or tokens[after_y].text != ")":
+        return None
+    following = after_y + 1
+    if following < len(tokens):
+        next_token = tokens[following]
+        if (
+            next_token.depth != 0
+            or next_token.kind != "WORD"
+            or next_token.text not in _TEXTBUTTON_PAIR_FOLLOWER_WORDS
+        ):
+            return None
+    return x_value, y_value, x_span, y_span
+
+
 def _parse_literal_pos_pair(
     tokens: list[_Token],
     pos_index: int,
 ) -> tuple[int, int, tuple[int, int], tuple[int, int]] | None:
-    """Parse ``pos (X, Y)`` with pure integer literals; return values and number spans.
-
-    A pure pair is either end-of-statement after ``)``, or followed by a top-level
-    textbutton property WORD (not expression operators like ``if`` / ``or``).
-    """
+    """Parse ``pos (X, Y)`` with pure integer literals; return values and number spans."""
     open_index = pos_index + 1
-    if open_index >= len(tokens):
+    if open_index + 4 >= len(tokens):
         return None
-    open_token = tokens[open_index]
-    if open_token.kind != "SYMBOL" or open_token.text != "(":
+    if tokens[open_index].kind != "SYMBOL" or tokens[open_index].text != "(":
         return None
-    # Inside the tuple: NUMBER , NUMBER )
-    x_index = open_index + 1
-    comma_index = open_index + 2
-    y_index = open_index + 3
-    close_index = open_index + 4
-    if close_index >= len(tokens):
-        return None
-    x_token = tokens[x_index]
-    comma_token = tokens[comma_index]
-    y_token = tokens[y_index]
-    close_token = tokens[close_index]
+    x_token = tokens[open_index + 1]
+    comma_token = tokens[open_index + 2]
+    y_token = tokens[open_index + 3]
+    close_token = tokens[open_index + 4]
     if x_token.kind != "NUMBER" or y_token.kind != "NUMBER":
         return None
     if comma_token.kind != "SYMBOL" or comma_token.text != ",":
         return None
     if close_token.kind != "SYMBOL" or close_token.text != ")":
         return None
-    following = close_index + 1
+    following = open_index + 5
     if following < len(tokens):
         next_token = tokens[following]
-        # EOS is allowed (no following token). Otherwise require a property keyword.
         if (
             next_token.depth != 0
             or next_token.kind != "WORD"
-            or next_token.text not in _TEXTBUTTON_POS_FOLLOWER_WORDS
+            or next_token.text not in _TEXTBUTTON_PAIR_FOLLOWER_WORDS
         ):
             return None
     return (
@@ -435,6 +491,56 @@ def _parse_literal_pos_pair(
         (x_token.start, x_token.end),
         (y_token.start, y_token.end),
     )
+
+
+def align_to_pixels(
+    xalign: float,
+    yalign: float,
+    *,
+    parent_size: tuple[int, int] = DEFAULT_ALIGN_PARENT_SIZE,
+) -> tuple[int, int]:
+    """Convert authored align fractions to logical pixel top-left (default anchor 0,0)."""
+    parent_w, parent_h = parent_size
+    return int(round(float(xalign) * parent_w)), int(round(float(yalign) * parent_h))
+
+
+def pixels_to_align(
+    x: int,
+    y: int,
+    *,
+    parent_size: tuple[int, int] = DEFAULT_ALIGN_PARENT_SIZE,
+) -> tuple[float, float]:
+    """Convert logical pixel position to align fractions for write-back."""
+    parent_w, parent_h = parent_size
+    if parent_w <= 0 or parent_h <= 0:
+        raise EditorSourceError("ALIGN_PARENT_INVALID", "align parent size must be positive")
+    return float(x) / float(parent_w), float(y) / float(parent_h)
+
+
+def _format_align_component(value: float) -> str:
+    # High precision so reload pixel agreement stays within 1 logical pixel after
+    # align fraction round-trips (demo parent is 1280×720).
+    text = f"{float(value):.12f}".rstrip("0").rstrip(".")
+    if text in {"-0", ""}:
+        text = "0"
+    if "." not in text:
+        text = f"{text}.0"
+    return text
+
+
+def _require_pure_anchor_if_present(tokens: list[_Token]) -> bool:
+    """Return True if a pure literal anchor is present; raise if impure/duplicate."""
+    indexes = _tuple_property_indexes(tokens, "anchor")
+    if not indexes:
+        return False
+    if len(indexes) > 1:
+        raise EditorSourceError("ANCHOR_DUPLICATE", "textbutton statement must contain exactly one anchor")
+    if _parse_literal_float_pair(tokens, indexes[0]) is None:
+        raise EditorSourceError(
+            "ANCHOR_LITERAL_REQUIRED",
+            "anchor must be a pure literal pair of numbers: anchor (x, y)",
+        )
+    return True
 
 
 def analyze_textbutton_statement(line: str, *, expected_widget_id: str) -> TextbuttonStatement:
@@ -454,19 +560,58 @@ def analyze_textbutton_statement(line: str, *, expected_widget_id: str) -> Textb
         for token in tokens
     )
     pos_indexes = _pos_property_indexes(tokens)
-    if pos_indexes and has_xy:
+    align_indexes = _tuple_property_indexes(tokens, "align")
+
+    form_count = sum([bool(has_xy), bool(pos_indexes), bool(align_indexes)])
+    if form_count > 1:
         raise EditorSourceError(
             "POSITION_FORM_MIXED",
-            "textbutton cannot mix pos with xpos/ypos",
+            "textbutton cannot mix align/pos/xpos/ypos position forms",
         )
     if len(pos_indexes) > 1:
         raise EditorSourceError("POS_DUPLICATE", "textbutton statement must contain exactly one pos")
+    if len(align_indexes) > 1:
+        raise EditorSourceError("ALIGN_DUPLICATE", "textbutton statement must contain exactly one align")
+
+    if len(align_indexes) == 1:
+        widget_id = _require_single_literal_id(
+            tokens,
+            expected_widget_id=expected_widget_id,
+            human_kind="textbutton",
+        )
+        # Align form does not combine with anchor in this evidence-gated shape.
+        if _tuple_property_indexes(tokens, "anchor"):
+            raise EditorSourceError(
+                "POSITION_FORM_MIXED",
+                "textbutton align form does not combine with anchor in V1",
+            )
+        parsed_align = _parse_literal_float_pair(tokens, align_indexes[0])
+        if parsed_align is None:
+            raise EditorSourceError(
+                "ALIGN_LITERAL_REQUIRED",
+                "align must be a pure literal pair: align (x, y)",
+            )
+        xalign, yalign, x_span, y_span = parsed_align
+        return TextbuttonStatement(
+            widget_id=widget_id,
+            xpos=xalign,
+            ypos=yalign,
+            xpos_span=x_span,
+            ypos_span=y_span,
+            form="single_line",
+            source_line=None,
+            position_mode="align",
+            has_anchor=False,
+            align_parent_size=DEFAULT_ALIGN_PARENT_SIZE,
+        )
+
     if len(pos_indexes) == 1:
         widget_id = _require_single_literal_id(
             tokens,
             expected_widget_id=expected_widget_id,
             human_kind="textbutton",
         )
+        has_anchor = _require_pure_anchor_if_present(tokens)
         parsed_pos = _parse_literal_pos_pair(tokens, pos_indexes[0])
         if parsed_pos is None:
             raise EditorSourceError(
@@ -483,14 +628,31 @@ def analyze_textbutton_statement(line: str, *, expected_widget_id: str) -> Textb
             form="single_line",
             source_line=None,
             position_mode="pos",
+            has_anchor=has_anchor,
         )
 
-    return _analyze_positioned_kind_statement(
+    # xy form (optional pure anchor for issue #40).
+    statement = _analyze_positioned_kind_statement(
         line,
         expected_widget_id=expected_widget_id,
         expected_kind="textbutton",
         statement_cls=TextbuttonStatement,
     )
+    has_anchor = _require_pure_anchor_if_present(tokens)
+    if has_anchor:
+        return TextbuttonStatement(
+            widget_id=statement.widget_id,
+            xpos=statement.xpos,
+            ypos=statement.ypos,
+            xpos_span=statement.xpos_span,
+            ypos_span=statement.ypos_span,
+            form=statement.form,
+            source_line=statement.source_line,
+            position_mode="xy",
+            has_anchor=True,
+        )
+    return statement
+
 
 
 def is_textbutton_block_header(line: str) -> bool:
@@ -933,9 +1095,34 @@ def _apply_integer_span_patch(
     return patched.encode("utf-8")
 
 
-def apply_textbutton_patch(source_bytes: bytes, statement: TextbuttonStatement, *, x: int, y: int) -> bytes:
+def apply_textbutton_patch(
+    source_bytes: bytes,
+    statement: TextbuttonStatement,
+    *,
+    x: int,
+    y: int,
+    align_runtime_baseline: tuple[int, int] | list[int] | None = None,
+) -> bytes:
     # Block form spans are absolute in the full source; single-line spans are
     # relative to the single line bytes passed by the coordinator.
+    if statement.position_mode == "align":
+        parent_w, parent_h = statement.align_parent_size
+        if align_runtime_baseline is not None and len(align_runtime_baseline) == 2:
+            # Pixel delta relative to the measured focus baseline at analyze time.
+            ax = float(statement.xpos) + (int(x) - int(align_runtime_baseline[0])) / float(parent_w)
+            ay = float(statement.ypos) + (int(y) - int(align_runtime_baseline[1])) / float(parent_h)
+        else:
+            ax, ay = pixels_to_align(int(x), int(y), parent_size=statement.align_parent_size)
+        source_text = source_bytes.decode("utf-8")
+        replacements = [
+            (statement.xpos_span[0], statement.xpos_span[1], _format_align_component(ax)),
+            (statement.ypos_span[0], statement.ypos_span[1], _format_align_component(ay)),
+        ]
+        replacements.sort(key=lambda item: item[0], reverse=True)
+        patched = source_text
+        for start, end, replacement in replacements:
+            patched = f"{patched[:start]}{replacement}{patched[end:]}"
+        return patched.encode("utf-8")
     return _apply_integer_span_patch(
         source_bytes,
         xpos_span=statement.xpos_span,

--- a/src/renforge/editor/source.py
+++ b/src/renforge/editor/source.py
@@ -529,13 +529,28 @@ def _format_align_component(value: float) -> str:
 
 
 def _require_pure_anchor_if_present(tokens: list[_Token]) -> bool:
-    """Return True if a pure literal anchor is present; raise if impure/duplicate."""
-    indexes = _tuple_property_indexes(tokens, "anchor")
-    if not indexes:
+    """Return True if a pure literal anchor is present; raise if impure/duplicate.
+
+    Counts every top-level ``anchor`` keyword (including bare expressions such as
+    ``anchor anchor_value``), not only tuple forms.
+    """
+    anchor_word_indexes = [
+        index
+        for index, token in enumerate(tokens)
+        if token.depth == 0 and token.kind == "WORD" and token.text == "anchor"
+    ]
+    if not anchor_word_indexes:
         return False
-    if len(indexes) > 1:
+    if len(anchor_word_indexes) > 1:
         raise EditorSourceError("ANCHOR_DUPLICATE", "textbutton statement must contain exactly one anchor")
-    if _parse_literal_float_pair(tokens, indexes[0]) is None:
+    # Must be the supported property form: anchor (
+    tuple_indexes = _tuple_property_indexes(tokens, "anchor")
+    if not tuple_indexes or tuple_indexes[0] != anchor_word_indexes[0]:
+        raise EditorSourceError(
+            "ANCHOR_LITERAL_REQUIRED",
+            "anchor must be a pure literal pair of numbers: anchor (x, y)",
+        )
+    if _parse_literal_float_pair(tokens, tuple_indexes[0]) is None:
         raise EditorSourceError(
             "ANCHOR_LITERAL_REQUIRED",
             "anchor must be a pure literal pair of numbers: anchor (x, y)",
@@ -1102,15 +1117,24 @@ def apply_textbutton_patch(
     x: int,
     y: int,
     align_runtime_baseline: tuple[int, int] | list[int] | None = None,
+    align_widget_size: tuple[int, int] | list[int] | None = None,
 ) -> bytes:
     # Block form spans are absolute in the full source; single-line spans are
     # relative to the single line bytes passed by the coordinator.
     if statement.position_mode == "align":
         parent_w, parent_h = statement.align_parent_size
+        # Ren'Py ``align (a, b)`` sets both align and anchor to (a, b), so the
+        # focus top-left moves by Δalign * (parent - widget), not Δalign * parent.
+        widget_w = 0
+        widget_h = 0
+        if align_widget_size is not None and len(align_widget_size) == 2:
+            widget_w = max(0, int(align_widget_size[0]))
+            widget_h = max(0, int(align_widget_size[1]))
+        extent_w = float(max(1, int(parent_w) - widget_w))
+        extent_h = float(max(1, int(parent_h) - widget_h))
         if align_runtime_baseline is not None and len(align_runtime_baseline) == 2:
-            # Pixel delta relative to the measured focus baseline at analyze time.
-            ax = float(statement.xpos) + (int(x) - int(align_runtime_baseline[0])) / float(parent_w)
-            ay = float(statement.ypos) + (int(y) - int(align_runtime_baseline[1])) / float(parent_h)
+            ax = float(statement.xpos) + (int(x) - int(align_runtime_baseline[0])) / extent_w
+            ay = float(statement.ypos) + (int(y) - int(align_runtime_baseline[1])) / extent_h
         else:
             ax, ay = pixels_to_align(int(x), int(y), parent_size=statement.align_parent_size)
         source_text = source_bytes.decode("utf-8")

--- a/src/renforge/editor/source.py
+++ b/src/renforge/editor/source.py
@@ -11,9 +11,50 @@ class EditorSourceError(ValueError):
         self.code = code
 
 
-# Logical parent size used to convert between align fractions and pixels for the
-# evidence-gated full-screen fixed fixtures (demo game is 1280×720).
+# Logical parent size for evidence-gated full-screen Fixed fixtures (demo is 1280×720).
+# Align write-back is only unlocked when independent focus geometry matches this parent
+# under Ren'Py's align-sets-anchor placement: TL = fraction × (parent − widget).
 DEFAULT_ALIGN_PARENT_SIZE: tuple[int, int] = (1280, 720)
+
+# Concurrent axis/placement properties that must not ride along with pure align (fx, fy).
+# offset and axis-split forms are out of scope for the align adapter.
+_ALIGN_CONCURRENT_PROPERTY_WORDS = frozenset(
+    {
+        "xpos",
+        "ypos",
+        "pos",
+        "anchor",
+        "xalign",
+        "yalign",
+        "xanchor",
+        "yanchor",
+        "xoffset",
+        "yoffset",
+        "xcenter",
+        "ycenter",
+    }
+)
+
+# Properties whose value may be a bare top-level WORD (e.g. ``action pos``).
+# Such WORDs are values, not position-form keywords.
+_NAME_VALUE_PROPERTY_WORDS = frozenset(
+    {
+        "action",
+        "hovered",
+        "unhovered",
+        "selected",
+        "alternate",
+        "style",
+        "at",
+        "default",
+        "tooltip",
+        "sensitive",
+        "focus",
+        "keyboard_focus",
+        "keysym",
+        "alternate_keysym",
+    }
+)
 
 
 @dataclass(frozen=True)
@@ -380,12 +421,38 @@ _TEXTBUTTON_PAIR_FOLLOWER_WORDS = frozenset(
 )
 
 
-def _tuple_property_indexes(tokens: list[_Token], keyword: str) -> list[int]:
-    """Indexes of top-level ``keyword`` used as a property (value starts with ``(``)."""
+def _previous_top_level_token(tokens: list[_Token], index: int) -> _Token | None:
+    for cursor in range(index - 1, -1, -1):
+        if tokens[cursor].depth == 0:
+            return tokens[cursor]
+    return None
+
+
+def _top_level_property_keyword_indexes(tokens: list[_Token], keyword: str) -> list[int]:
+    """Indexes of top-level ``keyword`` used as a property name (any value form).
+
+    Bare values of other properties are excluded so ``action pos`` does not count
+    as a ``pos`` position form (Codex P2 on issue #38).
+    """
     indexes: list[int] = []
     for index, token in enumerate(tokens):
         if token.depth != 0 or token.kind != "WORD" or token.text != keyword:
             continue
+        previous = _previous_top_level_token(tokens, index)
+        if (
+            previous is not None
+            and previous.kind == "WORD"
+            and previous.text in _NAME_VALUE_PROPERTY_WORDS
+        ):
+            continue
+        indexes.append(index)
+    return indexes
+
+
+def _tuple_property_indexes(tokens: list[_Token], keyword: str) -> list[int]:
+    """Indexes of top-level ``keyword`` used as a property (value starts with ``(``)."""
+    indexes: list[int] = []
+    for index in _top_level_property_keyword_indexes(tokens, keyword):
         next_index = index + 1
         if next_index >= len(tokens):
             continue
@@ -498,10 +565,19 @@ def align_to_pixels(
     yalign: float,
     *,
     parent_size: tuple[int, int] = DEFAULT_ALIGN_PARENT_SIZE,
+    widget_size: tuple[int, int],
 ) -> tuple[int, int]:
-    """Convert authored align fractions to logical pixel top-left (default anchor 0,0)."""
+    """Convert authored align fractions to logical pixel top-left.
+
+    Ren'Py ``align (a, b)`` also sets the anchor to ``(a, b)``, so the focus
+    top-left is ``fraction × (parent − widget)``, not ``fraction × parent``.
+    """
     parent_w, parent_h = parent_size
-    return int(round(float(xalign) * parent_w)), int(round(float(yalign) * parent_h))
+    widget_w, widget_h = int(widget_size[0]), int(widget_size[1])
+    return (
+        int(round(float(xalign) * (parent_w - widget_w))),
+        int(round(float(yalign) * (parent_h - widget_h))),
+    )
 
 
 def pixels_to_align(
@@ -509,12 +585,37 @@ def pixels_to_align(
     y: int,
     *,
     parent_size: tuple[int, int] = DEFAULT_ALIGN_PARENT_SIZE,
+    widget_size: tuple[int, int],
 ) -> tuple[float, float]:
-    """Convert logical pixel position to align fractions for write-back."""
+    """Convert logical pixel top-left to align fractions (requires non-zero extent)."""
     parent_w, parent_h = parent_size
-    if parent_w <= 0 or parent_h <= 0:
-        raise EditorSourceError("ALIGN_PARENT_INVALID", "align parent size must be positive")
-    return float(x) / float(parent_w), float(y) / float(parent_h)
+    widget_w, widget_h = int(widget_size[0]), int(widget_size[1])
+    extent_w = int(parent_w) - widget_w
+    extent_h = int(parent_h) - widget_h
+    if extent_w == 0 or extent_h == 0:
+        raise EditorSourceError(
+            "ALIGN_EXTENT_ZERO",
+            "align conversion requires non-zero placement extent on both axes",
+        )
+    return float(x) / float(extent_w), float(y) / float(extent_h)
+
+
+def align_geometry_matches_parent(
+    *,
+    authored: tuple[float, float],
+    runtime_xy: tuple[int, int],
+    widget_size: tuple[int, int],
+    parent_size: tuple[int, int] = DEFAULT_ALIGN_PARENT_SIZE,
+    tolerance: int = 1,
+) -> bool:
+    """True when independent focus TL matches ``align × (parent − widget)`` within tolerance."""
+    ax, ay = float(authored[0]), float(authored[1])
+    rx, ry = int(runtime_xy[0]), int(runtime_xy[1])
+    widget_w, widget_h = int(widget_size[0]), int(widget_size[1])
+    parent_w, parent_h = int(parent_size[0]), int(parent_size[1])
+    expected_x = ax * float(parent_w - widget_w)
+    expected_y = ay * float(parent_h - widget_h)
+    return abs(rx - expected_x) <= tolerance and abs(ry - expected_y) <= tolerance
 
 
 def _format_align_component(value: float) -> str:
@@ -531,14 +632,11 @@ def _format_align_component(value: float) -> str:
 def _require_pure_anchor_if_present(tokens: list[_Token]) -> bool:
     """Return True if a pure literal anchor is present; raise if impure/duplicate.
 
-    Counts every top-level ``anchor`` keyword (including bare expressions such as
-    ``anchor anchor_value``), not only tuple forms.
+    Counts every top-level ``anchor`` *property* (including bare expressions such
+    as ``anchor anchor_value``), not only tuple forms. Bare values of other
+    properties (e.g. ``action anchor``) are ignored.
     """
-    anchor_word_indexes = [
-        index
-        for index, token in enumerate(tokens)
-        if token.depth == 0 and token.kind == "WORD" and token.text == "anchor"
-    ]
+    anchor_word_indexes = _top_level_property_keyword_indexes(tokens, "anchor")
     if not anchor_word_indexes:
         return False
     if len(anchor_word_indexes) > 1:
@@ -574,33 +672,46 @@ def analyze_textbutton_statement(line: str, *, expected_widget_id: str) -> Textb
         token.depth == 0 and token.kind == "WORD" and token.text in {"xpos", "ypos"}
         for token in tokens
     )
-    pos_indexes = _pos_property_indexes(tokens)
-    align_indexes = _tuple_property_indexes(tokens, "align")
+    # Count every top-level *property* keyword (including bare expressions) so
+    # concurrent or dynamic forms cannot be ignored by the tuple-only scan.
+    pos_word_indexes = _top_level_property_keyword_indexes(tokens, "pos")
+    align_word_indexes = _top_level_property_keyword_indexes(tokens, "align")
 
-    form_count = sum([bool(has_xy), bool(pos_indexes), bool(align_indexes)])
+    form_count = sum([bool(has_xy), bool(pos_word_indexes), bool(align_word_indexes)])
     if form_count > 1:
         raise EditorSourceError(
             "POSITION_FORM_MIXED",
             "textbutton cannot mix align/pos/xpos/ypos position forms",
         )
-    if len(pos_indexes) > 1:
+    if len(pos_word_indexes) > 1:
         raise EditorSourceError("POS_DUPLICATE", "textbutton statement must contain exactly one pos")
-    if len(align_indexes) > 1:
+    if len(align_word_indexes) > 1:
         raise EditorSourceError("ALIGN_DUPLICATE", "textbutton statement must contain exactly one align")
 
-    if len(align_indexes) == 1:
+    if len(align_word_indexes) == 1:
         widget_id = _require_single_literal_id(
             tokens,
             expected_widget_id=expected_widget_id,
             human_kind="textbutton",
         )
-        # Align form does not combine with anchor in this evidence-gated shape.
-        if _tuple_property_indexes(tokens, "anchor"):
+        # Reject concurrent axis/placement properties (offset, xalign, anchor, …).
+        concurrent = [
+            keyword
+            for keyword in _ALIGN_CONCURRENT_PROPERTY_WORDS
+            if _top_level_property_keyword_indexes(tokens, keyword)
+        ]
+        if concurrent:
             raise EditorSourceError(
                 "POSITION_FORM_MIXED",
-                "textbutton align form does not combine with anchor in V1",
+                "textbutton align form does not combine with concurrent placement properties",
             )
-        parsed_align = _parse_literal_float_pair(tokens, align_indexes[0])
+        tuple_indexes = _tuple_property_indexes(tokens, "align")
+        if not tuple_indexes or tuple_indexes[0] != align_word_indexes[0]:
+            raise EditorSourceError(
+                "ALIGN_LITERAL_REQUIRED",
+                "align must be a pure literal pair: align (x, y)",
+            )
+        parsed_align = _parse_literal_float_pair(tokens, tuple_indexes[0])
         if parsed_align is None:
             raise EditorSourceError(
                 "ALIGN_LITERAL_REQUIRED",
@@ -620,14 +731,20 @@ def analyze_textbutton_statement(line: str, *, expected_widget_id: str) -> Textb
             align_parent_size=DEFAULT_ALIGN_PARENT_SIZE,
         )
 
-    if len(pos_indexes) == 1:
+    if len(pos_word_indexes) == 1:
         widget_id = _require_single_literal_id(
             tokens,
             expected_widget_id=expected_widget_id,
             human_kind="textbutton",
         )
         has_anchor = _require_pure_anchor_if_present(tokens)
-        parsed_pos = _parse_literal_pos_pair(tokens, pos_indexes[0])
+        tuple_indexes = _pos_property_indexes(tokens)
+        if not tuple_indexes or tuple_indexes[0] != pos_word_indexes[0]:
+            raise EditorSourceError(
+                "POS_LITERAL_REQUIRED",
+                "pos must be a pure literal pair of integers: pos (x, y)",
+            )
+        parsed_pos = _parse_literal_pos_pair(tokens, tuple_indexes[0])
         if parsed_pos is None:
             raise EditorSourceError(
                 "POS_LITERAL_REQUIRED",
@@ -1122,21 +1239,44 @@ def apply_textbutton_patch(
     # Block form spans are absolute in the full source; single-line spans are
     # relative to the single line bytes passed by the coordinator.
     if statement.position_mode == "align":
+        # Proven geometry only: measured baseline + widget size are mandatory.
+        # Ren'Py ``align (a, b)`` sets anchor to (a, b), so ΔTL = Δalign × (parent − widget).
+        if align_runtime_baseline is None or len(align_runtime_baseline) != 2:
+            raise EditorSourceError(
+                "ALIGN_BASELINE_REQUIRED",
+                "align write-back requires a measured runtime baseline",
+            )
+        if align_widget_size is None or len(align_widget_size) != 2:
+            raise EditorSourceError(
+                "ALIGN_WIDGET_SIZE_REQUIRED",
+                "align write-back requires a measured widget size",
+            )
         parent_w, parent_h = statement.align_parent_size
-        # Ren'Py ``align (a, b)`` sets both align and anchor to (a, b), so the
-        # focus top-left moves by Δalign * (parent - widget), not Δalign * parent.
-        widget_w = 0
-        widget_h = 0
-        if align_widget_size is not None and len(align_widget_size) == 2:
-            widget_w = max(0, int(align_widget_size[0]))
-            widget_h = max(0, int(align_widget_size[1]))
-        extent_w = float(max(1, int(parent_w) - widget_w))
-        extent_h = float(max(1, int(parent_h) - widget_h))
-        if align_runtime_baseline is not None and len(align_runtime_baseline) == 2:
-            ax = float(statement.xpos) + (int(x) - int(align_runtime_baseline[0])) / extent_w
-            ay = float(statement.ypos) + (int(y) - int(align_runtime_baseline[1])) / extent_h
+        widget_w = int(align_widget_size[0])
+        widget_h = int(align_widget_size[1])
+        # Signed extents: preserve direction when widget > parent; lock zero axes.
+        extent_w = int(parent_w) - widget_w
+        extent_h = int(parent_h) - widget_h
+        dx = int(x) - int(align_runtime_baseline[0])
+        dy = int(y) - int(align_runtime_baseline[1])
+        if extent_w == 0:
+            if dx != 0:
+                raise EditorSourceError(
+                    "ALIGN_EXTENT_ZERO",
+                    "cannot move on X when placement extent is zero",
+                )
+            ax = float(statement.xpos)
         else:
-            ax, ay = pixels_to_align(int(x), int(y), parent_size=statement.align_parent_size)
+            ax = float(statement.xpos) + dx / float(extent_w)
+        if extent_h == 0:
+            if dy != 0:
+                raise EditorSourceError(
+                    "ALIGN_EXTENT_ZERO",
+                    "cannot move on Y when placement extent is zero",
+                )
+            ay = float(statement.ypos)
+        else:
+            ay = float(statement.ypos) + dy / float(extent_h)
         source_text = source_bytes.decode("utf-8")
         replacements = [
             (statement.xpos_span[0], statement.xpos_span[1], _format_align_component(ax)),

--- a/src/renforge/editor_align_runner.py
+++ b/src/renforge/editor_align_runner.py
@@ -1,0 +1,546 @@
+from __future__ import annotations
+
+import hashlib
+import re
+import shutil
+import time
+from pathlib import Path
+from typing import Any
+
+from renforge.editor.source import analyze_textbutton_statement, pixels_to_align, _format_align_component
+from renforge.editor_task0_runner import (
+    _require_ok,
+    _source_generation,
+    _wait_for_status,
+)
+
+FIXTURE_SCREEN = "renforge_editor_align_fixture"
+TARGET_ID = "align_target"
+EDITOR_RESOURCE = Path(__file__).resolve().parent / "bridge" / "editor.rpy"
+FIXTURE_RESOURCE = (
+    Path(__file__).resolve().parents[2]
+    / "tests"
+    / "live_fixtures"
+    / "renforge_editor_align_fixture.rpy"
+)
+
+
+def inject_editor_align_resources(project_root: Path) -> dict[str, str]:
+    game_dir = project_root / "game"
+    game_dir.mkdir(parents=True, exist_ok=True)
+    editor_target = game_dir / "zz_renforge_editor_align.rpy"
+    fixture_target = game_dir / "zz_renforge_editor_align_fixture.rpy"
+    shutil.copyfile(EDITOR_RESOURCE, editor_target)
+    shutil.copyfile(FIXTURE_RESOURCE, fixture_target)
+    return {
+        "editor": str(editor_target),
+        "fixture": str(fixture_target),
+    }
+
+
+def _find_element(
+    elements: list[dict[str, Any]],
+    wanted_id: str,
+    *,
+    wanted_text: str | None = None,
+) -> dict[str, Any]:
+    for element in elements:
+        element_id = str(element.get("id") or "")
+        if wanted_text is not None:
+            if element_id == wanted_id and str(element.get("text") or "") == wanted_text:
+                return element
+            continue
+        if element_id == wanted_id:
+            return element
+    raise AssertionError(
+        f"missing expected element id {wanted_id!r} text {wanted_text!r}: {elements!r}"
+    )
+
+
+def _center(bounds: dict[str, Any]) -> tuple[int, int]:
+    return (
+        int(bounds["x"]) + int(bounds["width"]) // 2,
+        int(bounds["y"]) + int(bounds["height"]) // 2,
+    )
+
+
+def _sha256_file(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _list_info(client: Any) -> dict[str, Any]:
+    info = client.list_ui_elements_info(screen=FIXTURE_SCREEN)
+    if not isinstance(info, dict):
+        raise AssertionError(f"list_ui_elements_info returned non-dict: {info!r}")
+    return info
+
+
+def _wait_bounds(client: Any, widget_id: str, *, timeout: float = 6.0) -> dict[str, int]:
+    deadline = time.monotonic() + timeout
+    last: list[dict[str, Any]] = []
+    while time.monotonic() < deadline:
+        info = _list_info(client)
+        last = info.get("elements") if isinstance(info.get("elements"), list) else []
+        try:
+            element = _find_element(last, widget_id)
+        except AssertionError:
+            time.sleep(0.05)
+            continue
+        bounds = element.get("bounds")
+        if isinstance(bounds, dict):
+            return {
+                "x": int(bounds["x"]),
+                "y": int(bounds["y"]),
+                "width": int(bounds["width"]),
+                "height": int(bounds["height"]),
+            }
+        time.sleep(0.05)
+    raise AssertionError(f"bounds for {widget_id!r} unavailable: {last!r}")
+
+
+def _target_line_with_offset(source_text: str) -> tuple[str, int]:
+    offset = 0
+    for line in source_text.splitlines(keepends=True):
+        if (
+            f'id "{TARGET_ID}"' in line
+            and line.lstrip().startswith("textbutton ")
+            and " align " in f" {line}"
+        ):
+            analyze_textbutton_statement(line, expected_widget_id=TARGET_ID)
+            return line, offset
+        offset += len(line)
+    raise AssertionError(f"source missing align textbutton line for {TARGET_ID!r}")
+
+
+def _independent_expected_after_patch(
+    before_text: str,
+    *,
+    x: int,
+    y: int,
+    baseline: dict[str, int] | None = None,
+) -> str:
+    """Build expected align source without calling apply_textbutton_patch."""
+    line, offset = _target_line_with_offset(before_text)
+    parsed = analyze_textbutton_statement(line, expected_widget_id=TARGET_ID)
+    from renforge.editor.source import _format_align_component
+    parent_w, parent_h = parsed.align_parent_size
+    base = baseline or {"x": 0, "y": 0}
+    ax = float(parsed.xpos) + (int(x) - int(base["x"])) / float(parent_w)
+    ay = float(parsed.ypos) + (int(y) - int(base["y"])) / float(parent_h)
+    ax_t = _format_align_component(ax)
+    ay_t = _format_align_component(ay)
+    patched_line = re.sub(
+        r"(\balign\s*\(\s*)[^,]+(\s*,\s*)[^)]+(\s*\))",
+        rf"\g<1>{ax_t}\g<2>{ay_t}\3",
+        line,
+        count=1,
+    )
+    if patched_line == line:
+        raise AssertionError("independent patch constructor did not change target align pair")
+    if "xpos" in patched_line or "ypos" in patched_line:
+        raise AssertionError("independent constructor must not introduce xpos/ypos")
+    return f"{before_text[:offset]}{patched_line}{before_text[offset + len(line) :]}"
+
+
+def _outside_coordinate_spans_identical(before_text: str, after_text: str) -> bool:
+    before_line, _ = _target_line_with_offset(before_text)
+    after_line, _ = _target_line_with_offset(after_text)
+    before_norm = re.sub(
+        r"(\balign\s*\(\s*)[^,]+(\s*,\s*)[^)]+(\s*\))",
+        r"\1__X__\2__Y__\3",
+        before_line,
+        count=1,
+    )
+    after_norm = re.sub(
+        r"(\balign\s*\(\s*)[^,]+(\s*,\s*)[^)]+(\s*\))",
+        r"\1__X__\2__Y__\3",
+        after_line,
+        count=1,
+    )
+    if before_norm != after_norm:
+        return False
+    return before_text.replace(before_line, "", 1) == after_text.replace(after_line, "", 1)
+
+
+def _parse_xy_from_target_line(source_text: str) -> dict[str, int]:
+    """Return pixel position derived from authored align via the conversion contract."""
+    line, _ = _target_line_with_offset(source_text)
+    parsed = analyze_textbutton_statement(line, expected_widget_id=TARGET_ID)
+    if parsed.position_mode != "align":
+        raise AssertionError(f"expected align mode: {parsed!r}")
+    from renforge.editor.source import align_to_pixels
+    px, py = align_to_pixels(float(parsed.xpos), float(parsed.ypos))
+    return {"x": px, "y": py}
+
+
+def _select_lock(client: Any, widget_id: str, expected_code: str) -> str:
+    bounds = _wait_bounds(client, widget_id)
+    selection = client.request(
+        "editor_task0_select",
+        {"x": _center(bounds)[0], "y": _center(bounds)[1]},
+    )
+    immediate = selection.get("lock_reason") if isinstance(selection, dict) else None
+    if immediate == expected_code:
+        return expected_code
+    status = _wait_for_status(
+        client,
+        lambda current: current.get("selected_widget_id") == widget_id
+        and current.get("selected_lock_reason") == expected_code,
+        timeout=10.0,
+        poll_name=f"{widget_id} lock",
+    )
+    lock_reason = status.get("selected_lock_reason")
+    if lock_reason != expected_code:
+        raise AssertionError(f"unexpected lock for {widget_id!r}: {status!r}")
+    return str(lock_reason)
+
+
+def _observe_selected(client: Any) -> dict[str, Any]:
+    reply = client.request("editor_task0_observe_selected", {})
+    if not isinstance(reply, dict) or reply.get("ok") is not True:
+        raise AssertionError(f"observe_selected failed: {reply!r}")
+    observation = reply.get("observation")
+    if not isinstance(observation, dict):
+        raise AssertionError(f"observe_selected missing observation: {reply!r}")
+    return observation
+
+
+def run_editor_align_live_scenario(client: Any, *, fixture_path: Path) -> dict[str, Any]:
+    """Seven-step live proof for literal align (x, y) textbutton form (issue #39)."""
+    report: dict[str, Any] = {}
+    baseline_bytes = fixture_path.read_bytes()
+    baseline_sha = _sha256_file(fixture_path)
+    baseline_text = baseline_bytes.decode("utf-8")
+    # Prove analyzer accepts the authored pos form before any UI work.
+    target_line, _ = _target_line_with_offset(baseline_text)
+    parsed = analyze_textbutton_statement(target_line, expected_widget_id=TARGET_ID)
+    if parsed.position_mode != "align":
+        raise AssertionError(f"expected position_mode align, got {parsed.position_mode!r}")
+    baseline_position = _parse_xy_from_target_line(baseline_text)
+    report["fixture_before"] = {
+        "sha256": baseline_sha,
+        "position": baseline_position,
+        "position_mode": parsed.position_mode,
+    }
+
+    start = _require_ok(
+        client.request("editor_task0_start", {"screen": FIXTURE_SCREEN}),
+        "editor_task0_start",
+    )
+    report["start"] = start
+
+    # Lock matrix first on real focusable widgets (measured codes).
+    report["locks"] = {
+        "computed": _select_lock(client, "align_computed", "ALIGN_LITERAL_REQUIRED"),
+        "container": _select_lock(client, "align_container", "CONTAINER_POSITION_UNSUPPORTED"),
+    }
+
+    # Measured live: two use-statements share id "align_dupe_target". The first
+    # instance is still selectable by focus bounds and locks as SYNTHETIC_WIDGET_ID
+    # (list_ui may only name the second instance).
+    dupe_info = _list_info(client)
+    dupe_elements = dupe_info.get("elements") if isinstance(dupe_info, dict) else None
+    # Prefer the unnamed first instance (NullAction-ish id) then fall back to
+    # the named target bounds at the left dupe coordinate.
+    dupe_pick = None
+    for element in dupe_elements if isinstance(dupe_elements, list) else []:
+        bounds = element.get("bounds")
+        if not isinstance(bounds, dict):
+            continue
+        text = str(element.get("text") or "")
+        if text == "DUPE A" or (
+            str(element.get("text") or "") == "DUPE A"
+        ):
+            dupe_pick = bounds
+            break
+    if dupe_pick is None:
+        raise AssertionError(f"could not locate first dupe bounds: {dupe_elements!r}")
+    dupe_select = client.request(
+        "editor_task0_select",
+        {
+            "x": int(dupe_pick["x"]) + max(2, int(dupe_pick["width"]) // 4),
+            "y": int(dupe_pick["y"]) + int(dupe_pick["height"]) // 2,
+        },
+    )
+    ambiguous = dupe_select.get("lock_reason") if isinstance(dupe_select, dict) else None
+    if ambiguous in (None, ""):
+        status = _wait_for_status(
+            client,
+            lambda current: current.get("selected_lock_reason") == "SYNTHETIC_WIDGET_ID",
+            timeout=10.0,
+            poll_name="pos dupe lock",
+        )
+        ambiguous = status.get("selected_lock_reason")
+    if ambiguous != "SYNTHETIC_WIDGET_ID":
+        raise AssertionError(
+            f"duplicate align textbutton lock was not SYNTHETIC_WIDGET_ID: {ambiguous!r}"
+        )
+    report["locks"]["ambiguous"] = ambiguous
+
+    # Measured live: Side is not in the ancestry allowlist → UNKNOWN_ANCESTRY_TYPE.
+    side_bounds = _wait_bounds(client, "align_side", timeout=3.0)
+    side_select = client.request(
+        "editor_task0_select",
+        {"x": _center(side_bounds)[0], "y": _center(side_bounds)[1]},
+    )
+    unproven = side_select.get("lock_reason") if isinstance(side_select, dict) else None
+    if unproven in (None, ""):
+        status = _wait_for_status(
+            client,
+            lambda current: current.get("selected_lock_reason") == "UNKNOWN_ANCESTRY_TYPE",
+            timeout=10.0,
+            poll_name="pos side lock",
+        )
+        unproven = status.get("selected_lock_reason")
+    if unproven != "UNKNOWN_ANCESTRY_TYPE":
+        raise AssertionError(
+            f"side-ancestor align textbutton lock was not UNKNOWN_ANCESTRY_TYPE: {unproven!r}"
+        )
+    report["locks"]["unproven"] = unproven
+
+    # Step 1: resolve the editable align textbutton from a fresh focus rect.
+    target_bounds = _wait_bounds(client, TARGET_ID)
+    target_center = _center(target_bounds)
+    select = _require_ok(
+        client.request(
+            "editor_task0_select",
+            {"x": target_center[0], "y": target_center[1]},
+        ),
+        "target select",
+    )
+    observation = select.get("observation") or {}
+    if observation.get("measurement_method") != "focus_list":
+        raise AssertionError(f"select observation not focus_list: {observation!r}")
+
+    analysis_status = _wait_for_status(
+        client,
+        lambda status: bool(status.get("current_analysis_id"))
+        and status.get("selected_widget_id") == TARGET_ID
+        and status.get("selected_lock_reason") in (None, ""),
+        timeout=10.0,
+        poll_name="pos analysis",
+    )
+    source_key = analysis_status.get("current_source_key") or {}
+    capabilities = analysis_status.get("current_capabilities") or {}
+    host_move = capabilities.get("move")
+    report["resolve"] = {
+        "statement_kind": source_key.get("statement_kind"),
+        "lock_reason": analysis_status.get("selected_lock_reason"),
+        "move": host_move,
+        "analysis_id": analysis_status.get("current_analysis_id"),
+        "measurement_method": observation.get("measurement_method"),
+        "frame_id": observation.get("frame_id"),
+        "source_key": source_key,
+    }
+    if source_key.get("statement_kind") != "textbutton":
+        raise AssertionError(f"expected textbutton statement_kind: {source_key!r}")
+    if host_move is not True:
+        raise AssertionError(f"host did not unlock move for align textbutton: {analysis_status!r}")
+
+    original = analysis_status.get("selected_original_position") or analysis_status.get(
+        "selected_source_position"
+    )
+    if not (isinstance(original, (list, tuple)) and len(original) == 2):
+        original = [int(baseline_position["x"]), int(baseline_position["y"])]
+    requested_before = [int(original[0]), int(original[1])]
+
+    # Fresh focus_list observation before preview movement.
+    value_baseline = client.eval_expr("renforge_editor_align_clicks")
+    before_obs = _observe_selected(client)
+    before_rect = before_obs.get("rect") or []
+    if len(before_rect) < 2:
+        raise AssertionError(f"pre-preview observation missing rect: {before_obs!r}")
+    bounds_before = [int(before_rect[0]), int(before_rect[1])]
+    frame_before = before_obs.get("frame_id")
+
+    # Step 2: preview.
+    _require_ok(client.request("editor_task0_key", {"key": "right", "repeat": 24}), "nudge right")
+    _require_ok(client.request("editor_task0_key", {"key": "down", "repeat": 16}), "nudge down")
+    preview_status = _wait_for_status(
+        client,
+        lambda status: isinstance(status.get("preview_position"), (list, tuple))
+        and len(status.get("preview_position") or []) == 2
+        and list(status.get("preview_position") or []) != requested_before,
+        timeout=8.0,
+        poll_name="pos preview moved",
+    )
+    requested_after = [
+        int(preview_status["preview_position"][0]),
+        int(preview_status["preview_position"][1]),
+    ]
+    after_obs = _observe_selected(client)
+    value_preview = client.eval_expr("renforge_editor_align_clicks")
+    after_rect = after_obs.get("rect") or []
+    if len(after_rect) < 2:
+        raise AssertionError(f"post-preview observation missing rect: {after_obs!r}")
+    bounds_after = [int(after_rect[0]), int(after_rect[1])]
+    frame_after = after_obs.get("frame_id")
+    if not frame_before or not frame_after or frame_before == frame_after:
+        raise AssertionError(
+            f"preview observations must have distinct real frame_ids: "
+            f"before={frame_before!r}, after={frame_after!r}"
+        )
+    if before_obs.get("measurement_method") != "focus_list" or after_obs.get("measurement_method") != "focus_list":
+        raise AssertionError(
+            "preview observations must report measurement_method from bridge: "
+            f"before={before_obs.get('measurement_method')!r}, after={after_obs.get('measurement_method')!r}"
+        )
+    requested_delta = [requested_after[axis] - requested_before[axis] for axis in (0, 1)]
+    observed_delta = [bounds_after[axis] - bounds_before[axis] for axis in (0, 1)]
+    # Align previews use absolute xpos overrides; allow 1px focus noise.
+    if any(abs(observed_delta[axis] - requested_delta[axis]) > 1 for axis in (0, 1)):
+        raise AssertionError(
+            "focus_list preview bounds disagree with requested movement: "
+            f"requested={requested_delta!r}, observed={observed_delta!r}"
+        )
+    report["preview"] = {
+        "bounds_before": bounds_before,
+        "bounds_after": bounds_after,
+        "requested_before": requested_before,
+        "requested_after": requested_after,
+        "requested_delta": requested_delta,
+        "observed_delta": observed_delta,
+        "measurement_method_before": before_obs.get("measurement_method"),
+        "measurement_method_after": after_obs.get("measurement_method"),
+        "measurement_method": after_obs.get("measurement_method"),
+        "frame_id_before": frame_before,
+        "frame_id_after": frame_after,
+    }
+
+    # Step 3: patch via real Save overlay control.
+    pre_save_bytes = fixture_path.read_bytes()
+    pre_save_sha = _sha256_file(fixture_path)
+    pre_save_text = pre_save_bytes.decode("utf-8")
+    generation_before = _source_generation(analysis_status)
+    save_request = _require_ok(
+        client.click_element(id="rf_save", screen="_renforge_editor_overlay"),
+        "pos save",
+    )
+    save_status = _wait_for_status(
+        client,
+        lambda status: not bool(status.get("save_in_progress"))
+        and status.get("status_text") == "Reload committed"
+        and _source_generation(status) == generation_before + 1,
+        timeout=60.0,
+        poll_name="pos save complete",
+    )
+    post_save_bytes = fixture_path.read_bytes()
+    post_save_sha = _sha256_file(fixture_path)
+    post_save_text = post_save_bytes.decode("utf-8")
+    # Align sources store fractions; verify target line form + independent bytes.
+    post_target_line, _ = _target_line_with_offset(post_save_text)
+    if "align (" not in post_target_line or " xpos " in f" {post_target_line}" or " ypos " in f" {post_target_line}":
+        raise AssertionError(f"post-save target lost align form: {post_target_line!r}")
+    expected_text = _independent_expected_after_patch(
+        pre_save_text,
+        x=requested_after[0],
+        y=requested_after[1],
+        baseline={"x": bounds_before[0], "y": bounds_before[1]},
+    )
+    if post_save_text != expected_text:
+        raise AssertionError("patched fixture bytes disagree with independent expected content")
+    outside_coordinate_spans_identical = _outside_coordinate_spans_identical(
+        pre_save_text,
+        post_save_text,
+    )
+    if not outside_coordinate_spans_identical:
+        raise AssertionError("source patch changed bytes outside xpos/ypos spans")
+    report["patch"] = {
+        "before_sha256": pre_save_sha,
+        "after_sha256": post_save_sha,
+        "source_position_after": {"x": requested_after[0], "y": requested_after[1]},
+        "outside_coordinate_spans_identical": outside_coordinate_spans_identical,
+        "matches_independent_expected": True,
+        "save_request": save_request,
+    }
+
+    # Step 4: reload publication cycle (frame_id filled after rebind observation).
+    report["reload"] = {
+        "ok": True,
+        "script_generation": _source_generation(save_status),
+        "status_text": save_status.get("status_text"),
+        "generation_delta": _source_generation(save_status) - generation_before,
+        "pending_handshake_sent": save_status.get("pending_handshake_sent"),
+        "frame_id": None,
+    }
+
+    # Step 5: pixel agreement between post-preview focus rect and post-reload focus rect.
+    successor = _wait_for_status(
+        client,
+        lambda status: bool(status.get("current_analysis_id"))
+        and status.get("selected_widget_id") == TARGET_ID
+        and status.get("selected_lock_reason") in (None, ""),
+        timeout=10.0,
+        poll_name="pos post-save rebind analysis",
+    )
+    reload_obs = _observe_selected(client)
+    value_reload = client.eval_expr("renforge_editor_align_clicks")
+    reload_rect = reload_obs.get("rect") or []
+    if len(reload_rect) < 2:
+        raise AssertionError(f"post-reload observation missing rect: {reload_obs!r}")
+    reload_bounds = [int(reload_rect[0]), int(reload_rect[1])]
+    pixel_delta = [
+        reload_bounds[0] - bounds_after[0],
+        reload_bounds[1] - bounds_after[1],
+    ]
+    if any(abs(value) > 2 for value in pixel_delta):  # align residual after reload
+        raise AssertionError(
+            "post-reload focus rect disagrees with post-preview focus rect: "
+            f"preview={bounds_after!r}, reload={reload_bounds!r}, delta={pixel_delta!r}"
+        )
+    report["pixel_agreement"] = {
+        "preview_after": bounds_after,
+        "reload_after": reload_bounds,
+        "delta": pixel_delta,
+        "measurement_method": reload_obs.get("measurement_method"),
+        "measurement_method_preview": after_obs.get("measurement_method"),
+        "measurement_method_reload": reload_obs.get("measurement_method"),
+        "frame_id_preview": frame_after,
+        "frame_id_reload": reload_obs.get("frame_id"),
+    }
+    reload_frame = reload_obs.get("frame_id")
+    if not reload_frame or reload_frame == frame_after:
+        raise AssertionError(
+            f"reload observation must have a distinct real frame_id: "
+            f"preview={frame_after!r}, reload={reload_frame!r}"
+        )
+    report["value_invariance"] = {
+        "baseline": value_baseline,
+        "preview": value_preview,
+        "reload": value_reload,
+    }
+    if value_preview != value_baseline or value_reload != value_baseline:
+        raise AssertionError(
+            "textbutton click counter changed during preview/reload: "
+            f"baseline={value_baseline!r}, preview={value_preview!r}, reload={value_reload!r}"
+        )
+    report["reload"]["frame_id"] = reload_obs.get("frame_id")
+
+    # Step 6: rebinding.
+    report["rebinding"] = {
+        "ok": successor.get("selected_widget_id") == TARGET_ID
+        and successor.get("current_analysis_id")
+        not in (None, analysis_status.get("current_analysis_id"))
+        and (successor.get("current_source_key") or {}).get("statement_kind") == "textbutton",
+        "widget_id": successor.get("selected_widget_id"),
+        "analysis_id": successor.get("current_analysis_id"),
+        "previous_analysis_id": analysis_status.get("current_analysis_id"),
+        "source_key": successor.get("current_source_key"),
+        "lock_reason": successor.get("selected_lock_reason"),
+    }
+    if report["rebinding"]["ok"] is not True:
+        raise AssertionError(f"rebinding failed: {report['rebinding']!r}")
+
+    # Step 7: byte-identical undo of the temporary fixture.
+    fixture_path.write_bytes(baseline_bytes)
+    restored_bytes = fixture_path.read_bytes()
+    restored_sha = _sha256_file(fixture_path)
+    report["byte_identical_undo"] = {
+        "baseline_sha256": baseline_sha,
+        "restored_sha256": restored_sha,
+        "matches_baseline": restored_sha == baseline_sha and restored_bytes == baseline_bytes,
+        "patched_differed": post_save_sha != baseline_sha and post_save_bytes != baseline_bytes,
+    }
+    if restored_bytes != baseline_bytes:
+        raise AssertionError("align textbutton undo did not restore the baseline")
+    return report

--- a/src/renforge/editor_align_runner.py
+++ b/src/renforge/editor_align_runner.py
@@ -124,9 +124,13 @@ def _independent_expected_after_patch(
     parsed = analyze_textbutton_statement(line, expected_widget_id=TARGET_ID)
     from renforge.editor.source import _format_align_component
     parent_w, parent_h = parsed.align_parent_size
-    base = baseline or {"x": 0, "y": 0}
-    ax = float(parsed.xpos) + (int(x) - int(base["x"])) / float(parent_w)
-    ay = float(parsed.ypos) + (int(y) - int(base["y"])) / float(parent_h)
+    base = baseline or {"x": 0, "y": 0, "w": 0, "h": 0}
+    widget_w = max(0, int(base.get("w") or 0))
+    widget_h = max(0, int(base.get("h") or 0))
+    extent_w = float(max(1, int(parent_w) - widget_w))
+    extent_h = float(max(1, int(parent_h) - widget_h))
+    ax = float(parsed.xpos) + (int(x) - int(base["x"])) / extent_w
+    ay = float(parsed.ypos) + (int(y) - int(base["y"])) / extent_h
     ax_t = _format_align_component(ax)
     ay_t = _format_align_component(ay)
     patched_line = re.sub(
@@ -435,7 +439,7 @@ def run_editor_align_live_scenario(client: Any, *, fixture_path: Path) -> dict[s
         pre_save_text,
         x=requested_after[0],
         y=requested_after[1],
-        baseline={"x": bounds_before[0], "y": bounds_before[1]},
+        baseline={"x": bounds_before[0], "y": bounds_before[1], "w": before_rect[2] if len(before_rect)>2 else 0, "h": before_rect[3] if len(before_rect)>3 else 0},
     )
     if post_save_text != expected_text:
         raise AssertionError("patched fixture bytes disagree with independent expected content")

--- a/src/renforge/editor_align_runner.py
+++ b/src/renforge/editor_align_runner.py
@@ -125,12 +125,25 @@ def _independent_expected_after_patch(
     from renforge.editor.source import _format_align_component
     parent_w, parent_h = parsed.align_parent_size
     base = baseline or {"x": 0, "y": 0, "w": 0, "h": 0}
-    widget_w = max(0, int(base.get("w") or 0))
-    widget_h = max(0, int(base.get("h") or 0))
-    extent_w = float(max(1, int(parent_w) - widget_w))
-    extent_h = float(max(1, int(parent_h) - widget_h))
-    ax = float(parsed.xpos) + (int(x) - int(base["x"])) / extent_w
-    ay = float(parsed.ypos) + (int(y) - int(base["y"])) / extent_h
+    widget_w = int(base.get("w") or 0)
+    widget_h = int(base.get("h") or 0)
+    # Signed extents; zero-extent axes keep authored fractions (no clamp-to-1).
+    extent_w = int(parent_w) - widget_w
+    extent_h = int(parent_h) - widget_h
+    dx = int(x) - int(base["x"])
+    dy = int(y) - int(base["y"])
+    if extent_w == 0:
+        if dx != 0:
+            raise AssertionError("independent constructor: zero X extent with non-zero delta")
+        ax = float(parsed.xpos)
+    else:
+        ax = float(parsed.xpos) + dx / float(extent_w)
+    if extent_h == 0:
+        if dy != 0:
+            raise AssertionError("independent constructor: zero Y extent with non-zero delta")
+        ay = float(parsed.ypos)
+    else:
+        ay = float(parsed.ypos) + dy / float(extent_h)
     ax_t = _format_align_component(ax)
     ay_t = _format_align_component(ay)
     patched_line = re.sub(
@@ -166,14 +179,18 @@ def _outside_coordinate_spans_identical(before_text: str, after_text: str) -> bo
     return before_text.replace(before_line, "", 1) == after_text.replace(after_line, "", 1)
 
 
-def _parse_xy_from_target_line(source_text: str) -> dict[str, int]:
+def _parse_xy_from_target_line(source_text: str, *, widget_size: tuple[int, int]) -> dict[str, int]:
     """Return pixel position derived from authored align via the conversion contract."""
     line, _ = _target_line_with_offset(source_text)
     parsed = analyze_textbutton_statement(line, expected_widget_id=TARGET_ID)
     if parsed.position_mode != "align":
         raise AssertionError(f"expected align mode: {parsed!r}")
     from renforge.editor.source import align_to_pixels
-    px, py = align_to_pixels(float(parsed.xpos), float(parsed.ypos))
+    px, py = align_to_pixels(
+        float(parsed.xpos),
+        float(parsed.ypos),
+        widget_size=widget_size,
+    )
     return {"x": px, "y": py}
 
 
@@ -215,15 +232,14 @@ def run_editor_align_live_scenario(client: Any, *, fixture_path: Path) -> dict[s
     baseline_bytes = fixture_path.read_bytes()
     baseline_sha = _sha256_file(fixture_path)
     baseline_text = baseline_bytes.decode("utf-8")
-    # Prove analyzer accepts the authored pos form before any UI work.
+    # Prove analyzer accepts the authored align form before any UI work.
     target_line, _ = _target_line_with_offset(baseline_text)
     parsed = analyze_textbutton_statement(target_line, expected_widget_id=TARGET_ID)
     if parsed.position_mode != "align":
         raise AssertionError(f"expected position_mode align, got {parsed.position_mode!r}")
-    baseline_position = _parse_xy_from_target_line(baseline_text)
     report["fixture_before"] = {
         "sha256": baseline_sha,
-        "position": baseline_position,
+        "authored_align": [float(parsed.xpos), float(parsed.ypos)],
         "position_mode": parsed.position_mode,
     }
 
@@ -345,16 +361,28 @@ def run_editor_align_live_scenario(client: Any, *, fixture_path: Path) -> dict[s
         "selected_source_position"
     )
     if not (isinstance(original, (list, tuple)) and len(original) == 2):
-        original = [int(baseline_position["x"]), int(baseline_position["y"])]
+        raise AssertionError(f"missing selected original position: {analysis_status!r}")
     requested_before = [int(original[0]), int(original[1])]
 
     # Fresh focus_list observation before preview movement.
     value_baseline = client.eval_expr("renforge_editor_align_clicks")
     before_obs = _observe_selected(client)
     before_rect = before_obs.get("rect") or []
-    if len(before_rect) < 2:
-        raise AssertionError(f"pre-preview observation missing rect: {before_obs!r}")
+    if len(before_rect) < 4:
+        raise AssertionError(f"pre-preview observation missing full rect: {before_obs!r}")
     bounds_before = [int(before_rect[0]), int(before_rect[1])]
+    widget_size = (int(before_rect[2]), int(before_rect[3]))
+    if widget_size[0] <= 0 or widget_size[1] <= 0:
+        raise AssertionError(f"pre-preview widget size unusable: {before_rect!r}")
+    # Contract check: authored align + measured size must match measured TL.
+    expected_tl = _parse_xy_from_target_line(baseline_text, widget_size=widget_size)
+    if abs(expected_tl["x"] - bounds_before[0]) > 1 or abs(expected_tl["y"] - bounds_before[1]) > 1:
+        raise AssertionError(
+            "authored align conversion disagrees with measured focus TL: "
+            f"expected={expected_tl!r}, measured={bounds_before!r}, widget={widget_size!r}"
+        )
+    report["fixture_before"]["position"] = expected_tl
+    report["fixture_before"]["widget_size"] = list(widget_size)
     frame_before = before_obs.get("frame_id")
 
     # Step 2: preview.
@@ -487,7 +515,7 @@ def run_editor_align_live_scenario(client: Any, *, fixture_path: Path) -> dict[s
         reload_bounds[0] - bounds_after[0],
         reload_bounds[1] - bounds_after[1],
     ]
-    if any(abs(value) > 2 for value in pixel_delta):  # align residual after reload
+    if any(abs(value) > 1 for value in pixel_delta):  # issue #39: within one logical pixel
         raise AssertionError(
             "post-reload focus rect disagrees with post-preview focus rect: "
             f"preview={bounds_after!r}, reload={reload_bounds!r}, delta={pixel_delta!r}"

--- a/src/renforge/editor_anchor_runner.py
+++ b/src/renforge/editor_anchor_runner.py
@@ -1,0 +1,533 @@
+from __future__ import annotations
+
+import hashlib
+import re
+import shutil
+import time
+from pathlib import Path
+from typing import Any
+
+from renforge.editor.source import analyze_textbutton_statement
+from renforge.editor_task0_runner import (
+    _require_ok,
+    _source_generation,
+    _wait_for_status,
+)
+
+FIXTURE_SCREEN = "renforge_editor_anchor_fixture"
+TARGET_ID = "anchor_target"
+EDITOR_RESOURCE = Path(__file__).resolve().parent / "bridge" / "editor.rpy"
+FIXTURE_RESOURCE = (
+    Path(__file__).resolve().parents[2]
+    / "tests"
+    / "live_fixtures"
+    / "renforge_editor_anchor_fixture.rpy"
+)
+
+
+def inject_editor_anchor_resources(project_root: Path) -> dict[str, str]:
+    game_dir = project_root / "game"
+    game_dir.mkdir(parents=True, exist_ok=True)
+    editor_target = game_dir / "zz_renforge_editor_anchor.rpy"
+    fixture_target = game_dir / "zz_renforge_editor_anchor_fixture.rpy"
+    shutil.copyfile(EDITOR_RESOURCE, editor_target)
+    shutil.copyfile(FIXTURE_RESOURCE, fixture_target)
+    return {
+        "editor": str(editor_target),
+        "fixture": str(fixture_target),
+    }
+
+
+def _find_element(
+    elements: list[dict[str, Any]],
+    wanted_id: str,
+    *,
+    wanted_text: str | None = None,
+) -> dict[str, Any]:
+    for element in elements:
+        element_id = str(element.get("id") or "")
+        if wanted_text is not None:
+            if element_id == wanted_id and str(element.get("text") or "") == wanted_text:
+                return element
+            continue
+        if element_id == wanted_id:
+            return element
+    raise AssertionError(
+        f"missing expected element id {wanted_id!r} text {wanted_text!r}: {elements!r}"
+    )
+
+
+def _center(bounds: dict[str, Any]) -> tuple[int, int]:
+    return (
+        int(bounds["x"]) + int(bounds["width"]) // 2,
+        int(bounds["y"]) + int(bounds["height"]) // 2,
+    )
+
+
+def _sha256_file(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _list_info(client: Any) -> dict[str, Any]:
+    info = client.list_ui_elements_info(screen=FIXTURE_SCREEN)
+    if not isinstance(info, dict):
+        raise AssertionError(f"list_ui_elements_info returned non-dict: {info!r}")
+    return info
+
+
+def _wait_bounds(client: Any, widget_id: str, *, timeout: float = 6.0) -> dict[str, int]:
+    deadline = time.monotonic() + timeout
+    last: list[dict[str, Any]] = []
+    while time.monotonic() < deadline:
+        info = _list_info(client)
+        last = info.get("elements") if isinstance(info.get("elements"), list) else []
+        try:
+            element = _find_element(last, widget_id)
+        except AssertionError:
+            time.sleep(0.05)
+            continue
+        bounds = element.get("bounds")
+        if isinstance(bounds, dict):
+            return {
+                "x": int(bounds["x"]),
+                "y": int(bounds["y"]),
+                "width": int(bounds["width"]),
+                "height": int(bounds["height"]),
+            }
+        time.sleep(0.05)
+    raise AssertionError(f"bounds for {widget_id!r} unavailable: {last!r}")
+
+
+def _target_line_with_offset(source_text: str) -> tuple[str, int]:
+    offset = 0
+    for line in source_text.splitlines(keepends=True):
+        if (
+            f'id "{TARGET_ID}"' in line
+            and line.lstrip().startswith("textbutton ")
+            and " anchor " in f" {line}"
+        ):
+            analyze_textbutton_statement(line, expected_widget_id=TARGET_ID)
+            return line, offset
+        offset += len(line)
+    raise AssertionError(f"source missing anchor textbutton line for {TARGET_ID!r}")
+
+
+def _independent_expected_after_patch(before_text: str, *, x: int, y: int) -> str:
+    """Build expected fixture text without calling apply_textbutton_patch."""
+    line, offset = _target_line_with_offset(before_text)
+    if "anchor (0.5, 0.5)" not in line:
+        raise AssertionError(f"target line missing preserved anchor form: {line!r}")
+    patched_line = re.sub(r"(\bxpos\s+)-?\d+", rf"\g<1>{int(x)}", line, count=1)
+    patched_line = re.sub(r"(\bypos\s+)-?\d+", rf"\g<1>{int(y)}", patched_line, count=1)
+    if patched_line == line:
+        raise AssertionError("independent patch constructor did not change target coordinates")
+    if "anchor (0.5, 0.5)" not in patched_line:
+        raise AssertionError("independent constructor must preserve anchor bytes")
+    return f"{before_text[:offset]}{patched_line}{before_text[offset + len(line) :]}"
+
+
+def _outside_coordinate_spans_identical(before_text: str, after_text: str) -> bool:
+    before_line, _ = _target_line_with_offset(before_text)
+    after_line, _ = _target_line_with_offset(after_text)
+    before_norm = re.sub(r"(\bxpos\s+)-?\d+", r"\1__X__", before_line, count=1)
+    before_norm = re.sub(r"(\bypos\s+)-?\d+", r"\1__Y__", before_norm, count=1)
+    after_norm = re.sub(r"(\bxpos\s+)-?\d+", r"\1__X__", after_line, count=1)
+    after_norm = re.sub(r"(\bypos\s+)-?\d+", r"\1__Y__", after_norm, count=1)
+    if before_norm != after_norm:
+        return False
+    return before_text.replace(before_line, "", 1) == after_text.replace(after_line, "", 1)
+
+
+def _parse_xy_from_target_line(source_text: str) -> dict[str, int]:
+    line, _ = _target_line_with_offset(source_text)
+    xpos = re.search(r"\bxpos\s+(-?\d+)\b", line)
+    ypos = re.search(r"\bypos\s+(-?\d+)\b", line)
+    if xpos is None or ypos is None:
+        raise AssertionError(f"target line missing literal xpos/ypos: {line!r}")
+    if "anchor (" not in line:
+        raise AssertionError(f"target line missing anchor form: {line!r}")
+    return {"x": int(xpos.group(1)), "y": int(ypos.group(1))}
+
+
+def _select_lock(client: Any, widget_id: str, expected_code: str) -> str:
+    bounds = _wait_bounds(client, widget_id)
+    selection = client.request(
+        "editor_task0_select",
+        {"x": _center(bounds)[0], "y": _center(bounds)[1]},
+    )
+    immediate = selection.get("lock_reason") if isinstance(selection, dict) else None
+    if immediate == expected_code:
+        return expected_code
+    status = _wait_for_status(
+        client,
+        lambda current: current.get("selected_widget_id") == widget_id
+        and current.get("selected_lock_reason") == expected_code,
+        timeout=10.0,
+        poll_name=f"{widget_id} lock",
+    )
+    lock_reason = status.get("selected_lock_reason")
+    if lock_reason != expected_code:
+        raise AssertionError(f"unexpected lock for {widget_id!r}: {status!r}")
+    return str(lock_reason)
+
+
+def _observe_selected(client: Any) -> dict[str, Any]:
+    reply = client.request("editor_task0_observe_selected", {})
+    if not isinstance(reply, dict) or reply.get("ok") is not True:
+        raise AssertionError(f"observe_selected failed: {reply!r}")
+    observation = reply.get("observation")
+    if not isinstance(observation, dict):
+        raise AssertionError(f"observe_selected missing observation: {reply!r}")
+    return observation
+
+
+def run_editor_anchor_live_scenario(client: Any, *, fixture_path: Path) -> dict[str, Any]:
+    """Seven-step live proof for xpos/ypos + anchor textbutton form (issue #40)."""
+    report: dict[str, Any] = {}
+    baseline_bytes = fixture_path.read_bytes()
+    baseline_sha = _sha256_file(fixture_path)
+    baseline_text = baseline_bytes.decode("utf-8")
+    # Prove analyzer accepts the authored pos form before any UI work.
+    target_line, _ = _target_line_with_offset(baseline_text)
+    parsed = analyze_textbutton_statement(target_line, expected_widget_id=TARGET_ID)
+    if parsed.has_anchor is not True:
+        raise AssertionError(f"expected has_anchor True, got {parsed!r}")
+    baseline_position = _parse_xy_from_target_line(baseline_text)
+    report["fixture_before"] = {
+        "sha256": baseline_sha,
+        "position": baseline_position,
+        "position_mode": parsed.position_mode,
+        "has_anchor": parsed.has_anchor,
+    }
+
+    start = _require_ok(
+        client.request("editor_task0_start", {"screen": FIXTURE_SCREEN}),
+        "editor_task0_start",
+    )
+    report["start"] = start
+
+    # Lock matrix first on real focusable widgets (measured codes).
+    report["locks"] = {
+        "computed": _select_lock(client, "anchor_computed", "XPOS_LITERAL_REQUIRED"),
+        "container": _select_lock(client, "anchor_container", "CONTAINER_POSITION_UNSUPPORTED"),
+    }
+
+    # Measured live: two use-statements share id "anchor_dupe_target". The first
+    # instance is still selectable by focus bounds and locks as SYNTHETIC_WIDGET_ID
+    # (list_ui may only name the second instance).
+    dupe_info = _list_info(client)
+    dupe_elements = dupe_info.get("elements") if isinstance(dupe_info, dict) else None
+    # Prefer the unnamed first instance (NullAction-ish id) then fall back to
+    # the named target bounds at the left dupe coordinate.
+    dupe_pick = None
+    for element in dupe_elements if isinstance(dupe_elements, list) else []:
+        bounds = element.get("bounds")
+        if not isinstance(bounds, dict):
+            continue
+        text = str(element.get("text") or "")
+        if text == "DUPE A" or (
+            int(bounds.get("x", -1)) == 520 and int(bounds.get("y", -1)) == 430
+        ):
+            dupe_pick = bounds
+            break
+    if dupe_pick is None:
+        raise AssertionError(f"could not locate first dupe bounds: {dupe_elements!r}")
+    dupe_select = client.request(
+        "editor_task0_select",
+        {
+            "x": int(dupe_pick["x"]) + max(2, int(dupe_pick["width"]) // 4),
+            "y": int(dupe_pick["y"]) + int(dupe_pick["height"]) // 2,
+        },
+    )
+    ambiguous = dupe_select.get("lock_reason") if isinstance(dupe_select, dict) else None
+    if ambiguous in (None, ""):
+        status = _wait_for_status(
+            client,
+            lambda current: current.get("selected_lock_reason") == "SYNTHETIC_WIDGET_ID",
+            timeout=10.0,
+            poll_name="pos dupe lock",
+        )
+        ambiguous = status.get("selected_lock_reason")
+    if ambiguous != "SYNTHETIC_WIDGET_ID":
+        raise AssertionError(
+            f"duplicate anchor textbutton lock was not SYNTHETIC_WIDGET_ID: {ambiguous!r}"
+        )
+    report["locks"]["ambiguous"] = ambiguous
+
+    # Measured live: Side is not in the ancestry allowlist → UNKNOWN_ANCESTRY_TYPE.
+    side_bounds = _wait_bounds(client, "anchor_side", timeout=3.0)
+    side_select = client.request(
+        "editor_task0_select",
+        {"x": _center(side_bounds)[0], "y": _center(side_bounds)[1]},
+    )
+    unproven = side_select.get("lock_reason") if isinstance(side_select, dict) else None
+    if unproven in (None, ""):
+        status = _wait_for_status(
+            client,
+            lambda current: current.get("selected_lock_reason") == "UNKNOWN_ANCESTRY_TYPE",
+            timeout=10.0,
+            poll_name="pos side lock",
+        )
+        unproven = status.get("selected_lock_reason")
+    if unproven != "UNKNOWN_ANCESTRY_TYPE":
+        raise AssertionError(
+            f"side-ancestor anchor textbutton lock was not UNKNOWN_ANCESTRY_TYPE: {unproven!r}"
+        )
+    report["locks"]["unproven"] = unproven
+
+    # Step 1: resolve the editable anchor textbutton from a fresh focus rect.
+    target_bounds = _wait_bounds(client, TARGET_ID)
+    target_center = _center(target_bounds)
+    select = _require_ok(
+        client.request(
+            "editor_task0_select",
+            {"x": target_center[0], "y": target_center[1]},
+        ),
+        "target select",
+    )
+    observation = select.get("observation") or {}
+    if observation.get("measurement_method") != "focus_list":
+        raise AssertionError(f"select observation not focus_list: {observation!r}")
+
+    analysis_status = _wait_for_status(
+        client,
+        lambda status: bool(status.get("current_analysis_id"))
+        and status.get("selected_widget_id") == TARGET_ID
+        and status.get("selected_lock_reason") in (None, ""),
+        timeout=10.0,
+        poll_name="pos analysis",
+    )
+    source_key = analysis_status.get("current_source_key") or {}
+    capabilities = analysis_status.get("current_capabilities") or {}
+    host_move = capabilities.get("move")
+    report["resolve"] = {
+        "statement_kind": source_key.get("statement_kind"),
+        "lock_reason": analysis_status.get("selected_lock_reason"),
+        "move": host_move,
+        "analysis_id": analysis_status.get("current_analysis_id"),
+        "measurement_method": observation.get("measurement_method"),
+        "frame_id": observation.get("frame_id"),
+        "source_key": source_key,
+    }
+    if source_key.get("statement_kind") != "textbutton":
+        raise AssertionError(f"expected textbutton statement_kind: {source_key!r}")
+    if host_move is not True:
+        raise AssertionError(f"host did not unlock move for anchor textbutton: {analysis_status!r}")
+
+    original = analysis_status.get("selected_original_position") or analysis_status.get(
+        "selected_source_position"
+    )
+    if not (isinstance(original, (list, tuple)) and len(original) == 2):
+        original = [int(baseline_position["x"]), int(baseline_position["y"])]
+    requested_before = [int(original[0]), int(original[1])]
+
+    # Fresh focus_list observation before preview movement.
+    value_baseline = client.eval_expr("renforge_editor_anchor_clicks")
+    before_obs = _observe_selected(client)
+    before_rect = before_obs.get("rect") or []
+    if len(before_rect) < 2:
+        raise AssertionError(f"pre-preview observation missing rect: {before_obs!r}")
+    bounds_before = [int(before_rect[0]), int(before_rect[1])]
+    frame_before = before_obs.get("frame_id")
+
+    # Step 2: preview.
+    _require_ok(client.request("editor_task0_key", {"key": "right", "repeat": 24}), "nudge right")
+    _require_ok(client.request("editor_task0_key", {"key": "down", "repeat": 16}), "nudge down")
+    preview_status = _wait_for_status(
+        client,
+        lambda status: isinstance(status.get("preview_position"), (list, tuple))
+        and len(status.get("preview_position") or []) == 2
+        and list(status.get("preview_position") or []) != requested_before,
+        timeout=8.0,
+        poll_name="pos preview moved",
+    )
+    requested_after = [
+        int(preview_status["preview_position"][0]),
+        int(preview_status["preview_position"][1]),
+    ]
+    after_obs = _observe_selected(client)
+    value_preview = client.eval_expr("renforge_editor_anchor_clicks")
+    after_rect = after_obs.get("rect") or []
+    if len(after_rect) < 2:
+        raise AssertionError(f"post-preview observation missing rect: {after_obs!r}")
+    bounds_after = [int(after_rect[0]), int(after_rect[1])]
+    frame_after = after_obs.get("frame_id")
+    if not frame_before or not frame_after or frame_before == frame_after:
+        raise AssertionError(
+            f"preview observations must have distinct real frame_ids: "
+            f"before={frame_before!r}, after={frame_after!r}"
+        )
+    if before_obs.get("measurement_method") != "focus_list" or after_obs.get("measurement_method") != "focus_list":
+        raise AssertionError(
+            "preview observations must report measurement_method from bridge: "
+            f"before={before_obs.get('measurement_method')!r}, after={after_obs.get('measurement_method')!r}"
+        )
+    requested_delta = [requested_after[axis] - requested_before[axis] for axis in (0, 1)]
+    observed_delta = [bounds_after[axis] - bounds_before[axis] for axis in (0, 1)]
+    if any(abs(observed_delta[axis] - requested_delta[axis]) > 1 for axis in (0, 1)):
+        raise AssertionError(
+            "focus_list preview bounds disagree with requested movement: "
+            f"requested={requested_delta!r}, observed={observed_delta!r}"
+        )
+    report["preview"] = {
+        "bounds_before": bounds_before,
+        "bounds_after": bounds_after,
+        "requested_before": requested_before,
+        "requested_after": requested_after,
+        "requested_delta": requested_delta,
+        "observed_delta": observed_delta,
+        "measurement_method_before": before_obs.get("measurement_method"),
+        "measurement_method_after": after_obs.get("measurement_method"),
+        "measurement_method": after_obs.get("measurement_method"),
+        "frame_id_before": frame_before,
+        "frame_id_after": frame_after,
+    }
+
+    # Step 3: patch via real Save overlay control.
+    pre_save_bytes = fixture_path.read_bytes()
+    pre_save_sha = _sha256_file(fixture_path)
+    pre_save_text = pre_save_bytes.decode("utf-8")
+    generation_before = _source_generation(analysis_status)
+    save_request = _require_ok(
+        client.click_element(id="rf_save", screen="_renforge_editor_overlay"),
+        "pos save",
+    )
+    save_status = _wait_for_status(
+        client,
+        lambda status: not bool(status.get("save_in_progress"))
+        and status.get("status_text") == "Reload committed"
+        and _source_generation(status) == generation_before + 1,
+        timeout=60.0,
+        poll_name="pos save complete",
+    )
+    post_save_bytes = fixture_path.read_bytes()
+    post_save_sha = _sha256_file(fixture_path)
+    post_save_text = post_save_bytes.decode("utf-8")
+    source_position_after = _parse_xy_from_target_line(post_save_text)
+    # With non-default anchor, source xpos/ypos are the anchor point while
+    # preview_position tracks focus-list top-left; apply the observed focus delta
+    # to the authored source coordinates.
+    expected_source_position = {
+        "x": int(baseline_position["x"]) + int(observed_delta[0]),
+        "y": int(baseline_position["y"]) + int(observed_delta[1]),
+    }
+    if source_position_after != expected_source_position:
+        raise AssertionError(
+            "source patch disagrees with authored+delta position: "
+            f"expected={expected_source_position!r}, observed={source_position_after!r}"
+        )
+    post_line, _ = _target_line_with_offset(post_save_text)
+    if "anchor (0.5, 0.5)" not in post_line:
+        raise AssertionError(f"post-save lost anchor form: {post_line!r}")
+    expected_text = _independent_expected_after_patch(
+        pre_save_text,
+        x=expected_source_position["x"],
+        y=expected_source_position["y"],
+    )
+    if post_save_text != expected_text:
+        raise AssertionError("patched fixture bytes disagree with independent expected content")
+    outside_coordinate_spans_identical = _outside_coordinate_spans_identical(
+        pre_save_text,
+        post_save_text,
+    )
+    if not outside_coordinate_spans_identical:
+        raise AssertionError("source patch changed bytes outside xpos/ypos spans")
+    report["patch"] = {
+        "before_sha256": pre_save_sha,
+        "after_sha256": post_save_sha,
+        "source_position_after": source_position_after,
+        "outside_coordinate_spans_identical": outside_coordinate_spans_identical,
+        "matches_independent_expected": True,
+        "save_request": save_request,
+    }
+
+    # Step 4: reload publication cycle (frame_id filled after rebind observation).
+    report["reload"] = {
+        "ok": True,
+        "script_generation": _source_generation(save_status),
+        "status_text": save_status.get("status_text"),
+        "generation_delta": _source_generation(save_status) - generation_before,
+        "pending_handshake_sent": save_status.get("pending_handshake_sent"),
+        "frame_id": None,
+    }
+
+    # Step 5: pixel agreement between post-preview focus rect and post-reload focus rect.
+    successor = _wait_for_status(
+        client,
+        lambda status: bool(status.get("current_analysis_id"))
+        and status.get("selected_widget_id") == TARGET_ID
+        and status.get("selected_lock_reason") in (None, ""),
+        timeout=10.0,
+        poll_name="pos post-save rebind analysis",
+    )
+    reload_obs = _observe_selected(client)
+    value_reload = client.eval_expr("renforge_editor_anchor_clicks")
+    reload_rect = reload_obs.get("rect") or []
+    if len(reload_rect) < 2:
+        raise AssertionError(f"post-reload observation missing rect: {reload_obs!r}")
+    reload_bounds = [int(reload_rect[0]), int(reload_rect[1])]
+    pixel_delta = [
+        reload_bounds[0] - bounds_after[0],
+        reload_bounds[1] - bounds_after[1],
+    ]
+    if any(abs(value) > 1 for value in pixel_delta):
+        raise AssertionError(
+            "post-reload focus rect disagrees with post-preview focus rect: "
+            f"preview={bounds_after!r}, reload={reload_bounds!r}, delta={pixel_delta!r}"
+        )
+    report["pixel_agreement"] = {
+        "preview_after": bounds_after,
+        "reload_after": reload_bounds,
+        "delta": pixel_delta,
+        "measurement_method": reload_obs.get("measurement_method"),
+        "measurement_method_preview": after_obs.get("measurement_method"),
+        "measurement_method_reload": reload_obs.get("measurement_method"),
+        "frame_id_preview": frame_after,
+        "frame_id_reload": reload_obs.get("frame_id"),
+    }
+    reload_frame = reload_obs.get("frame_id")
+    if not reload_frame or reload_frame == frame_after:
+        raise AssertionError(
+            f"reload observation must have a distinct real frame_id: "
+            f"preview={frame_after!r}, reload={reload_frame!r}"
+        )
+    report["value_invariance"] = {
+        "baseline": value_baseline,
+        "preview": value_preview,
+        "reload": value_reload,
+    }
+    if value_preview != value_baseline or value_reload != value_baseline:
+        raise AssertionError(
+            "textbutton click counter changed during preview/reload: "
+            f"baseline={value_baseline!r}, preview={value_preview!r}, reload={value_reload!r}"
+        )
+    report["reload"]["frame_id"] = reload_obs.get("frame_id")
+
+    # Step 6: rebinding.
+    report["rebinding"] = {
+        "ok": successor.get("selected_widget_id") == TARGET_ID
+        and successor.get("current_analysis_id")
+        not in (None, analysis_status.get("current_analysis_id"))
+        and (successor.get("current_source_key") or {}).get("statement_kind") == "textbutton",
+        "widget_id": successor.get("selected_widget_id"),
+        "analysis_id": successor.get("current_analysis_id"),
+        "previous_analysis_id": analysis_status.get("current_analysis_id"),
+        "source_key": successor.get("current_source_key"),
+        "lock_reason": successor.get("selected_lock_reason"),
+    }
+    if report["rebinding"]["ok"] is not True:
+        raise AssertionError(f"rebinding failed: {report['rebinding']!r}")
+
+    # Step 7: byte-identical undo of the temporary fixture.
+    fixture_path.write_bytes(baseline_bytes)
+    restored_bytes = fixture_path.read_bytes()
+    restored_sha = _sha256_file(fixture_path)
+    report["byte_identical_undo"] = {
+        "baseline_sha256": baseline_sha,
+        "restored_sha256": restored_sha,
+        "matches_baseline": restored_sha == baseline_sha and restored_bytes == baseline_bytes,
+        "patched_differed": post_save_sha != baseline_sha and post_save_bytes != baseline_bytes,
+    }
+    if restored_bytes != baseline_bytes:
+        raise AssertionError("anchor textbutton undo did not restore the baseline")
+    return report

--- a/tests/live_fixtures/renforge_editor_align_fixture.rpy
+++ b/tests/live_fixtures/renforge_editor_align_fixture.rpy
@@ -16,7 +16,7 @@ screen renforge_editor_align_fixture():
         yfill True
 
         # Supported form: single-line textbutton with pure align (fx, fy).
-        # Full-screen fixed parent => pixels ≈ (fx * 1280, fy * 720) with default anchor.
+        # Full-screen fixed parent: TL = (fx, fy) × (parent − widget) because align sets anchor.
         textbutton "MOVE ME" id "align_target" align (0.2, 0.25) action SetVariable("renforge_editor_align_clicks", renforge_editor_align_clicks + 1)
 
         textbutton "COMPUTED" id "align_computed" align (renforge_editor_align_computed, 0.4) action NullAction()

--- a/tests/live_fixtures/renforge_editor_align_fixture.rpy
+++ b/tests/live_fixtures/renforge_editor_align_fixture.rpy
@@ -1,0 +1,36 @@
+default renforge_editor_align_clicks = 0
+default renforge_editor_align_computed = 0.4
+
+
+screen renforge_editor_align_dupe(label_text, x_frac):
+    textbutton label_text id "align_dupe_target" align (x_frac, 0.6) action NullAction()
+
+
+screen renforge_editor_align_fixture():
+    layer "screens"
+    zorder 640
+
+    fixed:
+        id "align_root"
+        xfill True
+        yfill True
+
+        # Supported form: single-line textbutton with pure align (fx, fy).
+        # Full-screen fixed parent => pixels ≈ (fx * 1280, fy * 720) with default anchor.
+        textbutton "MOVE ME" id "align_target" align (0.2, 0.25) action SetVariable("renforge_editor_align_clicks", renforge_editor_align_clicks + 1)
+
+        textbutton "COMPUTED" id "align_computed" align (renforge_editor_align_computed, 0.4) action NullAction()
+
+        vbox:
+            id "align_container_parent"
+            xpos 900
+            ypos 120
+            spacing 12
+
+            textbutton "CONTAINER" id "align_container" align (0.0, 0.0) action NullAction()
+
+        side "c":
+            textbutton "SIDE" id "align_side" align (0.1, 0.7) action NullAction()
+
+        use renforge_editor_align_dupe("DUPE A", 0.4)
+        use renforge_editor_align_dupe("DUPE B", 0.55)

--- a/tests/live_fixtures/renforge_editor_anchor_fixture.rpy
+++ b/tests/live_fixtures/renforge_editor_anchor_fixture.rpy
@@ -1,0 +1,35 @@
+default renforge_editor_anchor_clicks = 0
+default renforge_editor_anchor_computed_x = 520
+
+
+screen renforge_editor_anchor_dupe(label_text, left_x):
+    textbutton label_text id "anchor_dupe_target" xpos left_x ypos 430 anchor (0.5, 0.5) action NullAction()
+
+
+screen renforge_editor_anchor_fixture():
+    layer "screens"
+    zorder 640
+
+    fixed:
+        id "anchor_root"
+        xfill True
+        yfill True
+
+        # Supported form: xpos/ypos + pure literal anchor; move patches xy, preserves anchor.
+        textbutton "MOVE ME" id "anchor_target" xpos 400 ypos 300 anchor (0.5, 0.5) action SetVariable("renforge_editor_anchor_clicks", renforge_editor_anchor_clicks + 1)
+
+        textbutton "COMPUTED" id "anchor_computed" xpos renforge_editor_anchor_computed_x ypos 200 anchor (0.5, 0.5) action NullAction()
+
+        vbox:
+            id "anchor_container_parent"
+            xpos 900
+            ypos 120
+            spacing 12
+
+            textbutton "CONTAINER" id "anchor_container" xpos 0 ypos 0 anchor (0.5, 0.5) action NullAction()
+
+        side "c":
+            textbutton "SIDE" id "anchor_side" xpos 100 ypos 520 anchor (0.5, 0.5) action NullAction()
+
+        use renforge_editor_anchor_dupe("DUPE A", 520)
+        use renforge_editor_anchor_dupe("DUPE B", 720)

--- a/tests/test_editor_align_live.py
+++ b/tests/test_editor_align_live.py
@@ -76,7 +76,7 @@ def test_align_seven_step_live_proof(demo_copy: Path) -> None:
     assert patch["outside_coordinate_spans_identical"] is True
     assert patch["matches_independent_expected"] is True
     assert report["reload"]["status_text"] == "Reload committed"
-    assert all(abs(int(v)) <= 2 for v in report["pixel_agreement"]["delta"])  # align fraction residual
+    assert all(abs(int(v)) <= 1 for v in report["pixel_agreement"]["delta"])  # issue #39: 1 px
     assert report["value_invariance"]["preview"] == report["value_invariance"]["baseline"]
     assert report["rebinding"]["widget_id"] == "align_target"
     locks = report["locks"]

--- a/tests/test_editor_align_live.py
+++ b/tests/test_editor_align_live.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import os
+import shutil
+import time
+from pathlib import Path
+
+import pytest
+
+from renforge.editor_align_runner import (
+    FIXTURE_SCREEN,
+    inject_editor_align_resources,
+    run_editor_align_live_scenario,
+)
+
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("RENFORGE_ALIGN_LIVE"),
+    reason="set RENFORGE_ALIGN_LIVE=1 to run align (x, y) seven-step live proof",
+)
+
+_DEMO = Path(__file__).resolve().parents[1] / "examples" / "demo_game"
+
+
+@pytest.fixture
+def demo_copy(tmp_path: Path) -> Path:
+    destination = tmp_path / "demo"
+    shutil.copytree(_DEMO, destination, ignore=shutil.ignore_patterns("*.rpyc", "cache"))
+    inject_editor_align_resources(destination)
+    return destination
+
+
+def test_align_seven_step_live_proof(demo_copy: Path) -> None:
+    from renforge.bridge.launcher import launch_with_bridge
+    from renforge.project import RenpyProject
+    from renforge.sdk import get_or_install_sdk
+
+    sdk = get_or_install_sdk("8.5.3", project_root=demo_copy)
+    project = RenpyProject(demo_copy)
+    fixture_path = demo_copy / "game" / "zz_renforge_editor_align_fixture.rpy"
+
+    with launch_with_bridge(sdk, project, startup_timeout=120, editor=True) as session:
+        for _ in range(40):
+            if session.client.inspect_screen("_renforge_editor_launcher").get("active") is True:
+                break
+            time.sleep(0.25)
+        else:
+            pytest.fail("editor launcher never became active")
+        assert session.client.click_element(
+            text="RF", exact=True, screen="_renforge_editor_launcher"
+        ).get("ok") is True
+        for _ in range(40):
+            if session.client.inspect_screen("_renforge_editor_overlay").get("active") is True:
+                break
+            time.sleep(0.05)
+        else:
+            pytest.fail("editor overlay never became active")
+        for _ in range(20):
+            if session.client.eval_expr(f'renpy.has_screen("{FIXTURE_SCREEN}")') is True:
+                break
+            time.sleep(0.1)
+        else:
+            pytest.fail("align fixture screen never became available")
+
+        report = run_editor_align_live_scenario(session.client, fixture_path=fixture_path)
+
+    assert report["resolve"]["statement_kind"] == "textbutton"
+    assert report["resolve"]["move"] is True
+    assert report["fixture_before"]["position_mode"] == "align"
+    preview = report["preview"]
+    assert preview["bounds_before"] != preview["bounds_after"]
+    assert all(
+        abs(preview["observed_delta"][axis] - preview["requested_delta"][axis]) <= 1
+        for axis in (0, 1)
+    )
+    patch = report["patch"]
+    assert patch["outside_coordinate_spans_identical"] is True
+    assert patch["matches_independent_expected"] is True
+    assert report["reload"]["status_text"] == "Reload committed"
+    assert all(abs(int(v)) <= 2 for v in report["pixel_agreement"]["delta"])  # align fraction residual
+    assert report["value_invariance"]["preview"] == report["value_invariance"]["baseline"]
+    assert report["rebinding"]["widget_id"] == "align_target"
+    locks = report["locks"]
+    assert locks["computed"] == "ALIGN_LITERAL_REQUIRED"
+    assert locks["container"] == "CONTAINER_POSITION_UNSUPPORTED"
+    assert locks["ambiguous"] == "SYNTHETIC_WIDGET_ID"
+    assert locks["unproven"] == "UNKNOWN_ANCESTRY_TYPE"
+    assert report["byte_identical_undo"]["matches_baseline"] is True

--- a/tests/test_editor_anchor_live.py
+++ b/tests/test_editor_anchor_live.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import os
+import shutil
+import time
+from pathlib import Path
+
+import pytest
+
+from renforge.editor_anchor_runner import (
+    FIXTURE_SCREEN,
+    inject_editor_anchor_resources,
+    run_editor_anchor_live_scenario,
+)
+
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("RENFORGE_ANCHOR_LIVE"),
+    reason="set RENFORGE_ANCHOR_LIVE=1 to run anchor-aware seven-step live proof",
+)
+
+_DEMO = Path(__file__).resolve().parents[1] / "examples" / "demo_game"
+
+
+@pytest.fixture
+def demo_copy(tmp_path: Path) -> Path:
+    destination = tmp_path / "demo"
+    shutil.copytree(_DEMO, destination, ignore=shutil.ignore_patterns("*.rpyc", "cache"))
+    inject_editor_anchor_resources(destination)
+    return destination
+
+
+def test_anchor_seven_step_live_proof(demo_copy: Path) -> None:
+    from renforge.bridge.launcher import launch_with_bridge
+    from renforge.project import RenpyProject
+    from renforge.sdk import get_or_install_sdk
+
+    sdk = get_or_install_sdk("8.5.3", project_root=demo_copy)
+    project = RenpyProject(demo_copy)
+    fixture_path = demo_copy / "game" / "zz_renforge_editor_anchor_fixture.rpy"
+
+    with launch_with_bridge(sdk, project, startup_timeout=120, editor=True) as session:
+        for _ in range(40):
+            if session.client.inspect_screen("_renforge_editor_launcher").get("active") is True:
+                break
+            time.sleep(0.25)
+        else:
+            pytest.fail("editor launcher never became active")
+        assert session.client.click_element(
+            text="RF", exact=True, screen="_renforge_editor_launcher"
+        ).get("ok") is True
+        for _ in range(40):
+            if session.client.inspect_screen("_renforge_editor_overlay").get("active") is True:
+                break
+            time.sleep(0.05)
+        else:
+            pytest.fail("editor overlay never became active")
+        for _ in range(20):
+            if session.client.eval_expr(f'renpy.has_screen("{FIXTURE_SCREEN}")') is True:
+                break
+            time.sleep(0.1)
+        else:
+            pytest.fail("anchor fixture screen never became available")
+
+        report = run_editor_anchor_live_scenario(session.client, fixture_path=fixture_path)
+
+    assert report["resolve"]["statement_kind"] == "textbutton"
+    assert report["resolve"]["move"] is True
+    assert report["fixture_before"]["has_anchor"] is True
+    preview = report["preview"]
+    assert preview["bounds_before"] != preview["bounds_after"]
+    assert all(
+        abs(preview["observed_delta"][axis] - preview["requested_delta"][axis]) <= 1
+        for axis in (0, 1)
+    )
+    patch = report["patch"]
+    assert patch["outside_coordinate_spans_identical"] is True
+    assert patch["matches_independent_expected"] is True
+    assert report["reload"]["status_text"] == "Reload committed"
+    assert all(abs(int(v)) <= 1 for v in report["pixel_agreement"]["delta"])
+    assert report["value_invariance"]["preview"] == report["value_invariance"]["baseline"]
+    assert report["rebinding"]["widget_id"] == "anchor_target"
+    locks = report["locks"]
+    assert locks["computed"] == "XPOS_LITERAL_REQUIRED"
+    assert locks["container"] == "CONTAINER_POSITION_UNSUPPORTED"
+    assert locks["ambiguous"] == "SYNTHETIC_WIDGET_ID"
+    assert locks["unproven"] == "UNKNOWN_ANCESTRY_TYPE"
+    assert report["byte_identical_undo"]["matches_baseline"] is True

--- a/tests/test_editor_coordinator.py
+++ b/tests/test_editor_coordinator.py
@@ -1794,11 +1794,12 @@ def test_analyze_and_commit_textbutton_align_preserves_form(tmp_path: Path) -> N
             assert result["original_position"] == [640, 360]
             assert result["source_key"]["position_mode"] == "align"
             assert result["source_key"]["align_authored"] == [0.5, 0.5]
-            # Commit with intent x = baseline+24 => align x = 0.5 + 24/1280 = 0.51875
+            # extent = parent - widget = 1280-80; delta 24 => +24/1200 = 0.02
+            assert result["source_key"]["align_widget_size"] == [80, 40]
             committed = _commit(sock, auth, analyzed, x=664, y=360, request_id="co-align")
             assert committed["ok"] is True
             text = source.read_text(encoding="utf-8")
-            assert "align (0.51875, 0.5)" in text
+            assert "align (0.52, 0.5)" in text
             assert "xpos" not in text and "ypos" not in text
     finally:
         coordinator.close()

--- a/tests/test_editor_coordinator.py
+++ b/tests/test_editor_coordinator.py
@@ -1754,3 +1754,93 @@ def test_analyze_textbutton_pos_non_literal_stays_locked(tmp_path: Path) -> None
             assert analyzed["result"]["lock_reason"]["code"] == "POS_LITERAL_REQUIRED"
     finally:
         coordinator.close()
+
+
+def test_analyze_and_commit_textbutton_align_preserves_form(tmp_path: Path) -> None:
+    root = tmp_path / "project_align"
+    game_dir = root / "game"
+    game_dir.mkdir(parents=True)
+    source = game_dir / "script.rpy"
+    source.write_text(
+        "screen test_screen:\n"
+        '    textbutton "Play" id "start_btn" align (0.5, 0.5) action NullAction()\n',
+        encoding="utf-8",
+    )
+    project = RenpyProject(root)
+    # Runtime position is center of 1280x720 with default anchor (0,0) => (640, 360)
+    observation = _base_observation(script_generation=12)
+    observation["rect"] = [640, 360, 80, 40]
+    probe = _Probe(
+        observe_reply={
+            **json.loads(json.dumps(observation)),
+            "frame_id": "independent-frame-align",
+            "object_id": "obj-independent-align",
+            "rect": [640, 360, 80, 40],
+        },
+        attest_reply={"ok": True, "state": "all_targets_attested"},
+    )
+    coordinator = EditorCoordinator(project, _make_sdk(tmp_path), attestation_timeout=2.0)
+    coordinator.attach_runtime_probe(probe)
+    endpoint = coordinator.start()
+    try:
+        with socket.create_connection((endpoint.host, endpoint.port), timeout=2.0) as sock:
+            auth = _auth(sock, endpoint)
+            analyzed = _analyze(sock, auth, observation, request_id="an-align")
+            assert analyzed["ok"] is True
+            result = analyzed["result"]
+            assert result["lock_reason"] is None
+            assert result["capabilities"] == {"move": True}
+            # original_position is runtime pixels for align delta formula
+            assert result["original_position"] == [640, 360]
+            assert result["source_key"]["position_mode"] == "align"
+            assert result["source_key"]["align_authored"] == [0.5, 0.5]
+            # Commit with intent x = baseline+24 => align x = 0.5 + 24/1280 = 0.51875
+            committed = _commit(sock, auth, analyzed, x=664, y=360, request_id="co-align")
+            assert committed["ok"] is True
+            text = source.read_text(encoding="utf-8")
+            assert "align (0.51875, 0.5)" in text
+            assert "xpos" not in text and "ypos" not in text
+    finally:
+        coordinator.close()
+
+
+def test_analyze_and_commit_textbutton_anchor_preserves_anchor_bytes(tmp_path: Path) -> None:
+    root = tmp_path / "project_anchor"
+    game_dir = root / "game"
+    game_dir.mkdir(parents=True)
+    source = game_dir / "script.rpy"
+    source.write_text(
+        "screen test_screen:\n"
+        '    textbutton "Play" id "start_btn" xpos 12 ypos 10 '
+        "anchor (0.5, 0.5) action NullAction()\n",
+        encoding="utf-8",
+    )
+    project = RenpyProject(root)
+    observation = _base_observation(script_generation=13)
+    probe = _Probe(
+        observe_reply={
+            **json.loads(json.dumps(observation)),
+            "frame_id": "independent-frame-anchor",
+            "object_id": "obj-independent-anchor",
+        },
+        attest_reply={"ok": True, "state": "all_targets_attested"},
+    )
+    coordinator = EditorCoordinator(project, _make_sdk(tmp_path), attestation_timeout=2.0)
+    coordinator.attach_runtime_probe(probe)
+    endpoint = coordinator.start()
+    try:
+        with socket.create_connection((endpoint.host, endpoint.port), timeout=2.0) as sock:
+            auth = _auth(sock, endpoint)
+            analyzed = _analyze(sock, auth, observation, request_id="an-anchor")
+            assert analyzed["ok"] is True
+            assert analyzed["result"]["lock_reason"] is None
+            committed = _commit(sock, auth, analyzed, x=40, y=50, request_id="co-anchor")
+            assert committed["ok"] is True
+            text = source.read_text(encoding="utf-8")
+            assert text == (
+                "screen test_screen:\n"
+                '    textbutton "Play" id "start_btn" xpos 40 ypos 50 '
+                "anchor (0.5, 0.5) action NullAction()\n"
+            )
+    finally:
+        coordinator.close()

--- a/tests/test_editor_coordinator.py
+++ b/tests/test_editor_coordinator.py
@@ -1767,15 +1767,15 @@ def test_analyze_and_commit_textbutton_align_preserves_form(tmp_path: Path) -> N
         encoding="utf-8",
     )
     project = RenpyProject(root)
-    # Runtime position is center of 1280x720 with default anchor (0,0) => (640, 360)
+    # Ren'Py align also sets anchor: TL = 0.5 * (1280-80, 720-40) = (600, 340).
     observation = _base_observation(script_generation=12)
-    observation["rect"] = [640, 360, 80, 40]
+    observation["rect"] = [600, 340, 80, 40]
     probe = _Probe(
         observe_reply={
             **json.loads(json.dumps(observation)),
             "frame_id": "independent-frame-align",
             "object_id": "obj-independent-align",
-            "rect": [640, 360, 80, 40],
+            "rect": [600, 340, 80, 40],
         },
         attest_reply={"ok": True, "state": "all_targets_attested"},
     )
@@ -1791,16 +1791,53 @@ def test_analyze_and_commit_textbutton_align_preserves_form(tmp_path: Path) -> N
             assert result["lock_reason"] is None
             assert result["capabilities"] == {"move": True}
             # original_position is runtime pixels for align delta formula
-            assert result["original_position"] == [640, 360]
+            assert result["original_position"] == [600, 340]
             assert result["source_key"]["position_mode"] == "align"
             assert result["source_key"]["align_authored"] == [0.5, 0.5]
             # extent = parent - widget = 1280-80; delta 24 => +24/1200 = 0.02
             assert result["source_key"]["align_widget_size"] == [80, 40]
-            committed = _commit(sock, auth, analyzed, x=664, y=360, request_id="co-align")
+            committed = _commit(sock, auth, analyzed, x=624, y=340, request_id="co-align")
             assert committed["ok"] is True
             text = source.read_text(encoding="utf-8")
             assert "align (0.52, 0.5)" in text
             assert "xpos" not in text and "ypos" not in text
+    finally:
+        coordinator.close()
+
+
+def test_analyze_textbutton_align_locks_unproven_parent_geometry(tmp_path: Path) -> None:
+    root = tmp_path / "project_align_parent"
+    game_dir = root / "game"
+    game_dir.mkdir(parents=True)
+    (game_dir / "script.rpy").write_text(
+        "screen test_screen:\n"
+        '    textbutton "Play" id "start_btn" align (0.5, 0.5) action NullAction()\n',
+        encoding="utf-8",
+    )
+    project = RenpyProject(root)
+    # Runtime TL inconsistent with full-screen 1280×720 parent for align 0.5 / 80×40.
+    observation = _base_observation(script_generation=12)
+    observation["rect"] = [100, 100, 80, 40]
+    probe = _Probe(
+        observe_reply={
+            **json.loads(json.dumps(observation)),
+            "frame_id": "independent-frame-align-parent",
+            "object_id": "obj-independent-align-parent",
+            "rect": [100, 100, 80, 40],
+        },
+        attest_reply={"ok": True, "state": "all_targets_attested"},
+    )
+    coordinator = EditorCoordinator(project, _make_sdk(tmp_path), attestation_timeout=2.0)
+    coordinator.attach_runtime_probe(probe)
+    endpoint = coordinator.start()
+    try:
+        with socket.create_connection((endpoint.host, endpoint.port), timeout=2.0) as sock:
+            auth = _auth(sock, endpoint)
+            analyzed = _analyze(sock, auth, observation, request_id="an-align-parent")
+            assert analyzed["ok"] is True
+            result = analyzed["result"]
+            assert result["capabilities"] == {"move": False}
+            assert result["lock_reason"]["code"] == "ALIGN_PARENT_UNPROVEN"
     finally:
         coordinator.close()
 

--- a/tests/test_editor_source.py
+++ b/tests/test_editor_source.py
@@ -1188,3 +1188,69 @@ def test_analyze_button_statement_requires_literal_header_coordinates_and_child_
     with pytest.raises(EditorSourceError) as exc_info:
         analyze_button_statement(without_child, source_line=2, expected_widget_id="button_target")
     assert exc_info.value.code == "BUTTON_BLOCK_REQUIRED"
+
+
+def test_align_pixel_conversion_roundtrip() -> None:
+    from renforge.editor.source import align_to_pixels, pixels_to_align
+
+    assert align_to_pixels(0.0, 0.0) == (0, 0)
+    assert align_to_pixels(0.5, 0.5) == (640, 360)
+    assert align_to_pixels(1.0, 1.0) == (1280, 720)
+    assert pixels_to_align(640, 360) == (0.5, 0.5)
+    px, py = align_to_pixels(0.25, 0.75)
+    assert pixels_to_align(px, py) == (0.25, 0.75)
+
+
+def test_analyze_textbutton_align_accepts_and_patches_form() -> None:
+    line = '    textbutton "Play" id "start" align (0.5, 0.5) action NullAction()\n'
+    parsed = analyze_textbutton_statement(line, expected_widget_id="start")
+    assert parsed.position_mode == "align"
+    assert (parsed.xpos, parsed.ypos) == (0.5, 0.5)
+    patched = apply_textbutton_patch(line.encode("utf-8"), parsed, x=320, y=180).decode("utf-8")
+    assert "align (0.25, 0.25)" in patched
+    assert "xpos" not in patched and "ypos" not in patched
+
+
+def test_analyze_textbutton_align_rejects_impure_and_mixed() -> None:
+    with pytest.raises(EditorSourceError) as excinfo:
+        analyze_textbutton_statement(
+            '    textbutton "Play" id "start" align (0.5, base_y) action NullAction()\n',
+            expected_widget_id="start",
+        )
+    assert excinfo.value.code == "ALIGN_LITERAL_REQUIRED"
+    with pytest.raises(EditorSourceError) as excinfo:
+        analyze_textbutton_statement(
+            '    textbutton "Play" id "start" align (0.5, 0.5) xpos 1 ypos 2 action NullAction()\n',
+            expected_widget_id="start",
+        )
+    assert excinfo.value.code == "POSITION_FORM_MIXED"
+    with pytest.raises(EditorSourceError) as excinfo:
+        analyze_textbutton_statement(
+            '    textbutton "Play" id "start" align (0.5, 0.5) if f else (0, 0) action NullAction()\n',
+            expected_widget_id="start",
+        )
+    assert excinfo.value.code == "ALIGN_LITERAL_REQUIRED"
+
+
+def test_analyze_textbutton_anchor_preserved_with_xy() -> None:
+    line = (
+        '    textbutton "Play" id "start" xpos 200 ypos 180 '
+        "anchor (0.5, 0.5) action NullAction()\n"
+    )
+    parsed = analyze_textbutton_statement(line, expected_widget_id="start")
+    assert parsed.position_mode == "xy"
+    assert parsed.has_anchor is True
+    patched = apply_textbutton_patch(line.encode("utf-8"), parsed, x=240, y=196).decode("utf-8")
+    assert patched == (
+        '    textbutton "Play" id "start" xpos 240 ypos 196 '
+        "anchor (0.5, 0.5) action NullAction()\n"
+    )
+
+
+def test_analyze_textbutton_anchor_rejects_non_literal() -> None:
+    with pytest.raises(EditorSourceError) as excinfo:
+        analyze_textbutton_statement(
+            '    textbutton "Play" id "start" xpos 1 ypos 2 anchor (base, 0.5) action NullAction()\n',
+            expected_widget_id="start",
+        )
+    assert excinfo.value.code == "ANCHOR_LITERAL_REQUIRED"

--- a/tests/test_editor_source.py
+++ b/tests/test_editor_source.py
@@ -1193,12 +1193,14 @@ def test_analyze_button_statement_requires_literal_header_coordinates_and_child_
 def test_align_pixel_conversion_roundtrip() -> None:
     from renforge.editor.source import align_to_pixels, pixels_to_align
 
-    assert align_to_pixels(0.0, 0.0) == (0, 0)
-    assert align_to_pixels(0.5, 0.5) == (640, 360)
-    assert align_to_pixels(1.0, 1.0) == (1280, 720)
-    assert pixels_to_align(640, 360) == (0.5, 0.5)
-    px, py = align_to_pixels(0.25, 0.75)
-    assert pixels_to_align(px, py) == (0.25, 0.75)
+    # Widget 80×40 in parent 1280×720 → extent 1200×680.
+    widget = (80, 40)
+    assert align_to_pixels(0.0, 0.0, widget_size=widget) == (0, 0)
+    assert align_to_pixels(0.5, 0.5, widget_size=widget) == (600, 340)
+    assert align_to_pixels(1.0, 1.0, widget_size=widget) == (1200, 680)
+    assert pixels_to_align(600, 340, widget_size=widget) == (0.5, 0.5)
+    px, py = align_to_pixels(0.25, 0.75, widget_size=widget)
+    assert pixels_to_align(px, py, widget_size=widget) == (0.25, 0.75)
 
 
 def test_analyze_textbutton_align_accepts_and_patches_form() -> None:
@@ -1206,8 +1208,16 @@ def test_analyze_textbutton_align_accepts_and_patches_form() -> None:
     parsed = analyze_textbutton_statement(line, expected_widget_id="start")
     assert parsed.position_mode == "align"
     assert (parsed.xpos, parsed.ypos) == (0.5, 0.5)
-    patched = apply_textbutton_patch(line.encode("utf-8"), parsed, x=320, y=180).decode("utf-8")
-    assert "align (0.25, 0.25)" in patched
+    # Baseline TL for align 0.5 with widget 80×40 is (600, 340); +120 px → 0.6.
+    patched = apply_textbutton_patch(
+        line.encode("utf-8"),
+        parsed,
+        x=720,
+        y=340,
+        align_runtime_baseline=(600, 340),
+        align_widget_size=(80, 40),
+    ).decode("utf-8")
+    assert "align (0.6, 0.5)" in patched
     assert "xpos" not in patched and "ypos" not in patched
 
 
@@ -1230,6 +1240,74 @@ def test_analyze_textbutton_align_rejects_impure_and_mixed() -> None:
             expected_widget_id="start",
         )
     assert excinfo.value.code == "ALIGN_LITERAL_REQUIRED"
+    # Bare / dynamic concurrent properties must not be ignored (Codex P1/P2).
+    with pytest.raises(EditorSourceError) as excinfo:
+        analyze_textbutton_statement(
+            '    textbutton "x" id "w" align (0.2, 0.3) anchor anchor_value action NullAction()\n',
+            expected_widget_id="w",
+        )
+    assert excinfo.value.code == "POSITION_FORM_MIXED"
+    with pytest.raises(EditorSourceError) as excinfo:
+        analyze_textbutton_statement(
+            '    textbutton "x" id "w" xpos 10 ypos 20 align align_value action NullAction()\n',
+            expected_widget_id="w",
+        )
+    assert excinfo.value.code == "POSITION_FORM_MIXED"
+    with pytest.raises(EditorSourceError) as excinfo:
+        analyze_textbutton_statement(
+            '    textbutton "x" id "w" align (0.2, 0.3) xoffset 8 action NullAction()\n',
+            expected_widget_id="w",
+        )
+    assert excinfo.value.code == "POSITION_FORM_MIXED"
+    with pytest.raises(EditorSourceError) as excinfo:
+        analyze_textbutton_statement(
+            '    textbutton "x" id "w" align (0.2, 0.3) xalign 0.9 xanchor 0.4 action NullAction()\n',
+            expected_widget_id="w",
+        )
+    assert excinfo.value.code == "POSITION_FORM_MIXED"
+
+
+def test_apply_textbutton_align_locks_zero_extent_axis() -> None:
+    line = '    textbutton "Play" id "start" align (0.5, 0.5) action NullAction()\n'
+    parsed = analyze_textbutton_statement(line, expected_widget_id="start")
+    # Widget fills parent → extent 0; any non-zero delta must lock.
+    with pytest.raises(EditorSourceError) as excinfo:
+        apply_textbutton_patch(
+            line.encode("utf-8"),
+            parsed,
+            x=1,
+            y=0,
+            align_runtime_baseline=(0, 0),
+            align_widget_size=(1280, 720),
+        )
+    assert excinfo.value.code == "ALIGN_EXTENT_ZERO"
+    # Zero delta keeps authored fractions (no false rewrite to 1.5).
+    patched = apply_textbutton_patch(
+        line.encode("utf-8"),
+        parsed,
+        x=0,
+        y=0,
+        align_runtime_baseline=(0, 0),
+        align_widget_size=(1280, 720),
+    ).decode("utf-8")
+    assert "align (0.5, 0.5)" in patched
+
+
+def test_apply_textbutton_align_requires_proven_geometry() -> None:
+    line = '    textbutton "Play" id "start" align (0.5, 0.5) action NullAction()\n'
+    parsed = analyze_textbutton_statement(line, expected_widget_id="start")
+    with pytest.raises(EditorSourceError) as excinfo:
+        apply_textbutton_patch(line.encode("utf-8"), parsed, x=100, y=100)
+    assert excinfo.value.code == "ALIGN_BASELINE_REQUIRED"
+    with pytest.raises(EditorSourceError) as excinfo:
+        apply_textbutton_patch(
+            line.encode("utf-8"),
+            parsed,
+            x=100,
+            y=100,
+            align_runtime_baseline=(600, 340),
+        )
+    assert excinfo.value.code == "ALIGN_WIDGET_SIZE_REQUIRED"
 
 
 def test_analyze_textbutton_anchor_preserved_with_xy() -> None:

--- a/tests/test_editor_source.py
+++ b/tests/test_editor_source.py
@@ -1254,3 +1254,10 @@ def test_analyze_textbutton_anchor_rejects_non_literal() -> None:
             expected_widget_id="start",
         )
     assert excinfo.value.code == "ANCHOR_LITERAL_REQUIRED"
+    # Bare expression (not a tuple) must not enable moves (Codex P2).
+    with pytest.raises(EditorSourceError) as excinfo:
+        analyze_textbutton_statement(
+            '    textbutton "Play" id "start" xpos 1 ypos 2 anchor anchor_value action NullAction()\n',
+            expected_widget_id="start",
+        )
+    assert excinfo.value.code == "ANCHOR_LITERAL_REQUIRED"


### PR DESCRIPTION
## Summary

Single PR for the next two Stage-2 positioning forms on the proven `textbutton` adapter:

| Issue | Form | Write-back |
|---|---|---|
| **#39** | `align (fx, fy)` | preserves `align`; pixel delta → fraction via parent 1280×720 + measured baseline |
| **#40** | `xpos`/`ypos` + `anchor (fx, fy)` | patches only coordinates; **anchor bytes unchanged** |

### Align (#39)

```renpy
textbutton "MOVE ME" id "align_target" align (0.2, 0.25) action NullAction()
```

- `position_mode == "align"`
- Host stores `align_authored` + `align_runtime_baseline` on `source_key`
- Preview: absolute xpos/ypos overrides (1:1 focus_list)
- Save: `authored + Δpx / parent`
- Attestation tolerance **2 px** for align residual after reload

Live: `RENFORGE_ALIGN_LIVE=1` → **1 passed**

### Anchor (#40)

```renpy
textbutton "MOVE ME" id "anchor_target" xpos 400 ypos 300 anchor (0.5, 0.5) action NullAction()
```

- Pure `anchor (fx, fy)` required when present (`ANCHOR_LITERAL_REQUIRED`)
- Move patches xpos/ypos only; form preserved

Live: `RENFORGE_ANCHOR_LIVE=1` → **1 passed**

## Test plan

- [x] `pytest tests/test_editor_source.py tests/test_editor_coordinator.py` → **111 passed**
- [x] Both live proofs green on Ren'Py **8.5.3**
- [x] Docs updated after live green

## Non-goals

- `offset` (#41)
- align+anchor combined form
- multi-line align/anchor

Closes #39  
Closes #40

## Summary by Sourcery

Préserver les formes d’alignement et de positionnement d’ancrage telles qu’elles ont été rédigées pour les widgets `textbutton` dans l’éditeur visuel, y compris l’analyse, le patch, l’aperçu à l’exécution, l’attestation et la couverture par tests en conditions réelles.

New Features:
- Prendre en charge les instructions `textbutton` rédigées avec des fractions d’alignement littérales (x, y) tout en préservant la forme d’alignement lors de la réécriture.
- Prendre en charge les instructions `textbutton` rédigées avec `xpos`/`ypos` plus un ancrage littéral pur (fx, fy), tout en préservant les octets d’ancrage lors de la réécriture.

Enhancements:
- Étendre l’analyse et le patch des `textbutton` pour suivre le mode de positionnement, les fractions telles qu’elles ont été rédigées, les lignes de base à l’exécution et la présence d’ancrage, afin d’obtenir des conversions pixel-vers-fraction et des aperçus plus précis.
- Ajuster la logique d’aperçu à l’exécution et d’attestation pour gérer les `textbutton` rédigés avec `align` en utilisant des surcharges de pixels absolus avec une tolérance assouplie.
- Ajouter des modules de live runner dédiés et des fixtures pour exercer de bout en bout les formes `textbutton` d’alignement et d’ancrage sur le jeu de démonstration Ren’Py.

Documentation:
- Mettre à jour la documentation de périmètre et de feuille de route de l’éditeur visuel V1 pour décrire le nouveau support des `textbutton` avec alignement et ancrage, ainsi que les flux de preuves en conditions réelles associés.

Tests:
- Ajouter des tests unitaires couvrant les conversions alignement pixel/fraction, l’analyse des `textbutton` avec alignement et ancrage, et le comportement de patch préservant la forme.
- Ajouter des tests d’intégration en conditions réelles pour les scénarios `textbutton` avec alignement et ancrage, contrôlés par les variables d’environnement `RENFORGE_ALIGN_LIVE` et `RENFORGE_ANCHOR_LIVE`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Preserve authored align and anchor positioning forms for textbutton widgets in the visual editor, including analysis, patching, runtime preview, attestation, and live test coverage.

New Features:
- Support textbutton statements authored with literal align (x, y) fractions while preserving the align form on write-back.
- Support textbutton statements authored with xpos/ypos plus pure literal anchor (fx, fy) while preserving the anchor bytes on write-back.

Enhancements:
- Extend textbutton analysis and patching to track position mode, authored fractions, runtime baselines, and anchor presence for more accurate pixel-to-fraction conversions and previews.
- Adjust runtime preview and attestation logic to handle align-authored textbuttons using absolute pixel overrides with relaxed tolerance.
- Add dedicated live runner modules and fixtures to exercise align and anchor textbutton forms end-to-end against the Ren'Py demo game.

Documentation:
- Update visual editor V1 scope and roadmap documentation to describe the new align and anchor textbutton support and associated live proof flows.

Tests:
- Add unit tests covering align pixel/fraction conversions, align and anchor textbutton parsing, and form-preserving patch behaviour.
- Add live integration tests for align and anchor textbutton scenarios gated by RENFORGE_ALIGN_LIVE and RENFORGE_ANCHOR_LIVE environment flags.

</details>