### PR TITLE
feat(editor): preserve textbutton offset form through visual moves

### DIFF
--- a/docs/superpowers/specs/2026-07-30-renforge-visual-editor-v1-scope.md
+++ b/docs/superpowers/specs/2026-07-30-renforge-visual-editor-v1-scope.md
@@ -134,6 +134,21 @@ the anchor point.
 
 Live: `RENFORGE_ANCHOR_LIVE=1 … tests/test_editor_anchor_live.py` on Ren'Py **8.5.3**.
 
+### Literal `offset (x, y)` on textbutton (issue #41)
+
+```renpy
+textbutton "MOVE ME" id "offset_target" offset (200, 180) action NullAction()
+```
+
+Host analysis records `position_mode == "offset"` and stores authored integer offsets plus the
+measured focus baseline. Preview uses absolute xpos/ypos with offset/align/anchor neutralized;
+write-back applies `authored + Δpixel` (offset is additive) and preserves the `offset` form.
+Non-literal pairs, axis-split `xoffset`/`yoffset`, and mixed placement forms are locked
+(`OFFSET_LITERAL_REQUIRED`, `POSITION_FORM_MIXED`, `OFFSET_DUPLICATE`). Attestation requires
+agreement within **1 px**.
+
+Live: `RENFORGE_OFFSET_LIVE=1 … tests/test_editor_offset_live.py` on Ren'Py **8.5.3**.
+
 The `button` adapter is intentionally limited to `button id "..." xpos N ypos N:` headers. Computed
 coordinates, direct child `xpos`/`ypos`, layout-container ancestry, and ambiguous or unproven runtime
 instances remain selectable but locked with an exact reason.

--- a/docs/superpowers/specs/2026-07-30-renforge-visual-editor-vfull-roadmap.md
+++ b/docs/superpowers/specs/2026-07-30-renforge-visual-editor-vfull-roadmap.md
@@ -64,7 +64,7 @@ Real screens are messier.
 | Form | Problem | Possible approach |
 |---|---|---|
 | Multi-line statement with a block | Position keywords may sit on any line of the block | **Partially implemented (issue #37):** multi-line `textbutton` with `id`/`xpos`/`ypos` in the child block only; seven-step live proof green via `RENFORGE_MULTILINE_TEXTBUTTON_LIVE=1`. Other adapters remain single-line or header-only (`button`). |
-| `pos (x, y)` / `align` / `anchor` / `offset` | Different property, same intent | **`pos` (#38)**, **`align` (#39)**, **`anchor` (#40)** implemented for single-line `textbutton`. Write-back preserves form. Lives: `RENFORGE_POS_LIVE=1`, `RENFORGE_ALIGN_LIVE=1`, `RENFORGE_ANCHOR_LIVE=1`. `offset` still pending. |
+| `pos (x, y)` / `align` / `anchor` / `offset` | Different property, same intent | **`pos` (#38)**, **`align` (#39)**, **`anchor` (#40)**, **`offset` (#41)** implemented for single-line `textbutton`. Write-back preserves form. Lives: `RENFORGE_POS_LIVE=1`, `RENFORGE_ALIGN_LIVE=1`, `RENFORGE_ANCHOR_LIVE=1`, `RENFORGE_OFFSET_LIVE=1`. |
 | Position from a **variable or expression** | Cannot be rewritten without changing semantics | **Stays locked.** Offer to show the computed value, never to overwrite the expression |
 | Element inside `hbox` / `vbox` / `grid` | Position is computed by the layout, not authored | **Stays locked** for direct move. A layout-aware edit is a different feature |
 | Multiple instances from one loop / `use` | One source line, N runtime widgets | Needs a disambiguation UI; the stable key already carries `ordinal` |

--- a/src/renforge/bridge/editor.rpy
+++ b/src/renforge/bridge/editor.rpy
@@ -1135,28 +1135,32 @@ init 1100 python:
             next_y = int(source_position[1]) + int(position[1]) - int(runtime_baseline[1])
             source_key = target.get("source_key") or {}
             position_mode = source_key.get("position_mode") if builtins.isinstance(source_key, builtins.dict) else None
-            # Align/offset-authored targets: preview with absolute xpos/ypos so
-            # focus_list tracks the requested pixel delta 1:1. Source write-back
-            # still uses the authored form (host apply converts via baseline).
-            if position_mode in ("align", "offset"):
-                # Absolute placement for preview; neutralize align/anchor/offset so
-                # concurrent axis props cannot stack on top of the requested TL.
-                properties[str(widget_id)] = {
-                    "xpos": next_x,
-                    "ypos": next_y,
-                    "xalign": 0.0,
-                    "yalign": 0.0,
-                    "xanchor": 0.0,
-                    "yanchor": 0.0,
-                    "xoffset": 0,
-                    "yoffset": 0,
-                }
-            else:
-                properties[str(widget_id)] = {
-                    "xpos": next_x,
-                    "ypos": next_y,
-                }
+            properties[str(widget_id)] = _renforge_editor_preview_properties(next_x, next_y, position_mode)
         return properties
+
+
+    def _renforge_editor_preview_properties(next_x, next_y, position_mode):
+        """Build `_widget_properties` overrides for a preview placement.
+
+        Runtime-delta modes (align/offset) use absolute xpos/ypos and neutralize
+        concurrent axis props so focus_list tracks the requested TL 1:1.
+        """
+        # Keep in sync with renforge.editor.source.RUNTIME_DELTA_POSITION_MODES.
+        if position_mode in ("align", "offset"):
+            return {
+                "xpos": next_x,
+                "ypos": next_y,
+                "xalign": 0.0,
+                "yalign": 0.0,
+                "xanchor": 0.0,
+                "yanchor": 0.0,
+                "xoffset": 0,
+                "yoffset": 0,
+            }
+        return {
+            "xpos": next_x,
+            "ypos": next_y,
+        }
 
 
     def _renforge_editor_show_target_overrides(screen):

--- a/src/renforge/bridge/editor.rpy
+++ b/src/renforge/bridge/editor.rpy
@@ -1135,10 +1135,10 @@ init 1100 python:
             next_y = int(source_position[1]) + int(position[1]) - int(runtime_baseline[1])
             source_key = target.get("source_key") or {}
             position_mode = source_key.get("position_mode") if builtins.isinstance(source_key, builtins.dict) else None
-            # Align-authored targets: preview with absolute xpos/ypos so focus_list
-            # tracks the requested pixel delta 1:1. Source write-back still uses
-            # align fractions (host apply converts using the measured baseline).
-            if position_mode == "align":
+            # Align/offset-authored targets: preview with absolute xpos/ypos so
+            # focus_list tracks the requested pixel delta 1:1. Source write-back
+            # still uses the authored form (host apply converts via baseline).
+            if position_mode in ("align", "offset"):
                 # Absolute placement for preview; neutralize align/anchor/offset so
                 # concurrent axis props cannot stack on top of the requested TL.
                 properties[str(widget_id)] = {

--- a/src/renforge/editor/coordinator.py
+++ b/src/renforge/editor/coordinator.py
@@ -559,10 +559,10 @@ class EditorCoordinator:
                     header_line,
                     expected_widget_id=widget_id,
                 )
-            # Align is fractional in source; the editor delta formula works in
-            # logical pixels, so original_position is the measured runtime rect.
+            # Align is fractional and offset is additive; both write via measured
+            # runtime deltas, so original_position is the focus_list top-left.
             position_mode = getattr(statement, "position_mode", "xy")
-            if position_mode == "align":
+            if position_mode in {"align", "offset"}:
                 original_position = list(runtime_position)
             else:
                 original_position = [int(statement.xpos), int(statement.ypos)]
@@ -655,6 +655,16 @@ class EditorCoordinator:
                             "ALIGN_WIDGET_SIZE_UNPROVEN",
                             "independent observation must provide positive widget width and height",
                         )
+            if position_mode == "offset":
+                # Authored offset integers + independent runtime baseline for ΔTL.
+                source_key["offset_authored"] = [
+                    int(statement.xpos),
+                    int(statement.ypos),
+                ]
+                source_key["offset_runtime_baseline"] = [
+                    int(runtime_position[0]),
+                    int(runtime_position[1]),
+                ]
             if lock_reason is None:
                 if observation.get("measurement_method") != "focus_list":
                     lock_reason = self._lock_reason(
@@ -1109,9 +1119,10 @@ class EditorCoordinator:
                     lines[line_no - 1],
                     expected_widget_id=widget_id,
                 )
-                align_baseline = source_key.get("align_runtime_baseline")
-                align_size = source_key.get("align_widget_size")
-                if kind == "textbutton" and getattr(statement, "position_mode", "xy") == "align":
+                mode = getattr(statement, "position_mode", "xy") if kind == "textbutton" else "xy"
+                if kind == "textbutton" and mode == "align":
+                    align_baseline = source_key.get("align_runtime_baseline")
+                    align_size = source_key.get("align_widget_size")
                     lines[line_no - 1] = apply_textbutton_patch(
                         lines[line_no - 1].encode("utf-8"),
                         statement,
@@ -1125,6 +1136,19 @@ class EditorCoordinator:
                         align_widget_size=(
                             tuple(align_size)
                             if isinstance(align_size, (list, tuple)) and len(align_size) == 2
+                            else None
+                        ),
+                    ).decode("utf-8")
+                elif kind == "textbutton" and mode == "offset":
+                    offset_baseline = source_key.get("offset_runtime_baseline")
+                    lines[line_no - 1] = apply_textbutton_patch(
+                        lines[line_no - 1].encode("utf-8"),
+                        statement,
+                        x=x,
+                        y=y,
+                        offset_runtime_baseline=(
+                            tuple(offset_baseline)
+                            if isinstance(offset_baseline, (list, tuple)) and len(offset_baseline) == 2
                             else None
                         ),
                     ).decode("utf-8")

--- a/src/renforge/editor/coordinator.py
+++ b/src/renforge/editor/coordinator.py
@@ -42,6 +42,8 @@ from .source import (
     is_slider_style_bar_line,
     is_textbutton_block_header,
     peek_statement_kind,
+    textbutton_patch_kwargs,
+    uses_runtime_delta_position,
 )
 
 
@@ -559,10 +561,9 @@ class EditorCoordinator:
                     header_line,
                     expected_widget_id=widget_id,
                 )
-            # Align is fractional and offset is additive; both write via measured
-            # runtime deltas, so original_position is the focus_list top-left.
+            # Runtime-delta modes (align/offset): original_position is focus TL.
             position_mode = getattr(statement, "position_mode", "xy")
-            if position_mode in {"align", "offset"}:
+            if uses_runtime_delta_position(position_mode):
                 original_position = list(runtime_position)
             else:
                 original_position = [int(statement.xpos), int(statement.ypos)]
@@ -599,19 +600,20 @@ class EditorCoordinator:
                 "baseline_sha256": source_sha,
                 "position_mode": position_mode,
             }
-            if position_mode == "align":
-                # Authored fractions + independent geometry: Ren'Py align also
-                # sets anchor, so TL moves over (parent − widget) extent.
-                # Parent size is only unlocked when independent focus proves the
-                # full-screen 1280×720 placement model (issue #39).
-                source_key["align_authored"] = [
-                    float(statement.xpos),
-                    float(statement.ypos),
-                ]
-                source_key["align_runtime_baseline"] = [
+            if uses_runtime_delta_position(position_mode):
+                # Shared authored + measured baseline fields for delta write-back.
+                authored = (
+                    [float(statement.xpos), float(statement.ypos)]
+                    if position_mode == "align"
+                    else [int(statement.xpos), int(statement.ypos)]
+                )
+                source_key[f"{position_mode}_authored"] = authored
+                source_key[f"{position_mode}_runtime_baseline"] = [
                     int(runtime_position[0]),
                     int(runtime_position[1]),
                 ]
+            if position_mode == "align":
+                # Align-only geometry gate: parent must prove full-screen 1280×720.
                 parent_size = tuple(
                     getattr(statement, "align_parent_size", DEFAULT_ALIGN_PARENT_SIZE)
                 )
@@ -655,16 +657,6 @@ class EditorCoordinator:
                             "ALIGN_WIDGET_SIZE_UNPROVEN",
                             "independent observation must provide positive widget width and height",
                         )
-            if position_mode == "offset":
-                # Authored offset integers + independent runtime baseline for ΔTL.
-                source_key["offset_authored"] = [
-                    int(statement.xpos),
-                    int(statement.ypos),
-                ]
-                source_key["offset_runtime_baseline"] = [
-                    int(runtime_position[0]),
-                    int(runtime_position[1]),
-                ]
             if lock_reason is None:
                 if observation.get("measurement_method") != "focus_list":
                     lock_reason = self._lock_reason(
@@ -1119,38 +1111,15 @@ class EditorCoordinator:
                     lines[line_no - 1],
                     expected_widget_id=widget_id,
                 )
-                mode = getattr(statement, "position_mode", "xy") if kind == "textbutton" else "xy"
-                if kind == "textbutton" and mode == "align":
-                    align_baseline = source_key.get("align_runtime_baseline")
-                    align_size = source_key.get("align_widget_size")
+                if kind == "textbutton" and uses_runtime_delta_position(
+                    getattr(statement, "position_mode", "xy")
+                ):
                     lines[line_no - 1] = apply_textbutton_patch(
                         lines[line_no - 1].encode("utf-8"),
                         statement,
                         x=x,
                         y=y,
-                        align_runtime_baseline=(
-                            tuple(align_baseline)
-                            if isinstance(align_baseline, (list, tuple)) and len(align_baseline) == 2
-                            else None
-                        ),
-                        align_widget_size=(
-                            tuple(align_size)
-                            if isinstance(align_size, (list, tuple)) and len(align_size) == 2
-                            else None
-                        ),
-                    ).decode("utf-8")
-                elif kind == "textbutton" and mode == "offset":
-                    offset_baseline = source_key.get("offset_runtime_baseline")
-                    lines[line_no - 1] = apply_textbutton_patch(
-                        lines[line_no - 1].encode("utf-8"),
-                        statement,
-                        x=x,
-                        y=y,
-                        offset_runtime_baseline=(
-                            tuple(offset_baseline)
-                            if isinstance(offset_baseline, (list, tuple)) and len(offset_baseline) == 2
-                            else None
-                        ),
+                        **textbutton_patch_kwargs(statement, source_key),
                     ).decode("utf-8")
                 else:
                     lines[line_no - 1] = apply_editable_statement_patch(

--- a/src/renforge/editor/source.py
+++ b/src/renforge/editor/source.py
@@ -17,12 +17,32 @@ class EditorSourceError(ValueError):
 DEFAULT_ALIGN_PARENT_SIZE: tuple[int, int] = (1280, 720)
 
 # Concurrent axis/placement properties that must not ride along with pure align (fx, fy).
-# offset and axis-split forms are out of scope for the align adapter.
 _ALIGN_CONCURRENT_PROPERTY_WORDS = frozenset(
     {
         "xpos",
         "ypos",
         "pos",
+        "offset",
+        "anchor",
+        "xalign",
+        "yalign",
+        "xanchor",
+        "yanchor",
+        "xoffset",
+        "yoffset",
+        "xcenter",
+        "ycenter",
+    }
+)
+
+# Concurrent properties that must not ride along with pure offset (x, y).
+# Axis-split xoffset/yoffset and absolute/relative placement stay locked.
+_OFFSET_CONCURRENT_PROPERTY_WORDS = frozenset(
+    {
+        "xpos",
+        "ypos",
+        "pos",
+        "align",
         "anchor",
         "xalign",
         "yalign",
@@ -60,7 +80,7 @@ _NAME_VALUE_PROPERTY_WORDS = frozenset(
 @dataclass(frozen=True)
 class TextbuttonStatement:
     widget_id: str
-    # Pixel integers for xy/pos; fractional floats for align components.
+    # Pixel integers for xy/pos/offset; fractional floats for align components.
     xpos: int | float
     ypos: int | float
     xpos_span: tuple[int, int]
@@ -69,7 +89,7 @@ class TextbuttonStatement:
     # "block" keeps absolute character spans in the full source file.
     form: str = "single_line"
     source_line: int | None = None
-    # xy | pos | align — write-back preserves the authored form.
+    # xy | pos | align | offset — write-back preserves the authored form.
     position_mode: str = "xy"
     # When True, a pure literal anchor (fx, fy) is present and must be preserved.
     has_anchor: bool = False
@@ -388,6 +408,7 @@ _TEXTBUTTON_PAIR_FOLLOWER_WORDS = frozenset(
         "ypos",
         "pos",
         "align",
+        "offset",
         "anchor",
         "action",
         "style",
@@ -676,17 +697,30 @@ def analyze_textbutton_statement(line: str, *, expected_widget_id: str) -> Textb
     # concurrent or dynamic forms cannot be ignored by the tuple-only scan.
     pos_word_indexes = _top_level_property_keyword_indexes(tokens, "pos")
     align_word_indexes = _top_level_property_keyword_indexes(tokens, "align")
+    offset_word_indexes = _top_level_property_keyword_indexes(tokens, "offset")
 
-    form_count = sum([bool(has_xy), bool(pos_word_indexes), bool(align_word_indexes)])
+    form_count = sum(
+        [
+            bool(has_xy),
+            bool(pos_word_indexes),
+            bool(align_word_indexes),
+            bool(offset_word_indexes),
+        ]
+    )
     if form_count > 1:
         raise EditorSourceError(
             "POSITION_FORM_MIXED",
-            "textbutton cannot mix align/pos/xpos/ypos position forms",
+            "textbutton cannot mix align/pos/offset/xpos/ypos position forms",
         )
     if len(pos_word_indexes) > 1:
         raise EditorSourceError("POS_DUPLICATE", "textbutton statement must contain exactly one pos")
     if len(align_word_indexes) > 1:
         raise EditorSourceError("ALIGN_DUPLICATE", "textbutton statement must contain exactly one align")
+    if len(offset_word_indexes) > 1:
+        raise EditorSourceError(
+            "OFFSET_DUPLICATE",
+            "textbutton statement must contain exactly one offset",
+        )
 
     if len(align_word_indexes) == 1:
         widget_id = _require_single_literal_id(
@@ -761,6 +795,48 @@ def analyze_textbutton_statement(line: str, *, expected_widget_id: str) -> Textb
             source_line=None,
             position_mode="pos",
             has_anchor=has_anchor,
+        )
+
+    if len(offset_word_indexes) == 1:
+        widget_id = _require_single_literal_id(
+            tokens,
+            expected_widget_id=expected_widget_id,
+            human_kind="textbutton",
+        )
+        concurrent = [
+            keyword
+            for keyword in _OFFSET_CONCURRENT_PROPERTY_WORDS
+            if _top_level_property_keyword_indexes(tokens, keyword)
+        ]
+        if concurrent:
+            raise EditorSourceError(
+                "POSITION_FORM_MIXED",
+                "textbutton offset form does not combine with concurrent placement properties",
+            )
+        tuple_indexes = _tuple_property_indexes(tokens, "offset")
+        if not tuple_indexes or tuple_indexes[0] != offset_word_indexes[0]:
+            raise EditorSourceError(
+                "OFFSET_LITERAL_REQUIRED",
+                "offset must be a pure literal pair of integers: offset (x, y)",
+            )
+        # Same integer-pair shape as pos (supports signed NUMBER tokens).
+        parsed_offset = _parse_literal_pos_pair(tokens, tuple_indexes[0])
+        if parsed_offset is None:
+            raise EditorSourceError(
+                "OFFSET_LITERAL_REQUIRED",
+                "offset must be a pure literal pair of integers: offset (x, y)",
+            )
+        ox_value, oy_value, ox_span, oy_span = parsed_offset
+        return TextbuttonStatement(
+            widget_id=widget_id,
+            xpos=ox_value,
+            ypos=oy_value,
+            xpos_span=ox_span,
+            ypos_span=oy_span,
+            form="single_line",
+            source_line=None,
+            position_mode="offset",
+            has_anchor=False,
         )
 
     # xy form (optional pure anchor for issue #40).
@@ -1235,9 +1311,27 @@ def apply_textbutton_patch(
     y: int,
     align_runtime_baseline: tuple[int, int] | list[int] | None = None,
     align_widget_size: tuple[int, int] | list[int] | None = None,
+    offset_runtime_baseline: tuple[int, int] | list[int] | None = None,
 ) -> bytes:
     # Block form spans are absolute in the full source; single-line spans are
     # relative to the single line bytes passed by the coordinator.
+    if statement.position_mode == "offset":
+        # Ren'Py offset is additive on top of the base placement. Commit x/y are
+        # measured runtime top-left; write authored + (runtime − baseline).
+        if offset_runtime_baseline is None or len(offset_runtime_baseline) != 2:
+            raise EditorSourceError(
+                "OFFSET_BASELINE_REQUIRED",
+                "offset write-back requires a measured runtime baseline",
+            )
+        ox = int(statement.xpos) + (int(x) - int(offset_runtime_baseline[0]))
+        oy = int(statement.ypos) + (int(y) - int(offset_runtime_baseline[1]))
+        return _apply_integer_span_patch(
+            source_bytes,
+            xpos_span=statement.xpos_span,
+            ypos_span=statement.ypos_span,
+            x=ox,
+            y=oy,
+        )
     if statement.position_mode == "align":
         # Proven geometry only: measured baseline + widget size are mandatory.
         # Ren'Py ``align (a, b)`` sets anchor to (a, b), so ΔTL = Δalign × (parent − widget).

--- a/src/renforge/editor/source.py
+++ b/src/renforge/editor/source.py
@@ -16,6 +16,47 @@ class EditorSourceError(ValueError):
 # under Ren'Py's align-sets-anchor placement: TL = fraction × (parent − widget).
 DEFAULT_ALIGN_PARENT_SIZE: tuple[int, int] = (1280, 720)
 
+# Modes whose editor original_position is the measured focus_list top-left and whose
+# write-back is authored + (runtime − baseline). Preview uses absolute xpos/ypos.
+RUNTIME_DELTA_POSITION_MODES = frozenset({"align", "offset"})
+
+
+def uses_runtime_delta_position(mode: str | None) -> bool:
+    """True for align/offset — baseline/delta position modes (not absolute xy/pos)."""
+    return mode in RUNTIME_DELTA_POSITION_MODES
+
+
+def _pair2(value: object) -> tuple[int | float, int | float] | None:
+    if isinstance(value, (list, tuple)) and len(value) == 2:
+        return value[0], value[1]  # type: ignore[return-value]
+    return None
+
+
+def textbutton_patch_kwargs(
+    statement: TextbuttonStatement,
+    source_key: dict | None,
+) -> dict[str, object]:
+    """Keyword args for ``apply_textbutton_patch`` from an analyzed source_key.
+
+    Shared by coordinator commit paths so align/offset stay one branch each only
+    where their geometry contracts differ.
+    """
+    mode = getattr(statement, "position_mode", "xy")
+    key = source_key if isinstance(source_key, dict) else {}
+    if mode == "align":
+        baseline = _pair2(key.get("align_runtime_baseline"))
+        size = _pair2(key.get("align_widget_size"))
+        return {
+            "align_runtime_baseline": tuple(baseline) if baseline is not None else None,
+            "align_widget_size": tuple(int(v) for v in size) if size is not None else None,
+        }
+    if mode == "offset":
+        baseline = _pair2(key.get("offset_runtime_baseline"))
+        return {
+            "offset_runtime_baseline": tuple(int(v) for v in baseline) if baseline is not None else None,
+        }
+    return {}
+
 # Concurrent axis/placement properties that must not ride along with pure align (fx, fy).
 _ALIGN_CONCURRENT_PROPERTY_WORDS = frozenset(
     {

--- a/src/renforge/editor_align_runner.py
+++ b/src/renforge/editor_align_runner.py
@@ -1,9 +1,6 @@
 from __future__ import annotations
 
-import hashlib
 import re
-import shutil
-import time
 from pathlib import Path
 from typing import Any
 
@@ -14,89 +11,25 @@ from renforge.editor_task0_runner import (
     _wait_for_status,
 )
 
-FIXTURE_SCREEN = "renforge_editor_align_fixture"
-TARGET_ID = "align_target"
-EDITOR_RESOURCE = Path(__file__).resolve().parent / "bridge" / "editor.rpy"
-FIXTURE_RESOURCE = (
-    Path(__file__).resolve().parents[2]
-    / "tests"
-    / "live_fixtures"
-    / "renforge_editor_align_fixture.rpy"
+from renforge.editor_live_common import (
+    center as _center,
+    inject_editor_live_resources,
+    list_ui_info,
+    observe_selected as _observe_selected,
+    select_lock,
+    sha256_file as _sha256_file,
+    wait_bounds,
 )
 
+FIXTURE_SCREEN = "renforge_editor_align_fixture"
+TARGET_ID = "align_target"
 
 def inject_editor_align_resources(project_root: Path) -> dict[str, str]:
-    game_dir = project_root / "game"
-    game_dir.mkdir(parents=True, exist_ok=True)
-    editor_target = game_dir / "zz_renforge_editor_align.rpy"
-    fixture_target = game_dir / "zz_renforge_editor_align_fixture.rpy"
-    shutil.copyfile(EDITOR_RESOURCE, editor_target)
-    shutil.copyfile(FIXTURE_RESOURCE, fixture_target)
-    return {
-        "editor": str(editor_target),
-        "fixture": str(fixture_target),
-    }
-
-
-def _find_element(
-    elements: list[dict[str, Any]],
-    wanted_id: str,
-    *,
-    wanted_text: str | None = None,
-) -> dict[str, Any]:
-    for element in elements:
-        element_id = str(element.get("id") or "")
-        if wanted_text is not None:
-            if element_id == wanted_id and str(element.get("text") or "") == wanted_text:
-                return element
-            continue
-        if element_id == wanted_id:
-            return element
-    raise AssertionError(
-        f"missing expected element id {wanted_id!r} text {wanted_text!r}: {elements!r}"
+    return inject_editor_live_resources(
+        project_root,
+        editor_basename="editor_align",
+        fixture_filename="renforge_editor_align_fixture.rpy",
     )
-
-
-def _center(bounds: dict[str, Any]) -> tuple[int, int]:
-    return (
-        int(bounds["x"]) + int(bounds["width"]) // 2,
-        int(bounds["y"]) + int(bounds["height"]) // 2,
-    )
-
-
-def _sha256_file(path: Path) -> str:
-    return hashlib.sha256(path.read_bytes()).hexdigest()
-
-
-def _list_info(client: Any) -> dict[str, Any]:
-    info = client.list_ui_elements_info(screen=FIXTURE_SCREEN)
-    if not isinstance(info, dict):
-        raise AssertionError(f"list_ui_elements_info returned non-dict: {info!r}")
-    return info
-
-
-def _wait_bounds(client: Any, widget_id: str, *, timeout: float = 6.0) -> dict[str, int]:
-    deadline = time.monotonic() + timeout
-    last: list[dict[str, Any]] = []
-    while time.monotonic() < deadline:
-        info = _list_info(client)
-        last = info.get("elements") if isinstance(info.get("elements"), list) else []
-        try:
-            element = _find_element(last, widget_id)
-        except AssertionError:
-            time.sleep(0.05)
-            continue
-        bounds = element.get("bounds")
-        if isinstance(bounds, dict):
-            return {
-                "x": int(bounds["x"]),
-                "y": int(bounds["y"]),
-                "width": int(bounds["width"]),
-                "height": int(bounds["height"]),
-            }
-        time.sleep(0.05)
-    raise AssertionError(f"bounds for {widget_id!r} unavailable: {last!r}")
-
 
 def _target_line_with_offset(source_text: str) -> tuple[str, int]:
     offset = 0
@@ -110,7 +43,6 @@ def _target_line_with_offset(source_text: str) -> tuple[str, int]:
             return line, offset
         offset += len(line)
     raise AssertionError(f"source missing align textbutton line for {TARGET_ID!r}")
-
 
 def _independent_expected_after_patch(
     before_text: str,
@@ -158,7 +90,6 @@ def _independent_expected_after_patch(
         raise AssertionError("independent constructor must not introduce xpos/ypos")
     return f"{before_text[:offset]}{patched_line}{before_text[offset + len(line) :]}"
 
-
 def _outside_coordinate_spans_identical(before_text: str, after_text: str) -> bool:
     before_line, _ = _target_line_with_offset(before_text)
     after_line, _ = _target_line_with_offset(after_text)
@@ -178,7 +109,6 @@ def _outside_coordinate_spans_identical(before_text: str, after_text: str) -> bo
         return False
     return before_text.replace(before_line, "", 1) == after_text.replace(after_line, "", 1)
 
-
 def _parse_xy_from_target_line(source_text: str, *, widget_size: tuple[int, int]) -> dict[str, int]:
     """Return pixel position derived from authored align via the conversion contract."""
     line, _ = _target_line_with_offset(source_text)
@@ -192,39 +122,6 @@ def _parse_xy_from_target_line(source_text: str, *, widget_size: tuple[int, int]
         widget_size=widget_size,
     )
     return {"x": px, "y": py}
-
-
-def _select_lock(client: Any, widget_id: str, expected_code: str) -> str:
-    bounds = _wait_bounds(client, widget_id)
-    selection = client.request(
-        "editor_task0_select",
-        {"x": _center(bounds)[0], "y": _center(bounds)[1]},
-    )
-    immediate = selection.get("lock_reason") if isinstance(selection, dict) else None
-    if immediate == expected_code:
-        return expected_code
-    status = _wait_for_status(
-        client,
-        lambda current: current.get("selected_widget_id") == widget_id
-        and current.get("selected_lock_reason") == expected_code,
-        timeout=10.0,
-        poll_name=f"{widget_id} lock",
-    )
-    lock_reason = status.get("selected_lock_reason")
-    if lock_reason != expected_code:
-        raise AssertionError(f"unexpected lock for {widget_id!r}: {status!r}")
-    return str(lock_reason)
-
-
-def _observe_selected(client: Any) -> dict[str, Any]:
-    reply = client.request("editor_task0_observe_selected", {})
-    if not isinstance(reply, dict) or reply.get("ok") is not True:
-        raise AssertionError(f"observe_selected failed: {reply!r}")
-    observation = reply.get("observation")
-    if not isinstance(observation, dict):
-        raise AssertionError(f"observe_selected missing observation: {reply!r}")
-    return observation
-
 
 def run_editor_align_live_scenario(client: Any, *, fixture_path: Path) -> dict[str, Any]:
     """Seven-step live proof for literal align (x, y) textbutton form (issue #39)."""
@@ -251,14 +148,14 @@ def run_editor_align_live_scenario(client: Any, *, fixture_path: Path) -> dict[s
 
     # Lock matrix first on real focusable widgets (measured codes).
     report["locks"] = {
-        "computed": _select_lock(client, "align_computed", "ALIGN_LITERAL_REQUIRED"),
-        "container": _select_lock(client, "align_container", "CONTAINER_POSITION_UNSUPPORTED"),
+        "computed": select_lock(client, "align_computed", "ALIGN_LITERAL_REQUIRED", fixture_screen=FIXTURE_SCREEN),
+        "container": select_lock(client, "align_container", "CONTAINER_POSITION_UNSUPPORTED", fixture_screen=FIXTURE_SCREEN),
     }
 
     # Measured live: two use-statements share id "align_dupe_target". The first
     # instance is still selectable by focus bounds and locks as SYNTHETIC_WIDGET_ID
     # (list_ui may only name the second instance).
-    dupe_info = _list_info(client)
+    dupe_info = list_ui_info(client, FIXTURE_SCREEN)
     dupe_elements = dupe_info.get("elements") if isinstance(dupe_info, dict) else None
     # Prefer the unnamed first instance (NullAction-ish id) then fall back to
     # the named target bounds at the left dupe coordinate.
@@ -298,7 +195,7 @@ def run_editor_align_live_scenario(client: Any, *, fixture_path: Path) -> dict[s
     report["locks"]["ambiguous"] = ambiguous
 
     # Measured live: Side is not in the ancestry allowlist → UNKNOWN_ANCESTRY_TYPE.
-    side_bounds = _wait_bounds(client, "align_side", timeout=3.0)
+    side_bounds = wait_bounds(client, "align_side", timeout=3.0, fixture_screen=FIXTURE_SCREEN)
     side_select = client.request(
         "editor_task0_select",
         {"x": _center(side_bounds)[0], "y": _center(side_bounds)[1]},
@@ -319,7 +216,7 @@ def run_editor_align_live_scenario(client: Any, *, fixture_path: Path) -> dict[s
     report["locks"]["unproven"] = unproven
 
     # Step 1: resolve the editable align textbutton from a fresh focus rect.
-    target_bounds = _wait_bounds(client, TARGET_ID)
+    target_bounds = wait_bounds(client, TARGET_ID, fixture_screen=FIXTURE_SCREEN)
     target_center = _center(target_bounds)
     select = _require_ok(
         client.request(

--- a/src/renforge/editor_anchor_runner.py
+++ b/src/renforge/editor_anchor_runner.py
@@ -1,9 +1,6 @@
 from __future__ import annotations
 
-import hashlib
 import re
-import shutil
-import time
 from pathlib import Path
 from typing import Any
 
@@ -14,89 +11,25 @@ from renforge.editor_task0_runner import (
     _wait_for_status,
 )
 
-FIXTURE_SCREEN = "renforge_editor_anchor_fixture"
-TARGET_ID = "anchor_target"
-EDITOR_RESOURCE = Path(__file__).resolve().parent / "bridge" / "editor.rpy"
-FIXTURE_RESOURCE = (
-    Path(__file__).resolve().parents[2]
-    / "tests"
-    / "live_fixtures"
-    / "renforge_editor_anchor_fixture.rpy"
+from renforge.editor_live_common import (
+    center as _center,
+    inject_editor_live_resources,
+    list_ui_info,
+    observe_selected as _observe_selected,
+    select_lock,
+    sha256_file as _sha256_file,
+    wait_bounds,
 )
 
+FIXTURE_SCREEN = "renforge_editor_anchor_fixture"
+TARGET_ID = "anchor_target"
 
 def inject_editor_anchor_resources(project_root: Path) -> dict[str, str]:
-    game_dir = project_root / "game"
-    game_dir.mkdir(parents=True, exist_ok=True)
-    editor_target = game_dir / "zz_renforge_editor_anchor.rpy"
-    fixture_target = game_dir / "zz_renforge_editor_anchor_fixture.rpy"
-    shutil.copyfile(EDITOR_RESOURCE, editor_target)
-    shutil.copyfile(FIXTURE_RESOURCE, fixture_target)
-    return {
-        "editor": str(editor_target),
-        "fixture": str(fixture_target),
-    }
-
-
-def _find_element(
-    elements: list[dict[str, Any]],
-    wanted_id: str,
-    *,
-    wanted_text: str | None = None,
-) -> dict[str, Any]:
-    for element in elements:
-        element_id = str(element.get("id") or "")
-        if wanted_text is not None:
-            if element_id == wanted_id and str(element.get("text") or "") == wanted_text:
-                return element
-            continue
-        if element_id == wanted_id:
-            return element
-    raise AssertionError(
-        f"missing expected element id {wanted_id!r} text {wanted_text!r}: {elements!r}"
+    return inject_editor_live_resources(
+        project_root,
+        editor_basename="editor_anchor",
+        fixture_filename="renforge_editor_anchor_fixture.rpy",
     )
-
-
-def _center(bounds: dict[str, Any]) -> tuple[int, int]:
-    return (
-        int(bounds["x"]) + int(bounds["width"]) // 2,
-        int(bounds["y"]) + int(bounds["height"]) // 2,
-    )
-
-
-def _sha256_file(path: Path) -> str:
-    return hashlib.sha256(path.read_bytes()).hexdigest()
-
-
-def _list_info(client: Any) -> dict[str, Any]:
-    info = client.list_ui_elements_info(screen=FIXTURE_SCREEN)
-    if not isinstance(info, dict):
-        raise AssertionError(f"list_ui_elements_info returned non-dict: {info!r}")
-    return info
-
-
-def _wait_bounds(client: Any, widget_id: str, *, timeout: float = 6.0) -> dict[str, int]:
-    deadline = time.monotonic() + timeout
-    last: list[dict[str, Any]] = []
-    while time.monotonic() < deadline:
-        info = _list_info(client)
-        last = info.get("elements") if isinstance(info.get("elements"), list) else []
-        try:
-            element = _find_element(last, widget_id)
-        except AssertionError:
-            time.sleep(0.05)
-            continue
-        bounds = element.get("bounds")
-        if isinstance(bounds, dict):
-            return {
-                "x": int(bounds["x"]),
-                "y": int(bounds["y"]),
-                "width": int(bounds["width"]),
-                "height": int(bounds["height"]),
-            }
-        time.sleep(0.05)
-    raise AssertionError(f"bounds for {widget_id!r} unavailable: {last!r}")
-
 
 def _target_line_with_offset(source_text: str) -> tuple[str, int]:
     offset = 0
@@ -111,7 +44,6 @@ def _target_line_with_offset(source_text: str) -> tuple[str, int]:
         offset += len(line)
     raise AssertionError(f"source missing anchor textbutton line for {TARGET_ID!r}")
 
-
 def _independent_expected_after_patch(before_text: str, *, x: int, y: int) -> str:
     """Build expected fixture text without calling apply_textbutton_patch."""
     line, offset = _target_line_with_offset(before_text)
@@ -125,7 +57,6 @@ def _independent_expected_after_patch(before_text: str, *, x: int, y: int) -> st
         raise AssertionError("independent constructor must preserve anchor bytes")
     return f"{before_text[:offset]}{patched_line}{before_text[offset + len(line) :]}"
 
-
 def _outside_coordinate_spans_identical(before_text: str, after_text: str) -> bool:
     before_line, _ = _target_line_with_offset(before_text)
     after_line, _ = _target_line_with_offset(after_text)
@@ -137,7 +68,6 @@ def _outside_coordinate_spans_identical(before_text: str, after_text: str) -> bo
         return False
     return before_text.replace(before_line, "", 1) == after_text.replace(after_line, "", 1)
 
-
 def _parse_xy_from_target_line(source_text: str) -> dict[str, int]:
     line, _ = _target_line_with_offset(source_text)
     xpos = re.search(r"\bxpos\s+(-?\d+)\b", line)
@@ -147,39 +77,6 @@ def _parse_xy_from_target_line(source_text: str) -> dict[str, int]:
     if "anchor (" not in line:
         raise AssertionError(f"target line missing anchor form: {line!r}")
     return {"x": int(xpos.group(1)), "y": int(ypos.group(1))}
-
-
-def _select_lock(client: Any, widget_id: str, expected_code: str) -> str:
-    bounds = _wait_bounds(client, widget_id)
-    selection = client.request(
-        "editor_task0_select",
-        {"x": _center(bounds)[0], "y": _center(bounds)[1]},
-    )
-    immediate = selection.get("lock_reason") if isinstance(selection, dict) else None
-    if immediate == expected_code:
-        return expected_code
-    status = _wait_for_status(
-        client,
-        lambda current: current.get("selected_widget_id") == widget_id
-        and current.get("selected_lock_reason") == expected_code,
-        timeout=10.0,
-        poll_name=f"{widget_id} lock",
-    )
-    lock_reason = status.get("selected_lock_reason")
-    if lock_reason != expected_code:
-        raise AssertionError(f"unexpected lock for {widget_id!r}: {status!r}")
-    return str(lock_reason)
-
-
-def _observe_selected(client: Any) -> dict[str, Any]:
-    reply = client.request("editor_task0_observe_selected", {})
-    if not isinstance(reply, dict) or reply.get("ok") is not True:
-        raise AssertionError(f"observe_selected failed: {reply!r}")
-    observation = reply.get("observation")
-    if not isinstance(observation, dict):
-        raise AssertionError(f"observe_selected missing observation: {reply!r}")
-    return observation
-
 
 def run_editor_anchor_live_scenario(client: Any, *, fixture_path: Path) -> dict[str, Any]:
     """Seven-step live proof for xpos/ypos + anchor textbutton form (issue #40)."""
@@ -208,14 +105,14 @@ def run_editor_anchor_live_scenario(client: Any, *, fixture_path: Path) -> dict[
 
     # Lock matrix first on real focusable widgets (measured codes).
     report["locks"] = {
-        "computed": _select_lock(client, "anchor_computed", "XPOS_LITERAL_REQUIRED"),
-        "container": _select_lock(client, "anchor_container", "CONTAINER_POSITION_UNSUPPORTED"),
+        "computed": select_lock(client, "anchor_computed", "XPOS_LITERAL_REQUIRED", fixture_screen=FIXTURE_SCREEN),
+        "container": select_lock(client, "anchor_container", "CONTAINER_POSITION_UNSUPPORTED", fixture_screen=FIXTURE_SCREEN),
     }
 
     # Measured live: two use-statements share id "anchor_dupe_target". The first
     # instance is still selectable by focus bounds and locks as SYNTHETIC_WIDGET_ID
     # (list_ui may only name the second instance).
-    dupe_info = _list_info(client)
+    dupe_info = list_ui_info(client, FIXTURE_SCREEN)
     dupe_elements = dupe_info.get("elements") if isinstance(dupe_info, dict) else None
     # Prefer the unnamed first instance (NullAction-ish id) then fall back to
     # the named target bounds at the left dupe coordinate.
@@ -255,7 +152,7 @@ def run_editor_anchor_live_scenario(client: Any, *, fixture_path: Path) -> dict[
     report["locks"]["ambiguous"] = ambiguous
 
     # Measured live: Side is not in the ancestry allowlist → UNKNOWN_ANCESTRY_TYPE.
-    side_bounds = _wait_bounds(client, "anchor_side", timeout=3.0)
+    side_bounds = wait_bounds(client, "anchor_side", timeout=3.0, fixture_screen=FIXTURE_SCREEN)
     side_select = client.request(
         "editor_task0_select",
         {"x": _center(side_bounds)[0], "y": _center(side_bounds)[1]},
@@ -276,7 +173,7 @@ def run_editor_anchor_live_scenario(client: Any, *, fixture_path: Path) -> dict[
     report["locks"]["unproven"] = unproven
 
     # Step 1: resolve the editable anchor textbutton from a fresh focus rect.
-    target_bounds = _wait_bounds(client, TARGET_ID)
+    target_bounds = wait_bounds(client, TARGET_ID, fixture_screen=FIXTURE_SCREEN)
     target_center = _center(target_bounds)
     select = _require_ok(
         client.request(

--- a/src/renforge/editor_live_common.py
+++ b/src/renforge/editor_live_common.py
@@ -1,0 +1,168 @@
+"""Shared helpers for Stage-2 visual-editor seven-step live proofs.
+
+Keeps selection, bounds polling, lock checks, and resource injection consistent
+across pos/align/anchor/offset runners without coupling fixture-specific
+source-patch expectations.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import shutil
+import time
+from pathlib import Path
+from typing import Any, Callable
+
+from renforge.editor_task0_runner import _require_ok, _wait_for_status
+
+EDITOR_RESOURCE = Path(__file__).resolve().parent / "bridge" / "editor.rpy"
+LIVE_FIXTURES_DIR = Path(__file__).resolve().parents[2] / "tests" / "live_fixtures"
+
+
+def inject_editor_live_resources(
+    project_root: Path,
+    *,
+    editor_basename: str,
+    fixture_filename: str,
+    fixture_resource: Path | None = None,
+) -> dict[str, str]:
+    """Copy editor.rpy + fixture into ``game/`` under zz_renforge_* names."""
+    game_dir = project_root / "game"
+    game_dir.mkdir(parents=True, exist_ok=True)
+    editor_target = game_dir / f"zz_renforge_{editor_basename}.rpy"
+    fixture_target = game_dir / f"zz_renforge_{editor_basename}_fixture.rpy"
+    fixture_src = fixture_resource or (LIVE_FIXTURES_DIR / fixture_filename)
+    shutil.copyfile(EDITOR_RESOURCE, editor_target)
+    shutil.copyfile(fixture_src, fixture_target)
+    return {
+        "editor": str(editor_target),
+        "fixture": str(fixture_target),
+    }
+
+
+def find_element(
+    elements: list[dict[str, Any]],
+    wanted_id: str,
+    *,
+    wanted_text: str | None = None,
+) -> dict[str, Any]:
+    for element in elements:
+        element_id = str(element.get("id") or "")
+        if wanted_text is not None:
+            if element_id == wanted_id and str(element.get("text") or "") == wanted_text:
+                return element
+            continue
+        if element_id == wanted_id:
+            return element
+    raise AssertionError(
+        f"missing expected element id {wanted_id!r} text {wanted_text!r}: {elements!r}"
+    )
+
+
+def center(bounds: dict[str, Any]) -> tuple[int, int]:
+    return (
+        int(bounds["x"]) + int(bounds["width"]) // 2,
+        int(bounds["y"]) + int(bounds["height"]) // 2,
+    )
+
+
+def sha256_file(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def list_ui_info(client: Any, fixture_screen: str) -> dict[str, Any]:
+    info = client.list_ui_elements_info(screen=fixture_screen)
+    if not isinstance(info, dict):
+        raise AssertionError(f"list_ui_elements_info returned non-dict: {info!r}")
+    return info
+
+
+def wait_bounds(
+    client: Any,
+    widget_id: str,
+    *,
+    fixture_screen: str,
+    timeout: float = 6.0,
+) -> dict[str, int]:
+    deadline = time.monotonic() + timeout
+    last: list[dict[str, Any]] = []
+    while time.monotonic() < deadline:
+        info = list_ui_info(client, fixture_screen)
+        last = info.get("elements") if isinstance(info.get("elements"), list) else []
+        try:
+            element = find_element(last, widget_id)
+        except AssertionError:
+            time.sleep(0.05)
+            continue
+        bounds = element.get("bounds")
+        if isinstance(bounds, dict):
+            return {
+                "x": int(bounds["x"]),
+                "y": int(bounds["y"]),
+                "width": int(bounds["width"]),
+                "height": int(bounds["height"]),
+            }
+        time.sleep(0.05)
+    raise AssertionError(f"bounds for {widget_id!r} unavailable: {last!r}")
+
+
+def select_lock(
+    client: Any,
+    widget_id: str,
+    expected_code: str,
+    *,
+    fixture_screen: str,
+) -> str:
+    bounds = wait_bounds(client, widget_id, fixture_screen=fixture_screen)
+    selection = client.request(
+        "editor_task0_select",
+        {"x": center(bounds)[0], "y": center(bounds)[1]},
+    )
+    immediate = selection.get("lock_reason") if isinstance(selection, dict) else None
+    if immediate == expected_code:
+        return expected_code
+    status = _wait_for_status(
+        client,
+        lambda current: current.get("selected_widget_id") == widget_id
+        and current.get("selected_lock_reason") == expected_code,
+        timeout=10.0,
+        poll_name=f"{widget_id} lock",
+    )
+    lock_reason = status.get("selected_lock_reason")
+    if lock_reason != expected_code:
+        raise AssertionError(f"unexpected lock for {widget_id!r}: {status!r}")
+    return str(lock_reason)
+
+
+def observe_selected(client: Any) -> dict[str, Any]:
+    reply = client.request("editor_task0_observe_selected", {})
+    if not isinstance(reply, dict) or reply.get("ok") is not True:
+        raise AssertionError(f"observe_selected failed: {reply!r}")
+    observation = reply.get("observation")
+    if not isinstance(observation, dict):
+        raise AssertionError(f"observe_selected missing observation: {reply!r}")
+    return observation
+
+
+def find_target_line(
+    source_text: str,
+    *,
+    target_id: str,
+    form_token: str,
+    analyze: Callable[[str], Any],
+) -> tuple[str, int]:
+    """Return (line, byte_offset) for the single-line textbutton target."""
+    offset = 0
+    needle = f" {form_token} "
+    for line in source_text.splitlines(keepends=True):
+        if (
+            f'id "{target_id}"' in line
+            and line.lstrip().startswith("textbutton ")
+            and needle in f" {line}"
+        ):
+            analyze(line)
+            return line, offset
+        offset += len(line)
+    raise AssertionError(
+        f"source missing {form_token} textbutton line for {target_id!r}"
+    )

--- a/src/renforge/editor_offset_runner.py
+++ b/src/renforge/editor_offset_runner.py
@@ -1,0 +1,545 @@
+from __future__ import annotations
+
+import hashlib
+import re
+import shutil
+import time
+from pathlib import Path
+from typing import Any
+
+from renforge.editor.source import analyze_textbutton_statement
+from renforge.editor_task0_runner import (
+    _require_ok,
+    _source_generation,
+    _wait_for_status,
+)
+
+FIXTURE_SCREEN = "renforge_editor_offset_fixture"
+TARGET_ID = "offset_target"
+EDITOR_RESOURCE = Path(__file__).resolve().parent / "bridge" / "editor.rpy"
+FIXTURE_RESOURCE = (
+    Path(__file__).resolve().parents[2]
+    / "tests"
+    / "live_fixtures"
+    / "renforge_editor_offset_fixture.rpy"
+)
+
+
+def inject_editor_offset_resources(project_root: Path) -> dict[str, str]:
+    game_dir = project_root / "game"
+    game_dir.mkdir(parents=True, exist_ok=True)
+    editor_target = game_dir / "zz_renforge_editor_offset.rpy"
+    fixture_target = game_dir / "zz_renforge_editor_offset_fixture.rpy"
+    shutil.copyfile(EDITOR_RESOURCE, editor_target)
+    shutil.copyfile(FIXTURE_RESOURCE, fixture_target)
+    return {
+        "editor": str(editor_target),
+        "fixture": str(fixture_target),
+    }
+
+
+def _find_element(
+    elements: list[dict[str, Any]],
+    wanted_id: str,
+    *,
+    wanted_text: str | None = None,
+) -> dict[str, Any]:
+    for element in elements:
+        element_id = str(element.get("id") or "")
+        if wanted_text is not None:
+            if element_id == wanted_id and str(element.get("text") or "") == wanted_text:
+                return element
+            continue
+        if element_id == wanted_id:
+            return element
+    raise AssertionError(
+        f"missing expected element id {wanted_id!r} text {wanted_text!r}: {elements!r}"
+    )
+
+
+def _center(bounds: dict[str, Any]) -> tuple[int, int]:
+    return (
+        int(bounds["x"]) + int(bounds["width"]) // 2,
+        int(bounds["y"]) + int(bounds["height"]) // 2,
+    )
+
+
+def _sha256_file(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _list_info(client: Any) -> dict[str, Any]:
+    info = client.list_ui_elements_info(screen=FIXTURE_SCREEN)
+    if not isinstance(info, dict):
+        raise AssertionError(f"list_ui_elements_info returned non-dict: {info!r}")
+    return info
+
+
+def _wait_bounds(client: Any, widget_id: str, *, timeout: float = 6.0) -> dict[str, int]:
+    deadline = time.monotonic() + timeout
+    last: list[dict[str, Any]] = []
+    while time.monotonic() < deadline:
+        info = _list_info(client)
+        last = info.get("elements") if isinstance(info.get("elements"), list) else []
+        try:
+            element = _find_element(last, widget_id)
+        except AssertionError:
+            time.sleep(0.05)
+            continue
+        bounds = element.get("bounds")
+        if isinstance(bounds, dict):
+            return {
+                "x": int(bounds["x"]),
+                "y": int(bounds["y"]),
+                "width": int(bounds["width"]),
+                "height": int(bounds["height"]),
+            }
+        time.sleep(0.05)
+    raise AssertionError(f"bounds for {widget_id!r} unavailable: {last!r}")
+
+
+def _target_line_with_offset(source_text: str) -> tuple[str, int]:
+    offset = 0
+    for line in source_text.splitlines(keepends=True):
+        if (
+            f'id "{TARGET_ID}"' in line
+            and line.lstrip().startswith("textbutton ")
+            and " offset " in f" {line}"
+        ):
+            analyze_textbutton_statement(line, expected_widget_id=TARGET_ID)
+            return line, offset
+        offset += len(line)
+    raise AssertionError(f"source missing offset textbutton line for {TARGET_ID!r}")
+
+
+def _independent_expected_after_patch(
+    before_text: str,
+    *,
+    x: int,
+    y: int,
+    baseline: dict[str, int],
+) -> str:
+    """Build expected offset source via authored + (runtime − baseline)."""
+    line, file_offset = _target_line_with_offset(before_text)
+    parsed = analyze_textbutton_statement(line, expected_widget_id=TARGET_ID)
+    ox = int(parsed.xpos) + (int(x) - int(baseline["x"]))
+    oy = int(parsed.ypos) + (int(y) - int(baseline["y"]))
+    patched_line = re.sub(
+        r"(\boffset\s*\(\s*)-?\d+(\s*,\s*)-?\d+(\s*\))",
+        rf"\g<1>{ox}\g<2>{oy}\3",
+        line,
+        count=1,
+    )
+    if patched_line == line:
+        raise AssertionError("independent patch constructor did not change target offset pair")
+    if "xpos" in patched_line or "ypos" in patched_line:
+        raise AssertionError("independent constructor must not introduce xpos/ypos")
+    return f"{before_text[:file_offset]}{patched_line}{before_text[file_offset + len(line) :]}"
+
+
+def _outside_coordinate_spans_identical(before_text: str, after_text: str) -> bool:
+    before_line, _ = _target_line_with_offset(before_text)
+    after_line, _ = _target_line_with_offset(after_text)
+    before_norm = re.sub(
+        r"(\boffset\s*\(\s*)-?\d+(\s*,\s*)-?\d+(\s*\))",
+        r"\1__X__\2__Y__\3",
+        before_line,
+        count=1,
+    )
+    after_norm = re.sub(
+        r"(\boffset\s*\(\s*)-?\d+(\s*,\s*)-?\d+(\s*\))",
+        r"\1__X__\2__Y__\3",
+        after_line,
+        count=1,
+    )
+    if before_norm != after_norm:
+        return False
+    return before_text.replace(before_line, "", 1) == after_text.replace(after_line, "", 1)
+
+
+def _parse_xy_from_target_line(source_text: str) -> dict[str, int]:
+    line, _ = _target_line_with_offset(source_text)
+    match = re.search(r"\boffset\s*\(\s*(-?\d+)\s*,\s*(-?\d+)\s*\)", line)
+    if match is None:
+        raise AssertionError(f"target line missing literal offset pair: {line!r}")
+    return {"x": int(match.group(1)), "y": int(match.group(2))}
+
+
+def _select_lock(client: Any, widget_id: str, expected_code: str) -> str:
+    bounds = _wait_bounds(client, widget_id)
+    selection = client.request(
+        "editor_task0_select",
+        {"x": _center(bounds)[0], "y": _center(bounds)[1]},
+    )
+    immediate = selection.get("lock_reason") if isinstance(selection, dict) else None
+    if immediate == expected_code:
+        return expected_code
+    status = _wait_for_status(
+        client,
+        lambda current: current.get("selected_widget_id") == widget_id
+        and current.get("selected_lock_reason") == expected_code,
+        timeout=10.0,
+        poll_name=f"{widget_id} lock",
+    )
+    lock_reason = status.get("selected_lock_reason")
+    if lock_reason != expected_code:
+        raise AssertionError(f"unexpected lock for {widget_id!r}: {status!r}")
+    return str(lock_reason)
+
+
+def _observe_selected(client: Any) -> dict[str, Any]:
+    reply = client.request("editor_task0_observe_selected", {})
+    if not isinstance(reply, dict) or reply.get("ok") is not True:
+        raise AssertionError(f"observe_selected failed: {reply!r}")
+    observation = reply.get("observation")
+    if not isinstance(observation, dict):
+        raise AssertionError(f"observe_selected missing observation: {reply!r}")
+    return observation
+
+
+def run_editor_offset_live_scenario(client: Any, *, fixture_path: Path) -> dict[str, Any]:
+    """Seven-step live proof for literal offset (x, y) textbutton form (issue #41)."""
+    report: dict[str, Any] = {}
+    baseline_bytes = fixture_path.read_bytes()
+    baseline_sha = _sha256_file(fixture_path)
+    baseline_text = baseline_bytes.decode("utf-8")
+    # Prove analyzer accepts the authored offset form before any UI work.
+    target_line, _ = _target_line_with_offset(baseline_text)
+    parsed = analyze_textbutton_statement(target_line, expected_widget_id=TARGET_ID)
+    if parsed.position_mode != "offset":
+        raise AssertionError(f"expected position_mode offset, got {parsed.position_mode!r}")
+    baseline_position = _parse_xy_from_target_line(baseline_text)
+    report["fixture_before"] = {
+        "sha256": baseline_sha,
+        "position": baseline_position,
+        "position_mode": parsed.position_mode,
+    }
+
+    start = _require_ok(
+        client.request("editor_task0_start", {"screen": FIXTURE_SCREEN}),
+        "editor_task0_start",
+    )
+    report["start"] = start
+
+    # Lock matrix first on real focusable widgets (measured codes).
+    report["locks"] = {
+        "computed": _select_lock(client, "offset_computed", "OFFSET_LITERAL_REQUIRED"),
+        "container": _select_lock(client, "offset_container", "CONTAINER_POSITION_UNSUPPORTED"),
+    }
+
+    # Measured live: two use-statements share id "offset_dupe_target". The first
+    # instance is still selectable by focus bounds and locks as SYNTHETIC_WIDGET_ID
+    # (list_ui may only name the second instance).
+    dupe_info = _list_info(client)
+    dupe_elements = dupe_info.get("elements") if isinstance(dupe_info, dict) else None
+    # Prefer the unnamed first instance (NullAction-ish id) then fall back to
+    # the named target bounds at the left dupe coordinate.
+    dupe_pick = None
+    for element in dupe_elements if isinstance(dupe_elements, list) else []:
+        bounds = element.get("bounds")
+        if not isinstance(bounds, dict):
+            continue
+        text = str(element.get("text") or "")
+        if text == "DUPE A" or (
+            int(bounds.get("x", -1)) == 520 and int(bounds.get("y", -1)) == 430
+        ):
+            dupe_pick = bounds
+            break
+    if dupe_pick is None:
+        raise AssertionError(f"could not locate first dupe bounds: {dupe_elements!r}")
+    dupe_select = client.request(
+        "editor_task0_select",
+        {
+            "x": int(dupe_pick["x"]) + max(2, int(dupe_pick["width"]) // 4),
+            "y": int(dupe_pick["y"]) + int(dupe_pick["height"]) // 2,
+        },
+    )
+    ambiguous = dupe_select.get("lock_reason") if isinstance(dupe_select, dict) else None
+    if ambiguous in (None, ""):
+        status = _wait_for_status(
+            client,
+            lambda current: current.get("selected_lock_reason") == "SYNTHETIC_WIDGET_ID",
+            timeout=10.0,
+            poll_name="offset dupe lock",
+        )
+        ambiguous = status.get("selected_lock_reason")
+    if ambiguous != "SYNTHETIC_WIDGET_ID":
+        raise AssertionError(
+            f"duplicate offset textbutton lock was not SYNTHETIC_WIDGET_ID: {ambiguous!r}"
+        )
+    report["locks"]["ambiguous"] = ambiguous
+
+    # Measured live: Side is not in the ancestry allowlist → UNKNOWN_ANCESTRY_TYPE.
+    side_bounds = _wait_bounds(client, "offset_side", timeout=3.0)
+    side_select = client.request(
+        "editor_task0_select",
+        {"x": _center(side_bounds)[0], "y": _center(side_bounds)[1]},
+    )
+    unproven = side_select.get("lock_reason") if isinstance(side_select, dict) else None
+    if unproven in (None, ""):
+        status = _wait_for_status(
+            client,
+            lambda current: current.get("selected_lock_reason") == "UNKNOWN_ANCESTRY_TYPE",
+            timeout=10.0,
+            poll_name="offset side lock",
+        )
+        unproven = status.get("selected_lock_reason")
+    if unproven != "UNKNOWN_ANCESTRY_TYPE":
+        raise AssertionError(
+            f"side-ancestor offset textbutton lock was not UNKNOWN_ANCESTRY_TYPE: {unproven!r}"
+        )
+    report["locks"]["unproven"] = unproven
+
+    # Step 1: resolve the editable offset textbutton from a fresh focus rect.
+    target_bounds = _wait_bounds(client, TARGET_ID)
+    target_center = _center(target_bounds)
+    select = _require_ok(
+        client.request(
+            "editor_task0_select",
+            {"x": target_center[0], "y": target_center[1]},
+        ),
+        "target select",
+    )
+    observation = select.get("observation") or {}
+    if observation.get("measurement_method") != "focus_list":
+        raise AssertionError(f"select observation not focus_list: {observation!r}")
+
+    analysis_status = _wait_for_status(
+        client,
+        lambda status: bool(status.get("current_analysis_id"))
+        and status.get("selected_widget_id") == TARGET_ID
+        and status.get("selected_lock_reason") in (None, ""),
+        timeout=10.0,
+        poll_name="offset analysis",
+    )
+    source_key = analysis_status.get("current_source_key") or {}
+    capabilities = analysis_status.get("current_capabilities") or {}
+    host_move = capabilities.get("move")
+    report["resolve"] = {
+        "statement_kind": source_key.get("statement_kind"),
+        "lock_reason": analysis_status.get("selected_lock_reason"),
+        "move": host_move,
+        "analysis_id": analysis_status.get("current_analysis_id"),
+        "measurement_method": observation.get("measurement_method"),
+        "frame_id": observation.get("frame_id"),
+        "source_key": source_key,
+    }
+    if source_key.get("statement_kind") != "textbutton":
+        raise AssertionError(f"expected textbutton statement_kind: {source_key!r}")
+    if host_move is not True:
+        raise AssertionError(f"host did not unlock move for offset textbutton: {analysis_status!r}")
+
+    original = analysis_status.get("selected_original_position") or analysis_status.get(
+        "selected_source_position"
+    )
+    if not (isinstance(original, (list, tuple)) and len(original) == 2):
+        original = [int(baseline_position["x"]), int(baseline_position["y"])]
+    requested_before = [int(original[0]), int(original[1])]
+
+    # Fresh focus_list observation before preview movement.
+    value_baseline = client.eval_expr("renforge_editor_offset_clicks")
+    before_obs = _observe_selected(client)
+    before_rect = before_obs.get("rect") or []
+    if len(before_rect) < 2:
+        raise AssertionError(f"pre-preview observation missing rect: {before_obs!r}")
+    bounds_before = [int(before_rect[0]), int(before_rect[1])]
+    frame_before = before_obs.get("frame_id")
+
+    # Step 2: preview.
+    _require_ok(client.request("editor_task0_key", {"key": "right", "repeat": 24}), "nudge right")
+    _require_ok(client.request("editor_task0_key", {"key": "down", "repeat": 16}), "nudge down")
+    preview_status = _wait_for_status(
+        client,
+        lambda status: isinstance(status.get("preview_position"), (list, tuple))
+        and len(status.get("preview_position") or []) == 2
+        and list(status.get("preview_position") or []) != requested_before,
+        timeout=8.0,
+        poll_name="offset preview moved",
+    )
+    requested_after = [
+        int(preview_status["preview_position"][0]),
+        int(preview_status["preview_position"][1]),
+    ]
+    after_obs = _observe_selected(client)
+    value_preview = client.eval_expr("renforge_editor_offset_clicks")
+    after_rect = after_obs.get("rect") or []
+    if len(after_rect) < 2:
+        raise AssertionError(f"post-preview observation missing rect: {after_obs!r}")
+    bounds_after = [int(after_rect[0]), int(after_rect[1])]
+    frame_after = after_obs.get("frame_id")
+    if not frame_before or not frame_after or frame_before == frame_after:
+        raise AssertionError(
+            f"preview observations must have distinct real frame_ids: "
+            f"before={frame_before!r}, after={frame_after!r}"
+        )
+    if before_obs.get("measurement_method") != "focus_list" or after_obs.get("measurement_method") != "focus_list":
+        raise AssertionError(
+            "preview observations must report measurement_method from bridge: "
+            f"before={before_obs.get('measurement_method')!r}, after={after_obs.get('measurement_method')!r}"
+        )
+    requested_delta = [requested_after[axis] - requested_before[axis] for axis in (0, 1)]
+    observed_delta = [bounds_after[axis] - bounds_before[axis] for axis in (0, 1)]
+    if any(abs(observed_delta[axis] - requested_delta[axis]) > 1 for axis in (0, 1)):
+        raise AssertionError(
+            "focus_list preview bounds disagree with requested movement: "
+            f"requested={requested_delta!r}, observed={observed_delta!r}"
+        )
+    report["preview"] = {
+        "bounds_before": bounds_before,
+        "bounds_after": bounds_after,
+        "requested_before": requested_before,
+        "requested_after": requested_after,
+        "requested_delta": requested_delta,
+        "observed_delta": observed_delta,
+        "measurement_method_before": before_obs.get("measurement_method"),
+        "measurement_method_after": after_obs.get("measurement_method"),
+        "measurement_method": after_obs.get("measurement_method"),
+        "frame_id_before": frame_before,
+        "frame_id_after": frame_after,
+    }
+
+    # Step 3: patch via real Save overlay control.
+    pre_save_bytes = fixture_path.read_bytes()
+    pre_save_sha = _sha256_file(fixture_path)
+    pre_save_text = pre_save_bytes.decode("utf-8")
+    generation_before = _source_generation(analysis_status)
+    save_request = _require_ok(
+        client.click_element(id="rf_save", screen="_renforge_editor_overlay"),
+        "offset save",
+    )
+    save_status = _wait_for_status(
+        client,
+        lambda status: not bool(status.get("save_in_progress"))
+        and status.get("status_text") == "Reload committed"
+        and _source_generation(status) == generation_before + 1,
+        timeout=60.0,
+        poll_name="offset save complete",
+    )
+    post_save_bytes = fixture_path.read_bytes()
+    post_save_sha = _sha256_file(fixture_path)
+    post_save_text = post_save_bytes.decode("utf-8")
+    source_position_after = _parse_xy_from_target_line(post_save_text)
+    authored_before = _parse_xy_from_target_line(pre_save_text)
+    expected_source_position = {
+        "x": int(authored_before["x"]) + (requested_after[0] - bounds_before[0]),
+        "y": int(authored_before["y"]) + (requested_after[1] - bounds_before[1]),
+    }
+    if source_position_after != expected_source_position:
+        raise AssertionError(
+            "source offset disagrees with authored + runtime delta: "
+            f"expected={expected_source_position!r}, observed={source_position_after!r}"
+        )
+    expected_text = _independent_expected_after_patch(
+        pre_save_text,
+        x=requested_after[0],
+        y=requested_after[1],
+        baseline={"x": bounds_before[0], "y": bounds_before[1]},
+    )
+    if post_save_text != expected_text:
+        raise AssertionError("patched fixture bytes disagree with independent expected content")
+    outside_coordinate_spans_identical = _outside_coordinate_spans_identical(
+        pre_save_text,
+        post_save_text,
+    )
+    if not outside_coordinate_spans_identical:
+        raise AssertionError("source patch changed bytes outside offset spans")
+    report["patch"] = {
+        "before_sha256": pre_save_sha,
+        "after_sha256": post_save_sha,
+        "source_position_after": source_position_after,
+        "expected_source_position": expected_source_position,
+        "outside_coordinate_spans_identical": outside_coordinate_spans_identical,
+        "matches_independent_expected": True,
+        "save_request": save_request,
+    }
+
+    # Step 4: reload publication cycle (frame_id filled after rebind observation).
+    report["reload"] = {
+        "ok": True,
+        "script_generation": _source_generation(save_status),
+        "status_text": save_status.get("status_text"),
+        "generation_delta": _source_generation(save_status) - generation_before,
+        "pending_handshake_sent": save_status.get("pending_handshake_sent"),
+        "frame_id": None,
+    }
+
+    # Step 5: pixel agreement between post-preview focus rect and post-reload focus rect.
+    successor = _wait_for_status(
+        client,
+        lambda status: bool(status.get("current_analysis_id"))
+        and status.get("selected_widget_id") == TARGET_ID
+        and status.get("selected_lock_reason") in (None, ""),
+        timeout=10.0,
+        poll_name="offset post-save rebind analysis",
+    )
+    reload_obs = _observe_selected(client)
+    value_reload = client.eval_expr("renforge_editor_offset_clicks")
+    reload_rect = reload_obs.get("rect") or []
+    if len(reload_rect) < 2:
+        raise AssertionError(f"post-reload observation missing rect: {reload_obs!r}")
+    reload_bounds = [int(reload_rect[0]), int(reload_rect[1])]
+    pixel_delta = [
+        reload_bounds[0] - bounds_after[0],
+        reload_bounds[1] - bounds_after[1],
+    ]
+    if any(abs(value) > 1 for value in pixel_delta):
+        raise AssertionError(
+            "post-reload focus rect disagrees with post-preview focus rect: "
+            f"preview={bounds_after!r}, reload={reload_bounds!r}, delta={pixel_delta!r}"
+        )
+    report["pixel_agreement"] = {
+        "preview_after": bounds_after,
+        "reload_after": reload_bounds,
+        "delta": pixel_delta,
+        "measurement_method": reload_obs.get("measurement_method"),
+        "measurement_method_preview": after_obs.get("measurement_method"),
+        "measurement_method_reload": reload_obs.get("measurement_method"),
+        "frame_id_preview": frame_after,
+        "frame_id_reload": reload_obs.get("frame_id"),
+    }
+    reload_frame = reload_obs.get("frame_id")
+    if not reload_frame or reload_frame == frame_after:
+        raise AssertionError(
+            f"reload observation must have a distinct real frame_id: "
+            f"preview={frame_after!r}, reload={reload_frame!r}"
+        )
+    report["value_invariance"] = {
+        "baseline": value_baseline,
+        "preview": value_preview,
+        "reload": value_reload,
+    }
+    if value_preview != value_baseline or value_reload != value_baseline:
+        raise AssertionError(
+            "textbutton click counter changed during preview/reload: "
+            f"baseline={value_baseline!r}, preview={value_preview!r}, reload={value_reload!r}"
+        )
+    report["reload"]["frame_id"] = reload_obs.get("frame_id")
+
+    # Step 6: rebinding.
+    report["rebinding"] = {
+        "ok": successor.get("selected_widget_id") == TARGET_ID
+        and successor.get("current_analysis_id")
+        not in (None, analysis_status.get("current_analysis_id"))
+        and (successor.get("current_source_key") or {}).get("statement_kind") == "textbutton",
+        "widget_id": successor.get("selected_widget_id"),
+        "analysis_id": successor.get("current_analysis_id"),
+        "previous_analysis_id": analysis_status.get("current_analysis_id"),
+        "source_key": successor.get("current_source_key"),
+        "lock_reason": successor.get("selected_lock_reason"),
+    }
+    if report["rebinding"]["ok"] is not True:
+        raise AssertionError(f"rebinding failed: {report['rebinding']!r}")
+
+    # Step 7: byte-identical undo of the temporary fixture.
+    fixture_path.write_bytes(baseline_bytes)
+    restored_bytes = fixture_path.read_bytes()
+    restored_sha = _sha256_file(fixture_path)
+    report["byte_identical_undo"] = {
+        "baseline_sha256": baseline_sha,
+        "restored_sha256": restored_sha,
+        "matches_baseline": restored_sha == baseline_sha and restored_bytes == baseline_bytes,
+        "patched_differed": post_save_sha != baseline_sha and post_save_bytes != baseline_bytes,
+    }
+    if restored_bytes != baseline_bytes:
+        raise AssertionError("offset textbutton undo did not restore the baseline")
+    return report

--- a/src/renforge/editor_offset_runner.py
+++ b/src/renforge/editor_offset_runner.py
@@ -1,9 +1,6 @@
 from __future__ import annotations
 
-import hashlib
 import re
-import shutil
-import time
 from pathlib import Path
 from typing import Any
 
@@ -14,89 +11,25 @@ from renforge.editor_task0_runner import (
     _wait_for_status,
 )
 
-FIXTURE_SCREEN = "renforge_editor_offset_fixture"
-TARGET_ID = "offset_target"
-EDITOR_RESOURCE = Path(__file__).resolve().parent / "bridge" / "editor.rpy"
-FIXTURE_RESOURCE = (
-    Path(__file__).resolve().parents[2]
-    / "tests"
-    / "live_fixtures"
-    / "renforge_editor_offset_fixture.rpy"
+from renforge.editor_live_common import (
+    center as _center,
+    inject_editor_live_resources,
+    list_ui_info,
+    observe_selected as _observe_selected,
+    select_lock,
+    sha256_file as _sha256_file,
+    wait_bounds,
 )
 
+FIXTURE_SCREEN = "renforge_editor_offset_fixture"
+TARGET_ID = "offset_target"
 
 def inject_editor_offset_resources(project_root: Path) -> dict[str, str]:
-    game_dir = project_root / "game"
-    game_dir.mkdir(parents=True, exist_ok=True)
-    editor_target = game_dir / "zz_renforge_editor_offset.rpy"
-    fixture_target = game_dir / "zz_renforge_editor_offset_fixture.rpy"
-    shutil.copyfile(EDITOR_RESOURCE, editor_target)
-    shutil.copyfile(FIXTURE_RESOURCE, fixture_target)
-    return {
-        "editor": str(editor_target),
-        "fixture": str(fixture_target),
-    }
-
-
-def _find_element(
-    elements: list[dict[str, Any]],
-    wanted_id: str,
-    *,
-    wanted_text: str | None = None,
-) -> dict[str, Any]:
-    for element in elements:
-        element_id = str(element.get("id") or "")
-        if wanted_text is not None:
-            if element_id == wanted_id and str(element.get("text") or "") == wanted_text:
-                return element
-            continue
-        if element_id == wanted_id:
-            return element
-    raise AssertionError(
-        f"missing expected element id {wanted_id!r} text {wanted_text!r}: {elements!r}"
+    return inject_editor_live_resources(
+        project_root,
+        editor_basename="editor_offset",
+        fixture_filename="renforge_editor_offset_fixture.rpy",
     )
-
-
-def _center(bounds: dict[str, Any]) -> tuple[int, int]:
-    return (
-        int(bounds["x"]) + int(bounds["width"]) // 2,
-        int(bounds["y"]) + int(bounds["height"]) // 2,
-    )
-
-
-def _sha256_file(path: Path) -> str:
-    return hashlib.sha256(path.read_bytes()).hexdigest()
-
-
-def _list_info(client: Any) -> dict[str, Any]:
-    info = client.list_ui_elements_info(screen=FIXTURE_SCREEN)
-    if not isinstance(info, dict):
-        raise AssertionError(f"list_ui_elements_info returned non-dict: {info!r}")
-    return info
-
-
-def _wait_bounds(client: Any, widget_id: str, *, timeout: float = 6.0) -> dict[str, int]:
-    deadline = time.monotonic() + timeout
-    last: list[dict[str, Any]] = []
-    while time.monotonic() < deadline:
-        info = _list_info(client)
-        last = info.get("elements") if isinstance(info.get("elements"), list) else []
-        try:
-            element = _find_element(last, widget_id)
-        except AssertionError:
-            time.sleep(0.05)
-            continue
-        bounds = element.get("bounds")
-        if isinstance(bounds, dict):
-            return {
-                "x": int(bounds["x"]),
-                "y": int(bounds["y"]),
-                "width": int(bounds["width"]),
-                "height": int(bounds["height"]),
-            }
-        time.sleep(0.05)
-    raise AssertionError(f"bounds for {widget_id!r} unavailable: {last!r}")
-
 
 def _target_line_with_offset(source_text: str) -> tuple[str, int]:
     offset = 0
@@ -110,7 +43,6 @@ def _target_line_with_offset(source_text: str) -> tuple[str, int]:
             return line, offset
         offset += len(line)
     raise AssertionError(f"source missing offset textbutton line for {TARGET_ID!r}")
-
 
 def _independent_expected_after_patch(
     before_text: str,
@@ -136,7 +68,6 @@ def _independent_expected_after_patch(
         raise AssertionError("independent constructor must not introduce xpos/ypos")
     return f"{before_text[:file_offset]}{patched_line}{before_text[file_offset + len(line) :]}"
 
-
 def _outside_coordinate_spans_identical(before_text: str, after_text: str) -> bool:
     before_line, _ = _target_line_with_offset(before_text)
     after_line, _ = _target_line_with_offset(after_text)
@@ -156,46 +87,12 @@ def _outside_coordinate_spans_identical(before_text: str, after_text: str) -> bo
         return False
     return before_text.replace(before_line, "", 1) == after_text.replace(after_line, "", 1)
 
-
 def _parse_xy_from_target_line(source_text: str) -> dict[str, int]:
     line, _ = _target_line_with_offset(source_text)
     match = re.search(r"\boffset\s*\(\s*(-?\d+)\s*,\s*(-?\d+)\s*\)", line)
     if match is None:
         raise AssertionError(f"target line missing literal offset pair: {line!r}")
     return {"x": int(match.group(1)), "y": int(match.group(2))}
-
-
-def _select_lock(client: Any, widget_id: str, expected_code: str) -> str:
-    bounds = _wait_bounds(client, widget_id)
-    selection = client.request(
-        "editor_task0_select",
-        {"x": _center(bounds)[0], "y": _center(bounds)[1]},
-    )
-    immediate = selection.get("lock_reason") if isinstance(selection, dict) else None
-    if immediate == expected_code:
-        return expected_code
-    status = _wait_for_status(
-        client,
-        lambda current: current.get("selected_widget_id") == widget_id
-        and current.get("selected_lock_reason") == expected_code,
-        timeout=10.0,
-        poll_name=f"{widget_id} lock",
-    )
-    lock_reason = status.get("selected_lock_reason")
-    if lock_reason != expected_code:
-        raise AssertionError(f"unexpected lock for {widget_id!r}: {status!r}")
-    return str(lock_reason)
-
-
-def _observe_selected(client: Any) -> dict[str, Any]:
-    reply = client.request("editor_task0_observe_selected", {})
-    if not isinstance(reply, dict) or reply.get("ok") is not True:
-        raise AssertionError(f"observe_selected failed: {reply!r}")
-    observation = reply.get("observation")
-    if not isinstance(observation, dict):
-        raise AssertionError(f"observe_selected missing observation: {reply!r}")
-    return observation
-
 
 def run_editor_offset_live_scenario(client: Any, *, fixture_path: Path) -> dict[str, Any]:
     """Seven-step live proof for literal offset (x, y) textbutton form (issue #41)."""
@@ -223,14 +120,14 @@ def run_editor_offset_live_scenario(client: Any, *, fixture_path: Path) -> dict[
 
     # Lock matrix first on real focusable widgets (measured codes).
     report["locks"] = {
-        "computed": _select_lock(client, "offset_computed", "OFFSET_LITERAL_REQUIRED"),
-        "container": _select_lock(client, "offset_container", "CONTAINER_POSITION_UNSUPPORTED"),
+        "computed": select_lock(client, "offset_computed", "OFFSET_LITERAL_REQUIRED", fixture_screen=FIXTURE_SCREEN),
+        "container": select_lock(client, "offset_container", "CONTAINER_POSITION_UNSUPPORTED", fixture_screen=FIXTURE_SCREEN),
     }
 
     # Measured live: two use-statements share id "offset_dupe_target". The first
     # instance is still selectable by focus bounds and locks as SYNTHETIC_WIDGET_ID
     # (list_ui may only name the second instance).
-    dupe_info = _list_info(client)
+    dupe_info = list_ui_info(client, FIXTURE_SCREEN)
     dupe_elements = dupe_info.get("elements") if isinstance(dupe_info, dict) else None
     # Prefer the unnamed first instance (NullAction-ish id) then fall back to
     # the named target bounds at the left dupe coordinate.
@@ -270,7 +167,7 @@ def run_editor_offset_live_scenario(client: Any, *, fixture_path: Path) -> dict[
     report["locks"]["ambiguous"] = ambiguous
 
     # Measured live: Side is not in the ancestry allowlist → UNKNOWN_ANCESTRY_TYPE.
-    side_bounds = _wait_bounds(client, "offset_side", timeout=3.0)
+    side_bounds = wait_bounds(client, "offset_side", timeout=3.0, fixture_screen=FIXTURE_SCREEN)
     side_select = client.request(
         "editor_task0_select",
         {"x": _center(side_bounds)[0], "y": _center(side_bounds)[1]},
@@ -291,7 +188,7 @@ def run_editor_offset_live_scenario(client: Any, *, fixture_path: Path) -> dict[
     report["locks"]["unproven"] = unproven
 
     # Step 1: resolve the editable offset textbutton from a fresh focus rect.
-    target_bounds = _wait_bounds(client, TARGET_ID)
+    target_bounds = wait_bounds(client, TARGET_ID, fixture_screen=FIXTURE_SCREEN)
     target_center = _center(target_bounds)
     select = _require_ok(
         client.request(

--- a/src/renforge/editor_pos_runner.py
+++ b/src/renforge/editor_pos_runner.py
@@ -1,9 +1,6 @@
 from __future__ import annotations
 
-import hashlib
 import re
-import shutil
-import time
 from pathlib import Path
 from typing import Any
 
@@ -14,89 +11,25 @@ from renforge.editor_task0_runner import (
     _wait_for_status,
 )
 
-FIXTURE_SCREEN = "renforge_editor_pos_fixture"
-TARGET_ID = "pos_target"
-EDITOR_RESOURCE = Path(__file__).resolve().parent / "bridge" / "editor.rpy"
-FIXTURE_RESOURCE = (
-    Path(__file__).resolve().parents[2]
-    / "tests"
-    / "live_fixtures"
-    / "renforge_editor_pos_fixture.rpy"
+from renforge.editor_live_common import (
+    center as _center,
+    inject_editor_live_resources,
+    list_ui_info,
+    observe_selected as _observe_selected,
+    select_lock,
+    sha256_file as _sha256_file,
+    wait_bounds,
 )
 
+FIXTURE_SCREEN = "renforge_editor_pos_fixture"
+TARGET_ID = "pos_target"
 
 def inject_editor_pos_resources(project_root: Path) -> dict[str, str]:
-    game_dir = project_root / "game"
-    game_dir.mkdir(parents=True, exist_ok=True)
-    editor_target = game_dir / "zz_renforge_editor_pos.rpy"
-    fixture_target = game_dir / "zz_renforge_editor_pos_fixture.rpy"
-    shutil.copyfile(EDITOR_RESOURCE, editor_target)
-    shutil.copyfile(FIXTURE_RESOURCE, fixture_target)
-    return {
-        "editor": str(editor_target),
-        "fixture": str(fixture_target),
-    }
-
-
-def _find_element(
-    elements: list[dict[str, Any]],
-    wanted_id: str,
-    *,
-    wanted_text: str | None = None,
-) -> dict[str, Any]:
-    for element in elements:
-        element_id = str(element.get("id") or "")
-        if wanted_text is not None:
-            if element_id == wanted_id and str(element.get("text") or "") == wanted_text:
-                return element
-            continue
-        if element_id == wanted_id:
-            return element
-    raise AssertionError(
-        f"missing expected element id {wanted_id!r} text {wanted_text!r}: {elements!r}"
+    return inject_editor_live_resources(
+        project_root,
+        editor_basename="editor_pos",
+        fixture_filename="renforge_editor_pos_fixture.rpy",
     )
-
-
-def _center(bounds: dict[str, Any]) -> tuple[int, int]:
-    return (
-        int(bounds["x"]) + int(bounds["width"]) // 2,
-        int(bounds["y"]) + int(bounds["height"]) // 2,
-    )
-
-
-def _sha256_file(path: Path) -> str:
-    return hashlib.sha256(path.read_bytes()).hexdigest()
-
-
-def _list_info(client: Any) -> dict[str, Any]:
-    info = client.list_ui_elements_info(screen=FIXTURE_SCREEN)
-    if not isinstance(info, dict):
-        raise AssertionError(f"list_ui_elements_info returned non-dict: {info!r}")
-    return info
-
-
-def _wait_bounds(client: Any, widget_id: str, *, timeout: float = 6.0) -> dict[str, int]:
-    deadline = time.monotonic() + timeout
-    last: list[dict[str, Any]] = []
-    while time.monotonic() < deadline:
-        info = _list_info(client)
-        last = info.get("elements") if isinstance(info.get("elements"), list) else []
-        try:
-            element = _find_element(last, widget_id)
-        except AssertionError:
-            time.sleep(0.05)
-            continue
-        bounds = element.get("bounds")
-        if isinstance(bounds, dict):
-            return {
-                "x": int(bounds["x"]),
-                "y": int(bounds["y"]),
-                "width": int(bounds["width"]),
-                "height": int(bounds["height"]),
-            }
-        time.sleep(0.05)
-    raise AssertionError(f"bounds for {widget_id!r} unavailable: {last!r}")
-
 
 def _target_line_with_offset(source_text: str) -> tuple[str, int]:
     offset = 0
@@ -110,7 +43,6 @@ def _target_line_with_offset(source_text: str) -> tuple[str, int]:
             return line, offset
         offset += len(line)
     raise AssertionError(f"source missing pos textbutton line for {TARGET_ID!r}")
-
 
 def _independent_expected_after_patch(before_text: str, *, x: int, y: int) -> str:
     """Build expected fixture text without calling apply_textbutton_patch."""
@@ -126,7 +58,6 @@ def _independent_expected_after_patch(before_text: str, *, x: int, y: int) -> st
     if "xpos" in patched_line or "ypos" in patched_line:
         raise AssertionError("independent constructor must not introduce xpos/ypos")
     return f"{before_text[:offset]}{patched_line}{before_text[offset + len(line) :]}"
-
 
 def _outside_coordinate_spans_identical(before_text: str, after_text: str) -> bool:
     before_line, _ = _target_line_with_offset(before_text)
@@ -147,46 +78,12 @@ def _outside_coordinate_spans_identical(before_text: str, after_text: str) -> bo
         return False
     return before_text.replace(before_line, "", 1) == after_text.replace(after_line, "", 1)
 
-
 def _parse_xy_from_target_line(source_text: str) -> dict[str, int]:
     line, _ = _target_line_with_offset(source_text)
     match = re.search(r"\bpos\s*\(\s*(-?\d+)\s*,\s*(-?\d+)\s*\)", line)
     if match is None:
         raise AssertionError(f"target line missing literal pos pair: {line!r}")
     return {"x": int(match.group(1)), "y": int(match.group(2))}
-
-
-def _select_lock(client: Any, widget_id: str, expected_code: str) -> str:
-    bounds = _wait_bounds(client, widget_id)
-    selection = client.request(
-        "editor_task0_select",
-        {"x": _center(bounds)[0], "y": _center(bounds)[1]},
-    )
-    immediate = selection.get("lock_reason") if isinstance(selection, dict) else None
-    if immediate == expected_code:
-        return expected_code
-    status = _wait_for_status(
-        client,
-        lambda current: current.get("selected_widget_id") == widget_id
-        and current.get("selected_lock_reason") == expected_code,
-        timeout=10.0,
-        poll_name=f"{widget_id} lock",
-    )
-    lock_reason = status.get("selected_lock_reason")
-    if lock_reason != expected_code:
-        raise AssertionError(f"unexpected lock for {widget_id!r}: {status!r}")
-    return str(lock_reason)
-
-
-def _observe_selected(client: Any) -> dict[str, Any]:
-    reply = client.request("editor_task0_observe_selected", {})
-    if not isinstance(reply, dict) or reply.get("ok") is not True:
-        raise AssertionError(f"observe_selected failed: {reply!r}")
-    observation = reply.get("observation")
-    if not isinstance(observation, dict):
-        raise AssertionError(f"observe_selected missing observation: {reply!r}")
-    return observation
-
 
 def run_editor_pos_live_scenario(client: Any, *, fixture_path: Path) -> dict[str, Any]:
     """Seven-step live proof for literal pos (x, y) textbutton form (issue #38)."""
@@ -214,14 +111,14 @@ def run_editor_pos_live_scenario(client: Any, *, fixture_path: Path) -> dict[str
 
     # Lock matrix first on real focusable widgets (measured codes).
     report["locks"] = {
-        "computed": _select_lock(client, "pos_computed", "POS_LITERAL_REQUIRED"),
-        "container": _select_lock(client, "pos_container", "CONTAINER_POSITION_UNSUPPORTED"),
+        "computed": select_lock(client, "pos_computed", "POS_LITERAL_REQUIRED", fixture_screen=FIXTURE_SCREEN),
+        "container": select_lock(client, "pos_container", "CONTAINER_POSITION_UNSUPPORTED", fixture_screen=FIXTURE_SCREEN),
     }
 
     # Measured live: two use-statements share id "pos_dupe_target". The first
     # instance is still selectable by focus bounds and locks as SYNTHETIC_WIDGET_ID
     # (list_ui may only name the second instance).
-    dupe_info = _list_info(client)
+    dupe_info = list_ui_info(client, FIXTURE_SCREEN)
     dupe_elements = dupe_info.get("elements") if isinstance(dupe_info, dict) else None
     # Prefer the unnamed first instance (NullAction-ish id) then fall back to
     # the named target bounds at the left dupe coordinate.
@@ -261,7 +158,7 @@ def run_editor_pos_live_scenario(client: Any, *, fixture_path: Path) -> dict[str
     report["locks"]["ambiguous"] = ambiguous
 
     # Measured live: Side is not in the ancestry allowlist → UNKNOWN_ANCESTRY_TYPE.
-    side_bounds = _wait_bounds(client, "pos_side", timeout=3.0)
+    side_bounds = wait_bounds(client, "pos_side", timeout=3.0, fixture_screen=FIXTURE_SCREEN)
     side_select = client.request(
         "editor_task0_select",
         {"x": _center(side_bounds)[0], "y": _center(side_bounds)[1]},
@@ -282,7 +179,7 @@ def run_editor_pos_live_scenario(client: Any, *, fixture_path: Path) -> dict[str
     report["locks"]["unproven"] = unproven
 
     # Step 1: resolve the editable pos textbutton from a fresh focus rect.
-    target_bounds = _wait_bounds(client, TARGET_ID)
+    target_bounds = wait_bounds(client, TARGET_ID, fixture_screen=FIXTURE_SCREEN)
     target_center = _center(target_bounds)
     select = _require_ok(
         client.request(

--- a/tests/live_fixtures/renforge_editor_offset_fixture.rpy
+++ b/tests/live_fixtures/renforge_editor_offset_fixture.rpy
@@ -1,0 +1,35 @@
+default renforge_editor_offset_clicks = 0
+default renforge_editor_offset_computed_x = 520
+
+
+screen renforge_editor_offset_dupe(label_text, left_x):
+    textbutton label_text id "offset_dupe_target" offset (left_x, 430) action NullAction()
+
+
+screen renforge_editor_offset_fixture():
+    layer "screens"
+    zorder 640
+
+    fixed:
+        id "offset_root"
+        xfill True
+        yfill True
+
+        # Supported form: single-line textbutton with literal offset (x, y).
+        textbutton "MOVE ME" id "offset_target" offset (200, 180) action SetVariable("renforge_editor_offset_clicks", renforge_editor_offset_clicks + 1)
+
+        textbutton "COMPUTED" id "offset_computed" offset (renforge_editor_offset_computed_x, 300) action NullAction()
+
+        vbox:
+            id "offset_container_parent"
+            xoffset 900
+            yoffset 120
+            spacing 12
+
+            textbutton "CONTAINER" id "offset_container" offset (0, 0) action NullAction()
+
+        side "c":
+            textbutton "SIDE" id "offset_side" offset (100, 520) action NullAction()
+
+        use renforge_editor_offset_dupe("DUPE A", 520)
+        use renforge_editor_offset_dupe("DUPE B", 720)

--- a/tests/test_editor_coordinator.py
+++ b/tests/test_editor_coordinator.py
@@ -1842,6 +1842,54 @@ def test_analyze_textbutton_align_locks_unproven_parent_geometry(tmp_path: Path)
         coordinator.close()
 
 
+def test_analyze_and_commit_textbutton_offset_preserves_form(tmp_path: Path) -> None:
+    root = tmp_path / "project_offset"
+    game_dir = root / "game"
+    game_dir.mkdir(parents=True)
+    source = game_dir / "script.rpy"
+    source.write_text(
+        "screen test_screen:\n"
+        '    textbutton "Play" id "start_btn" offset (12, 10) action NullAction()\n',
+        encoding="utf-8",
+    )
+    project = RenpyProject(root)
+    # Runtime TL equals authored offset for base placement 0,0.
+    observation = _base_observation(script_generation=14)
+    observation["rect"] = [12, 10, 80, 40]
+    probe = _Probe(
+        observe_reply={
+            **json.loads(json.dumps(observation)),
+            "frame_id": "independent-frame-offset",
+            "object_id": "obj-independent-offset",
+            "rect": [12, 10, 80, 40],
+        },
+        attest_reply={"ok": True, "state": "all_targets_attested"},
+    )
+    coordinator = EditorCoordinator(project, _make_sdk(tmp_path), attestation_timeout=2.0)
+    coordinator.attach_runtime_probe(probe)
+    endpoint = coordinator.start()
+    try:
+        with socket.create_connection((endpoint.host, endpoint.port), timeout=2.0) as sock:
+            auth = _auth(sock, endpoint)
+            analyzed = _analyze(sock, auth, observation, request_id="an-offset")
+            assert analyzed["ok"] is True
+            result = analyzed["result"]
+            assert result["lock_reason"] is None
+            assert result["capabilities"] == {"move": True}
+            assert result["original_position"] == [12, 10]
+            assert result["source_key"]["position_mode"] == "offset"
+            assert result["source_key"]["offset_authored"] == [12, 10]
+            assert result["source_key"]["offset_runtime_baseline"] == [12, 10]
+            # Move runtime TL by +20,+30 → offset becomes 32, 40.
+            committed = _commit(sock, auth, analyzed, x=32, y=40, request_id="co-offset")
+            assert committed["ok"] is True
+            text = source.read_text(encoding="utf-8")
+            assert "offset (32, 40)" in text
+            assert "xpos" not in text and "ypos" not in text
+    finally:
+        coordinator.close()
+
+
 def test_analyze_and_commit_textbutton_anchor_preserves_anchor_bytes(tmp_path: Path) -> None:
     root = tmp_path / "project_anchor"
     game_dir = root / "game"

--- a/tests/test_editor_offset_live.py
+++ b/tests/test_editor_offset_live.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import os
+import shutil
+import time
+from pathlib import Path
+
+import pytest
+
+from renforge.editor_offset_runner import (
+    FIXTURE_SCREEN,
+    inject_editor_offset_resources,
+    run_editor_offset_live_scenario,
+)
+
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("RENFORGE_OFFSET_LIVE"),
+    reason="set RENFORGE_OFFSET_LIVE=1 to run offset (x, y) seven-step live proof",
+)
+
+_DEMO = Path(__file__).resolve().parents[1] / "examples" / "demo_game"
+
+
+@pytest.fixture
+def demo_copy(tmp_path: Path) -> Path:
+    destination = tmp_path / "demo"
+    shutil.copytree(_DEMO, destination, ignore=shutil.ignore_patterns("*.rpyc", "cache"))
+    inject_editor_offset_resources(destination)
+    return destination
+
+
+def test_offset_seven_step_live_proof(demo_copy: Path) -> None:
+    from renforge.bridge.launcher import launch_with_bridge
+    from renforge.project import RenpyProject
+    from renforge.sdk import get_or_install_sdk
+
+    sdk = get_or_install_sdk("8.5.3", project_root=demo_copy)
+    project = RenpyProject(demo_copy)
+    fixture_path = demo_copy / "game" / "zz_renforge_editor_offset_fixture.rpy"
+
+    with launch_with_bridge(
+        sdk,
+        project,
+        startup_timeout=120,
+        editor=True,
+    ) as session:
+        for _ in range(40):
+            launcher = session.client.inspect_screen("_renforge_editor_launcher")
+            if launcher.get("active") is True:
+                break
+            time.sleep(0.25)
+        else:
+            pytest.fail("editor launcher never became active")
+
+        launcher_click = session.client.click_element(
+            text="RF",
+            exact=True,
+            screen="_renforge_editor_launcher",
+        )
+        assert launcher_click.get("ok") is True, launcher_click
+        for _ in range(40):
+            overlay = session.client.inspect_screen("_renforge_editor_overlay")
+            if overlay.get("active") is True:
+                break
+            time.sleep(0.05)
+        else:
+            pytest.fail("editor overlay never became active")
+
+        for _ in range(20):
+            available = session.client.eval_expr(f'renpy.has_screen("{FIXTURE_SCREEN}")')
+            if available is True:
+                break
+            time.sleep(0.1)
+        else:
+            pytest.fail("offset fixture screen never became available")
+
+        report = run_editor_offset_live_scenario(
+            session.client,
+            fixture_path=fixture_path,
+        )
+
+    assert report["resolve"]["statement_kind"] == "textbutton"
+    assert report["resolve"]["lock_reason"] in (None, "")
+    assert report["resolve"]["move"] is True
+    assert report["resolve"]["measurement_method"] == "focus_list"
+    assert report["fixture_before"]["position_mode"] == "offset"
+
+    preview = report["preview"]
+    assert preview["bounds_before"] != preview["bounds_after"]
+    assert all(
+        abs(preview["observed_delta"][axis] - preview["requested_delta"][axis]) <= 1
+        for axis in (0, 1)
+    )
+
+    patch = report["patch"]
+    assert patch["outside_coordinate_spans_identical"] is True
+    assert patch["matches_independent_expected"] is True
+    assert patch["after_sha256"] != patch["before_sha256"]
+    # Offset write-back is authored + Δruntime, not absolute runtime coordinates.
+    assert patch["source_position_after"] == patch["expected_source_position"]
+
+    assert report["reload"]["ok"] is True
+    assert report["reload"]["status_text"] == "Reload committed"
+    assert report["reload"]["generation_delta"] == 1
+
+    assert all(abs(int(value)) <= 1 for value in report["pixel_agreement"]["delta"])
+
+    value_invariance = report["value_invariance"]
+    assert value_invariance["preview"] == value_invariance["baseline"]
+    assert value_invariance["reload"] == value_invariance["baseline"]
+
+    assert report["rebinding"]["ok"] is True
+    assert report["rebinding"]["widget_id"] == "offset_target"
+
+    locks = report["locks"]
+    assert locks["computed"] == "OFFSET_LITERAL_REQUIRED"
+    assert locks["container"] == "CONTAINER_POSITION_UNSUPPORTED"
+    assert locks["ambiguous"] == "SYNTHETIC_WIDGET_ID"
+    assert locks["unproven"] == "UNKNOWN_ANCESTRY_TYPE"
+
+    undo = report["byte_identical_undo"]
+    assert undo["matches_baseline"] is True
+    assert undo["patched_differed"] is True

--- a/tests/test_editor_source.py
+++ b/tests/test_editor_source.py
@@ -1316,6 +1316,25 @@ def test_analyze_textbutton_offset_rejects_impure_and_mixed() -> None:
             expected_widget_id="start",
         )
     assert excinfo.value.code == "POSITION_FORM_MIXED"
+    # Concurrent placement forms must also lock pure offset (Sourcery).
+    with pytest.raises(EditorSourceError) as excinfo:
+        analyze_textbutton_statement(
+            '    textbutton "Play" id "start" offset (1, 2) anchor (0.5, 0.5) action NullAction()\n',
+            expected_widget_id="start",
+        )
+    assert excinfo.value.code == "POSITION_FORM_MIXED"
+    with pytest.raises(EditorSourceError) as excinfo:
+        analyze_textbutton_statement(
+            '    textbutton "Play" id "start" offset (1, 2) pos (3, 4) action NullAction()\n',
+            expected_widget_id="start",
+        )
+    assert excinfo.value.code == "POSITION_FORM_MIXED"
+    with pytest.raises(EditorSourceError) as excinfo:
+        analyze_textbutton_statement(
+            '    textbutton "Play" id "start" offset (1, 2) align (0.3, 0.4) action NullAction()\n',
+            expected_widget_id="start",
+        )
+    assert excinfo.value.code == "POSITION_FORM_MIXED"
     with pytest.raises(EditorSourceError) as excinfo:
         analyze_textbutton_statement(
             '    textbutton "Play" id "start" offset (1, 2) offset (3, 4) action NullAction()\n',

--- a/tests/test_editor_source.py
+++ b/tests/test_editor_source.py
@@ -1267,6 +1267,80 @@ def test_analyze_textbutton_align_rejects_impure_and_mixed() -> None:
     assert excinfo.value.code == "POSITION_FORM_MIXED"
 
 
+def test_analyze_textbutton_offset_accepts_and_patches_form() -> None:
+    line = '    textbutton "Play" id "start" offset (12, 10) action NullAction()\n'
+    parsed = analyze_textbutton_statement(line, expected_widget_id="start")
+    assert parsed.position_mode == "offset"
+    assert (parsed.xpos, parsed.ypos) == (12, 10)
+    # Runtime baseline equals authored offset when base placement is 0,0;
+    # move runtime TL by +20,+30 → authored becomes 32, 40.
+    patched = apply_textbutton_patch(
+        line.encode("utf-8"),
+        parsed,
+        x=32,
+        y=40,
+        offset_runtime_baseline=(12, 10),
+    ).decode("utf-8")
+    assert patched == '    textbutton "Play" id "start" offset (32, 40) action NullAction()\n'
+    assert "xpos" not in patched and "ypos" not in patched
+
+    negative = '    textbutton "Play" id "start" offset (-12, -10) action NullAction()\n'
+    neg_parsed = analyze_textbutton_statement(negative, expected_widget_id="start")
+    assert (neg_parsed.xpos, neg_parsed.ypos) == (-12, -10)
+    neg_patched = apply_textbutton_patch(
+        negative.encode("utf-8"),
+        neg_parsed,
+        x=-1,
+        y=2,
+        offset_runtime_baseline=(-12, -10),
+    ).decode("utf-8")
+    assert neg_patched == '    textbutton "Play" id "start" offset (-1, 2) action NullAction()\n'
+
+
+def test_analyze_textbutton_offset_rejects_impure_and_mixed() -> None:
+    with pytest.raises(EditorSourceError) as excinfo:
+        analyze_textbutton_statement(
+            '    textbutton "Play" id "start" offset (base_x, 10) action NullAction()\n',
+            expected_widget_id="start",
+        )
+    assert excinfo.value.code == "OFFSET_LITERAL_REQUIRED"
+    with pytest.raises(EditorSourceError) as excinfo:
+        analyze_textbutton_statement(
+            '    textbutton "Play" id "start" offset (1, 2) xpos 3 ypos 4 action NullAction()\n',
+            expected_widget_id="start",
+        )
+    assert excinfo.value.code == "POSITION_FORM_MIXED"
+    with pytest.raises(EditorSourceError) as excinfo:
+        analyze_textbutton_statement(
+            '    textbutton "Play" id "start" offset (1, 2) xoffset 8 action NullAction()\n',
+            expected_widget_id="start",
+        )
+    assert excinfo.value.code == "POSITION_FORM_MIXED"
+    with pytest.raises(EditorSourceError) as excinfo:
+        analyze_textbutton_statement(
+            '    textbutton "Play" id "start" offset (1, 2) offset (3, 4) action NullAction()\n',
+            expected_widget_id="start",
+        )
+    assert excinfo.value.code == "OFFSET_DUPLICATE"
+    with pytest.raises(EditorSourceError) as excinfo:
+        analyze_textbutton_statement(
+            '    textbutton "Play" id "start" offset offset_value action NullAction()\n',
+            expected_widget_id="start",
+        )
+    assert excinfo.value.code == "OFFSET_LITERAL_REQUIRED"
+    with pytest.raises(EditorSourceError) as excinfo:
+        apply_textbutton_patch(
+            b'    textbutton "Play" id "start" offset (1, 2) action NullAction()\n',
+            analyze_textbutton_statement(
+                '    textbutton "Play" id "start" offset (1, 2) action NullAction()\n',
+                expected_widget_id="start",
+            ),
+            x=10,
+            y=10,
+        )
+    assert excinfo.value.code == "OFFSET_BASELINE_REQUIRED"
+
+
 def test_apply_textbutton_align_locks_zero_extent_axis() -> None:
     line = '    textbutton "Play" id "start" align (0.5, 0.5) action NullAction()\n'
     parsed = analyze_textbutton_statement(line, expected_widget_id="start")


### PR DESCRIPTION
## Summary

Implements **issue #41** — preserve authored `offset (x, y)` on single-line `textbutton` during visual moves, following the same Stage-2 workflow as pos/align/anchor.

- **Analyze:** pure integer pair `offset (x, y)` only; locks for non-literal, duplicate, and concurrent placement (`xpos`/`pos`/`align`/`xoffset`/…).
- **Write-back:** `authored + Δpixel` (offset is additive over base placement); form and unrelated bytes preserved.
- **Preview:** absolute `xpos`/`ypos` with align/anchor/offset neutralized so focus_list tracks the pixel delta 1:1.
- **Live:** opt-in seven-step proof on Ren'Py **8.5.3** (`RENFORGE_OFFSET_LIVE=1`).

Closes #41

## Validation

```text
tests/test_editor_source.py tests/test_editor_coordinator.py
117 passed

RENFORGE_OFFSET_LIVE=1 tests/test_editor_offset_live.py
1 passed (~10s)
```

## Test plan

- [x] Unit: accept pure offset, patch with baseline delta, reject impure/mixed/duplicate
- [x] Coordinator: analyze + commit preserves `offset` form
- [x] Live seven-step: preview, patch, reload, 1px agreement, rebinding, byte-identical undo
- [ ] Await Sourcery/Codex review bots

## Summary by Sourcery

Préserver le formulaire de positionnement par décalage (x, y) des textbuttons sur une seule ligne lors des déplacements dans l’éditeur visuel, en utilisant le même workflow de delta de ligne de base que le support existant pour pos/align/anchor.

Nouvelles fonctionnalités :
- Prendre en charge le décalage littéral (x, y) comme `position_mode` de première classe pour les instructions de textbutton sur une seule ligne, en garantissant que la forme de décalage définie par l’auteur est conservée lors de la réécriture.
- Ajouter une intégration de décalage en direct (x, y) afin que l’aperçu et les validations basés sur `focus_list` déplacent les textbuttons définis avec décalage via des deltas mesurés à l’exécution plutôt qu’en réécrivant vers `xpos`/`ypos`.

Améliorations :
- Étendre les règles de verrouillage de placement concurrent afin que les textbuttons définis avec décalage refusent les combinaisons de placement mixtes ou non littérales de type décalage/scission d’axes/absolu.
- Augmenter la logique du coordinateur et du pont pour gérer les textbuttons définis avec décalage de manière cohérente avec `align`, y compris le suivi de la ligne de base et les capacités de déplacement.

Documentation :
- Documenter la prise en charge du décalage littéral (x, y) pour les textbuttons, les raisons de verrouillage, et le drapeau de preuve en direct dans le périmètre et les spécifications de la feuille de route de l’éditeur visuel v1.

Tests :
- Ajouter des tests unitaires pour l’analyse et la modification des formulaires de décalage de textbutton et pour l’application du rejet des décalages mixtes/impurs/dupliqués.
- Introduire un test d’intégration en sept étapes `RENFORGE_OFFSET_LIVE` et des écrans de fixture pour valider le comportement de bout en bout du décalage, la concordance au pixel près et un undo strictement identique en octets.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Preserve single-line textbutton offset (x, y) positioning form during visual editor moves using the same baseline-delta workflow as existing pos/align/anchor support.

New Features:
- Support literal offset (x, y) as a first-class position_mode for single-line textbutton statements, ensuring authored offset form is retained on write-back.
- Add live offset (x, y) integration so focus_list-based preview and commits move offset-authored textbuttons via measured runtime deltas rather than rewriting to xpos/ypos.

Enhancements:
- Extend concurrent placement locking rules so offset-authored textbuttons reject mixed or non-literal offset/axis-split/absolute placement combinations.
- Augment coordinator and bridge logic to handle offset-authored textbuttons consistently with align, including baseline tracking and move capabilities.

Documentation:
- Document literal textbutton offset (x, y) support, lock reasons, and live proof flag in the visual editor v1 scope and roadmap specs.

Tests:
- Add unit tests for analyzing and patching textbutton offset forms and for enforcing mixed/impure/duplicate offset rejection.
- Introduce a seven-step RENFORGE_OFFSET_LIVE integration test and fixture screens to validate end-to-end offset behavior, pixel agreement, and byte-identical undo.

</details>