### PR TITLE
Prove runtime disambiguation for repeated loop and `use` instances (#42)

### DIFF
--- a/docs/superpowers/specs/2026-07-30-renforge-visual-editor-v1-scope.md
+++ b/docs/superpowers/specs/2026-07-30-renforge-visual-editor-v1-scope.md
@@ -34,7 +34,7 @@ requires it — none is arbitrary.
 | 1 | Displayable is **focusable** | Selection and every save-bearing measurement read `renpy.display.focus.focus_list` |
 | 2 | Source statement carries one **literal `id`** matching the runtime widget id | Runtime preview uses `_widget_properties`, keyed by the authored widget id; synthetic observation IDs do not qualify |
 | 3 | A proven adapter statement (`textbutton` single-line or multi-line block, `imagebutton`, single-line `bar`/`vbar`, slider-styled `bar`) or an explicit-block `button`, with one literal integer **`xpos` and `ypos`** | The token-aware patcher replaces only the coordinate spans; block forms preserve every non-position byte |
-| 4 | Exactly one runtime instance with a fully classified, static ancestry outside **`viewport` / `Crop` / `Transform(crop=)`**, loop and repeated `use` cases | Only a unique static instance under proven clipping can be rebound unambiguously |
+| 4 | Exactly one runtime instance with a fully classified, static ancestry outside **`viewport` / `Crop` / `Transform(crop=)`**, loop and repeated `use` cases | A repeated statement stores its position once for all N instances, so no write can move one of them alone (issue #42) |
 
 **A failing gate is a first-class UI state, never a silent no-op.** The overlay must name which gate
 failed and why, e.g. *"`text` is not focusable — cannot be selected in V1"* or
@@ -83,9 +83,9 @@ textbutton "MOVE ME":
 Requirements: header ends with `:`; header carries no `id`/`xpos`/`ypos`; exactly one literal string
 `id` and one literal integer `xpos`/`ypos` each among direct children at the block indent; patch
 replaces only those two integer tokens (absolute spans in the full file); every other block byte is
-preserved. Computed coordinates, container ancestry, ambiguous `use` instances, and unproven ancestry
+preserved. Computed coordinates, container ancestry, repeated `use` instances, and unproven ancestry
 remain locked with the measured codes (`XPOS_LITERAL_REQUIRED`, `CONTAINER_POSITION_UNSUPPORTED`,
-`SYNTHETIC_WIDGET_ID`, `UNKNOWN_ANCESTRY_TYPE`, …).
+`REPEATED_USE_UNSUPPORTED`, `UNKNOWN_ANCESTRY_TYPE`, …).
 
 Live proof: `RENFORGE_MULTILINE_TEXTBUTTON_LIVE=1 uv run --extra test python -m pytest -q tests/test_editor_multiline_textbutton_live.py`
 against Ren'Py **8.5.3**.
@@ -170,7 +170,7 @@ Live proof: `RENFORGE_VBAR_LIVE=1 uv run --extra test python -m pytest -q tests/
 against Ren'Py **8.5.3**. Vbar inherits the exact #34 lock boundaries: computed/non-literal `xpos`
 and `ypos` (`XPOS_LITERAL_REQUIRED` / `YPOS_LITERAL_REQUIRED`), style-driven position
 (`BAR_STYLE_POSITION_UNSUPPORTED`), missing direct position (`BAR_POSITION_NOT_DIRECTLY_AUTHORED`),
-container ancestry (`CONTAINER_POSITION_UNSUPPORTED`), duplicate instances (`SYNTHETIC_WIDGET_ID`),
+container ancestry (`CONTAINER_POSITION_UNSUPPORTED`), repeated instances (`REPEATED_USE_UNSUPPORTED`),
 unknown ancestry (`UNKNOWN_ANCESTRY_TYPE`), and multi-line statements
 (`MULTILINE_STATEMENT_REJECTED`). These targets remain selectable but locked with their measured reason.
 
@@ -193,6 +193,27 @@ present without xpos/ypos), container ancestry, duplicate instances, and unprove
 `vslider`, style-driven position without inline literals, container-driven position, computed
 coordinates, multi-line blocks, and unproven ancestry remain pending or locked; no other forms are
 claimed.
+
+### Repeated loop and `use` instances (issue #42)
+
+Instance identity comes from the SL2 cache path, not from `screen.widgets`. Ren'Py keys each `SLFor`
+iteration by the author's own loop index and gives every `use` call site its own cache dict, so
+walking the cache maps each focus entry to exactly one instance without inventing an id. The widgets
+map cannot: it keeps a single displayable per widget id, so siblings of a repeated statement used to
+fail id resolution and lock as `SYNTHETIC_WIDGET_ID` by accident.
+
+Selection is therefore proven, and the write stays locked — **not** pending implementation. A repeated
+statement holds its authored position in one place shared by all N instances, so a write moves all of
+them; moving one alone would require synthesising a per-instance expression, which the editor is not
+entitled to do. The runtime key now carries `kind`, `instance_count` and `instance_key`, and the lock
+is `LOOP_INSTANCE_UNSUPPORTED` or `REPEATED_USE_UNSUPPORTED`. A repetition lock outranks a source-form
+lock, so the reason does not depend on gate ordering.
+
+`instance_key` holds SL2 AST serials, which are reassigned on script reload; it is stable within one
+script generation and is omitted for unique statements, so it never enters their rebinding equality.
+
+Live proof: `RENFORGE_LOOP_LIVE=1 uv run --extra test python -m pytest -q tests/test_editor_loop_live.py`
+against Ren'Py **8.5.3**.
 
 ## Proven mechanisms (do not redesign)
 

--- a/docs/superpowers/specs/2026-07-30-renforge-visual-editor-vfull-roadmap.md
+++ b/docs/superpowers/specs/2026-07-30-renforge-visual-editor-vfull-roadmap.md
@@ -35,7 +35,7 @@ The proof uses fresh `focus_list` observations for every visual position and ver
 value is invariant across preview and reload. Vbar inherits #34's exact measured lock boundaries:
 computed/non-literal coordinates (`XPOS_LITERAL_REQUIRED` / `YPOS_LITERAL_REQUIRED`), style-driven
 position (`BAR_STYLE_POSITION_UNSUPPORTED`), missing direct position (`BAR_POSITION_NOT_DIRECTLY_AUTHORED`),
-container ancestry (`CONTAINER_POSITION_UNSUPPORTED`), duplicate instances (`SYNTHETIC_WIDGET_ID`),
+container ancestry (`CONTAINER_POSITION_UNSUPPORTED`), repeated instances (`REPEATED_USE_UNSUPPORTED`),
 unknown ancestry (`UNKNOWN_ANCESTRY_TYPE`), and multi-line statements (`MULTILINE_STATEMENT_REJECTED`).
 These remain selectable but locked; all other vbar forms remain pending.
 
@@ -67,11 +67,46 @@ Real screens are messier.
 | `pos (x, y)` / `align` / `anchor` / `offset` | Different property, same intent | **`pos` (#38)**, **`align` (#39)**, **`anchor` (#40)**, **`offset` (#41)** implemented for single-line `textbutton`. Write-back preserves form. Lives: `RENFORGE_POS_LIVE=1`, `RENFORGE_ALIGN_LIVE=1`, `RENFORGE_ANCHOR_LIVE=1`, `RENFORGE_OFFSET_LIVE=1`. |
 | Position from a **variable or expression** | Cannot be rewritten without changing semantics | **Stays locked.** Offer to show the computed value, never to overwrite the expression |
 | Element inside `hbox` / `vbox` / `grid` | Position is computed by the layout, not authored | **Stays locked** for direct move. A layout-aware edit is a different feature |
-| Multiple instances from one loop / `use` | One source line, N runtime widgets | Needs a disambiguation UI; the stable key already carries `ordinal` |
+| Multiple instances from one loop / `use` | One source line, N runtime widgets | **Selection proven, write blocked (issue #42).** Instances are now identified individually; the source write stays locked. See below. |
 
 **Design rule inherited from the agreed spec:** the editor preserves the form the author used. An
 element written with `xpos` gets `xpos` back; one written with `offset` gets `offset`. The editor is
 not entitled to normalise someone's source.
+
+### Repetition (issue #42) — selection proven, instance-specific write blocked
+
+Measured live on Ren'Py **8.5.3** via `RENFORGE_LOOP_LIVE=1`.
+
+**Selection is proven.** Ren'Py keys each `SLFor` iteration in its SL2 cache by the author's own loop
+index (`slast.py`: `newcaches[index] = ctx.new_cache = {}`) and gives every `use` call site its own
+cache dict. Walking that cache maps every focus entry to exactly one instance — 12/12 in the fixture,
+no collisions — using authored data rather than a synthetic id. `screen.widgets` cannot do this: it
+stores one displayable per widget id, so the last iteration overwrites its siblings, which is why
+these instances previously locked as `SYNTHETIC_WIDGET_ID` by accident rather than by design.
+
+**The instance-specific source write is blocked**, and this is a property of the source, not a gap in
+the implementation. Every repetition shape keeps the authored position in a single location shared by
+all N instances:
+
+| Shape | Measured | Why no write is possible |
+|---|---|---|
+| Literal position in a loop | 3 instances, all at `(200,160)` | One literal serves N; a write moves all of them |
+| Loop-derived position | 3 instances at `x = 200 + i·160` | The position is an expression, locked by the expression gate |
+| Layout-positioned in a loop | 3 instances in a `vbox` | Locked by the container gate |
+| Repeated `use` | 2 call sites, both resolving to line 8 | One authored line backs both sites |
+
+Moving one instance alone would mean synthesising a per-instance expression — which the design rule
+above forbids. The gate therefore stays locked, but the lock is now *precise*: `LOOP_INSTANCE_UNSUPPORTED`
+and `REPEATED_USE_UNSUPPORTED` replace the incidental `SYNTHETIC_WIDGET_ID`, and the runtime key
+carries `kind`, `instance_count` and `instance_key` so a failed-gate UI can explain which instance of
+how many is selected (issue #52).
+
+**Identity outranks form.** When a statement is both repeated and expression-positioned, the analysis
+reports the repetition lock. Otherwise the reported reason would depend on which gate ran last.
+
+**Known limit:** `instance_key` contains SL2 AST serials, which Ren'Py reassigns on every script
+reload. It is stable within one script generation — enough to rebind during a session — and is
+deliberately absent from unique statements so it never enters their rebinding equality.
 
 ---
 

--- a/src/renforge/bridge/editor.rpy
+++ b/src/renforge/bridge/editor.rpy
@@ -228,6 +228,7 @@ init 1100 python:
     _EDITOR_LOCKED_TEXT = "LOCKED"
     _SNAP_ACQUIRE = 6
     _SNAP_RELEASE = 10
+    _CACHE_WALK_MAX_DEPTH = 32
     _ALLOWED_ANCESTRY_TYPES = set(
         [
             "ScreenDisplayable",
@@ -697,6 +698,130 @@ init 1100 python:
         return screen, widgets
 
 
+    def _renforge_editor_cache_index(screen):
+        """Map every cached displayable to the SL2 cache path that produced it.
+
+        Ren'Py keys `SLFor` iterations by the author's own loop index
+        (`slast.py` `newcaches[index]`) and gives every `use` call site its own
+        cache dict carrying an `"ast"` entry. That path is authored data, so it
+        identifies one runtime instance of a repeated statement without any
+        synthetic id. `screen.widgets` cannot: it holds a single displayable per
+        widget id, so the last iteration overwrites its siblings.
+        """
+        index = {}
+        root = getattr(screen, "cache", None)
+        if not isinstance(root, builtins.dict):
+            return index
+
+        def walk(cache, path, uses, depth):
+            if depth > _CACHE_WALK_MAX_DEPTH:
+                return
+            if isinstance(cache, builtins.dict):
+                for key, value in cache.items():
+                    if key == "ast":
+                        continue
+                    # An SLUse cache dict carries its target ast; that marks the
+                    # boundary as a call site rather than a loop iteration.
+                    boundary = isinstance(value, builtins.dict) and "ast" in value
+                    walk(value, path + [key], uses + [boundary], depth + 1)
+                return
+            displayable = getattr(cache, "displayable", None)
+            if displayable is None:
+                return
+            index[id(displayable)] = {
+                "path": tuple(builtins.repr(part) for part in path),
+                "use_boundaries": tuple(uses),
+                "displayable": displayable,
+            }
+
+        walk(root, [], [], 0)
+        return index
+
+
+    def _renforge_editor_statement_widget_ids(screen_name, cache_index):
+        """Learn each statement's authored widget id from any one instance.
+
+        `screen.widgets` keeps only the last instance of a repeated statement,
+        so its siblings resolve to no id at all. Instances that share a terminal
+        cache segment come from the same source statement and therefore carry
+        the same authored `id` literal.
+        """
+        statement_ids = {}
+        for entry in cache_index.values():
+            path = entry["path"]
+            if not path or path[-1] in statement_ids:
+                continue
+            _screen, widget_id, error = _renforge_editor_resolve_widget_id(
+                screen_name,
+                entry["displayable"],
+            )
+            if error is None and widget_id:
+                statement_ids[path[-1]] = widget_id
+        return statement_ids
+
+
+    def _renforge_editor_instance_discriminator(entry, cache_index):
+        """Describe how many runtime instances share one authored statement.
+
+        Instances of the same statement share the terminal cache segment (the
+        statement serial) and differ earlier in the path. The divergent segment
+        tells loop iterations apart from repeated `use` call sites.
+        """
+        if not entry:
+            return None
+        path = entry["path"]
+        terminal = path[-1] if path else None
+        siblings = [
+            other for other in cache_index.values() if other["path"] and other["path"][-1] == terminal
+        ]
+        instance_count = len(siblings)
+        # A unique instance keeps the bare static descriptor. Cache paths carry
+        # AST serials that are reassigned on every script reload, so they must
+        # never reach the descriptor the host compares when rebinding.
+        if instance_count <= 1:
+            return {"kind": "static", "instance_count": 1}
+        depth = _renforge_editor_divergence_depth(siblings)
+        kind = "static"
+        if depth is not None:
+            kind = "use" if any(other["use_boundaries"][depth] for other in siblings) else "loop"
+        discriminator = {
+            "kind": kind,
+            "instance_count": instance_count,
+            "instance_key": builtins.list(path),
+        }
+        if kind == "use":
+            discriminator["repeated"] = True
+            discriminator["repeated_use"] = True
+        elif kind == "loop":
+            discriminator["loop"] = True
+        return discriminator
+
+
+    def _renforge_editor_divergence_depth(siblings):
+        """First path segment on which sibling instances disagree."""
+        for depth in builtins.range(builtins.min(len(other["path"]) for other in siblings)):
+            if len(set(other["path"][depth] for other in siblings)) > 1:
+                return depth
+        return None
+
+
+    def _renforge_editor_rebind_signature(runtime_key):
+        """Identity a target keeps across frames, ignoring focus_list order.
+
+        Repeated statements share screen, id and source location, so the cache
+        instance key is what tells their instances apart. It is absent for a
+        unique statement, which leaves the signature unchanged.
+        """
+        discriminator = runtime_key.get("instance_discriminator") or {}
+        instance_key = discriminator.get("instance_key")
+        return (
+            str(runtime_key.get("screen") or ""),
+            str(runtime_key.get("widget_id") or ""),
+            tuple(runtime_key.get("source_location") or []),
+            tuple(instance_key) if isinstance(instance_key, (builtins.list, tuple)) else None,
+        )
+
+
     def _renforge_editor_descendant_ids(widget):
         found = set()
         stack = [widget]
@@ -775,12 +900,24 @@ init 1100 python:
         return "none"
 
 
-    def _renforge_editor_runtime_key_from_focus(focus, ordinal):
+    def _renforge_editor_runtime_key_from_focus(focus, ordinal, instances=None):
         screen_name = _renforge_editor_screen_name(focus)
         if not isinstance(screen_name, str):
             return None, "MISSING_INVOCATION_PATH", None, None
         widget = getattr(focus, "widget", None)
+        cache_index = instances.get(screen_name) if instances else None
+        cache_entry = cache_index["entries"].get(id(widget)) if cache_index else None
         screen, widget_id, resolve_error = _renforge_editor_resolve_widget_id(screen_name, widget)
+        if resolve_error == "SYNTHETIC_WIDGET_ID" and cache_entry is not None:
+            # A sibling instance of the same statement owns the authored id.
+            if cache_index["statement_ids"] is None:
+                cache_index["statement_ids"] = _renforge_editor_statement_widget_ids(
+                    screen_name,
+                    cache_index["entries"],
+                )
+            statement_id = cache_index["statement_ids"].get(cache_entry["path"][-1])
+            if statement_id:
+                widget_id, resolve_error = statement_id, None
         if resolve_error is not None:
             return None, resolve_error, None, None
         if not isinstance(widget_id, str) or not widget_id:
@@ -793,10 +930,14 @@ init 1100 python:
             named_widget = widgets.get(widget_id)
         if named_widget is None:
             named_widget = widget
+        # The source location belongs to the statement, so a sibling instance
+        # from the widgets map carries it; ancestry and geometry must come from
+        # the focused instance, whose parents can differ between call sites.
         source_location = _renforge_editor_location(named_widget)
         if source_location is None:
             return None, "MISSING_SOURCE_LOCATION", None, None
-        ancestry_nodes = _renforge_editor_find_ancestry(screen, named_widget)
+        instance_widget = widget if cache_entry is not None else named_widget
+        ancestry_nodes = _renforge_editor_find_ancestry(screen, instance_widget)
         if not ancestry_nodes:
             return None, "UNKNOWN_ANCESTRY_TYPE", None, None
         ancestry = []
@@ -834,16 +975,21 @@ init 1100 python:
                     "layout": layout_name,
                 }
             )
+        discriminator = {"kind": "static", "instance_count": 1}
+        if cache_entry is not None:
+            measured = _renforge_editor_instance_discriminator(
+                cache_entry,
+                cache_index["entries"],
+            )
+            if measured is not None:
+                discriminator = measured
+        discriminator["ordinal"] = int(ordinal)
         key = {
             "screen": screen_name,
             "invocation_path": screen_name,
             "widget_id": widget_id,
             "source_location": source_location,
-            "instance_discriminator": {
-                "kind": "static",
-                "instance_count": 1,
-                "ordinal": int(ordinal),
-            },
+            "instance_discriminator": discriminator,
             "ancestry": ancestry,
         }
         return key, None, named_widget, widget
@@ -901,8 +1047,23 @@ init 1100 python:
         return None
 
 
+    def _renforge_editor_screen_instances(screen_name, instances):
+        """Cache-derived instance identity for one screen, built once per frame."""
+        if screen_name in instances:
+            return instances[screen_name]
+        screen, _widgets = _renforge_editor_widget_map(screen_name)
+        instances[screen_name] = {
+            "entries": _renforge_editor_cache_index(screen) if screen is not None else {},
+            # Resolving statement ids costs a descendant walk per statement, so
+            # it is deferred until a widget id actually fails to resolve.
+            "statement_ids": None,
+        }
+        return instances[screen_name]
+
+
     def _renforge_editor_focus_candidates():
         candidates = []
+        instances = {}
         try:
             focus_list = list(renpy.display.focus.focus_list or [])
         except Exception:
@@ -920,11 +1081,14 @@ init 1100 python:
                 continue
             if rect[2] <= 0 or rect[3] <= 0:
                 continue
+            screen_name = _renforge_editor_screen_name(focus)
+            if isinstance(screen_name, str):
+                _renforge_editor_screen_instances(screen_name, instances)
             runtime_key, resolve_error, named_widget, focused_widget = _renforge_editor_runtime_key_from_focus(
                 focus,
                 ordinal,
+                instances,
             )
-            screen_name = _renforge_editor_screen_name(focus)
             owner_hit = bool(screen_name in _EDITOR_SCREENS)
             if runtime_key is not None:
                 for node in runtime_key.get("ancestry", []):
@@ -962,8 +1126,15 @@ init 1100 python:
                 key.get("widget_id"),
                 tuple(key.get("source_location") or []),
             )
-            if counts.get(signature, 0) > 1:
-                candidate["resolve_error"] = "MULTI_INSTANCE_UNSUPPORTED"
+            if counts.get(signature, 0) <= 1:
+                continue
+            # Repetition the cache walk identified is not ambiguity: the host
+            # gets a distinct instance key and answers with the precise
+            # repetition lock. Only unidentified duplicates stay ambiguous.
+            discriminator = key.get("instance_discriminator") or {}
+            if discriminator.get("kind") in ("loop", "use"):
+                continue
+            candidate["resolve_error"] = "MULTI_INSTANCE_UNSUPPORTED"
         return candidates
 
 
@@ -2511,21 +2682,12 @@ init 1100 python:
         if not candidates:
             # fallback by stable signature
             candidates = []
-            wanted = (
-                str(runtime_key.get("screen") or ""),
-                str(runtime_key.get("widget_id") or ""),
-                tuple(runtime_key.get("source_location") or []),
-            )
+            wanted = _renforge_editor_rebind_signature(runtime_key)
             for candidate in _renforge_editor_focus_candidates():
                 candidate_key = candidate.get("runtime_key")
                 if not isinstance(candidate_key, builtins.dict):
                     continue
-                signature = (
-                    str(candidate_key.get("screen") or ""),
-                    str(candidate_key.get("widget_id") or ""),
-                    tuple(candidate_key.get("source_location") or []),
-                )
-                if signature == wanted:
+                if _renforge_editor_rebind_signature(candidate_key) == wanted:
                     candidates.append(candidate)
         if len(candidates) > 1:
             return {"ok": False, "error": "AMBIGUOUS_REBIND"}
@@ -2581,22 +2743,13 @@ init 1100 python:
                 and isinstance(candidate.get("runtime_key", {}).get("source_location"), list)
             ]
             if not targets:
-                wanted = (
-                    str(expected_runtime_key.get("screen") or ""),
-                    str(expected_runtime_key.get("widget_id") or ""),
-                    tuple(expected_runtime_key.get("source_location") or []),
-                )
+                wanted = _renforge_editor_rebind_signature(expected_runtime_key)
                 signature_matches = []
                 for candidate in _renforge_editor_focus_candidates():
                     candidate_key = candidate.get("runtime_key")
                     if not isinstance(candidate_key, builtins.dict):
                         continue
-                    signature = (
-                        str(candidate_key.get("screen") or ""),
-                        str(candidate_key.get("widget_id") or ""),
-                        tuple(candidate_key.get("source_location") or []),
-                    )
-                    if signature == wanted:
+                    if _renforge_editor_rebind_signature(candidate_key) == wanted:
                         signature_matches.append(candidate)
                 if len(signature_matches) > 1:
                     return {"ok": False, "error": "AMBIGUOUS_REBIND", "widget_id": widget_id}

--- a/src/renforge/bridge/editor.rpy
+++ b/src/renforge/bridge/editor.rpy
@@ -760,20 +760,31 @@ init 1100 python:
         return statement_ids
 
 
-    def _renforge_editor_instance_discriminator(entry, cache_index):
+    def _renforge_editor_statement_siblings(cache_index):
+        """Group cache entries by the statement that produced them.
+
+        Built once per screen per frame: scanning the whole index for every
+        focus candidate instead would cost O(candidates × entries).
+        """
+        siblings = {}
+        for entry in cache_index.values():
+            path = entry["path"]
+            if path:
+                siblings.setdefault(path[-1], []).append(entry)
+        return siblings
+
+
+    def _renforge_editor_instance_discriminator(entry, statement_siblings):
         """Describe how many runtime instances share one authored statement.
 
         Instances of the same statement share the terminal cache segment (the
         statement serial) and differ earlier in the path. The divergent segment
         tells loop iterations apart from repeated `use` call sites.
         """
-        if not entry:
-            return None
         path = entry["path"]
-        terminal = path[-1] if path else None
-        siblings = [
-            other for other in cache_index.values() if other["path"] and other["path"][-1] == terminal
-        ]
+        siblings = statement_siblings.get(path[-1]) if path else None
+        if not siblings:
+            return None
         instance_count = len(siblings)
         # A unique instance keeps the bare static descriptor. Cache paths carry
         # AST serials that are reassigned on every script reload, so they must
@@ -979,7 +990,7 @@ init 1100 python:
         if cache_entry is not None:
             measured = _renforge_editor_instance_discriminator(
                 cache_entry,
-                cache_index["entries"],
+                cache_index["statement_siblings"],
             )
             if measured is not None:
                 discriminator = measured
@@ -1052,8 +1063,10 @@ init 1100 python:
         if screen_name in instances:
             return instances[screen_name]
         screen, _widgets = _renforge_editor_widget_map(screen_name)
+        entries = _renforge_editor_cache_index(screen) if screen is not None else {}
         instances[screen_name] = {
-            "entries": _renforge_editor_cache_index(screen) if screen is not None else {},
+            "entries": entries,
+            "statement_siblings": _renforge_editor_statement_siblings(entries),
             # Resolving statement ids costs a descendant walk per statement, so
             # it is deferred until a widget id actually fails to resolve.
             "statement_ids": None,

--- a/src/renforge/editor/coordinator.py
+++ b/src/renforge/editor/coordinator.py
@@ -510,7 +510,8 @@ class EditorCoordinator:
             if self._script_generation != generation:
                 raise EditorError("SCRIPT_GENERATION_MISMATCH", "observation generation does not match coordinator")
 
-        lock_reason = self._runtime_lock_reason(runtime_key)
+        runtime_lock_reason = self._runtime_lock_reason(runtime_key)
+        lock_reason = runtime_lock_reason
         source_key: dict[str, Any] | None = None
         runtime_position = self._extract_position(independent)
         original_position = list(runtime_position)
@@ -688,6 +689,12 @@ class EditorCoordinator:
             lock_reason = self._lock_reason(exc.code, exc.message)
         except (OSError, UnicodeDecodeError) as exc:
             lock_reason = self._lock_reason("SOURCE_READ_FAILED", f"unable to read source: {exc}")
+
+        # Instance identity gates the source form. A repeated statement stays
+        # locked for being repeated, whatever its position keywords read like;
+        # otherwise the reported reason would depend on which gate ran last.
+        if runtime_lock_reason is not None:
+            lock_reason = runtime_lock_reason
 
         analysis_id = uuid.uuid4().hex
         record = _AnalysisRecord(

--- a/src/renforge/editor/coordinator.py
+++ b/src/renforge/editor/coordinator.py
@@ -684,17 +684,16 @@ class EditorCoordinator:
         except EditorPathError as exc:
             lock_reason = self._lock_reason(exc.code, str(exc))
         except EditorSourceError as exc:
-            lock_reason = self._lock_reason(exc.code, str(exc))
+            # Identity outranks source form: a repeated statement stays locked
+            # for being repeated, whatever its position keywords read like, so
+            # the reason does not depend on which gate ran last. Read, path and
+            # generation failures below are not form questions and keep their
+            # own reason.
+            lock_reason = runtime_lock_reason or self._lock_reason(exc.code, str(exc))
         except EditorError as exc:
             lock_reason = self._lock_reason(exc.code, exc.message)
         except (OSError, UnicodeDecodeError) as exc:
             lock_reason = self._lock_reason("SOURCE_READ_FAILED", f"unable to read source: {exc}")
-
-        # Instance identity gates the source form. A repeated statement stays
-        # locked for being repeated, whatever its position keywords read like;
-        # otherwise the reported reason would depend on which gate ran last.
-        if runtime_lock_reason is not None:
-            lock_reason = runtime_lock_reason
 
         analysis_id = uuid.uuid4().hex
         record = _AnalysisRecord(

--- a/src/renforge/editor_align_runner.py
+++ b/src/renforge/editor_align_runner.py
@@ -183,14 +183,14 @@ def run_editor_align_live_scenario(client: Any, *, fixture_path: Path) -> dict[s
     if ambiguous in (None, ""):
         status = _wait_for_status(
             client,
-            lambda current: current.get("selected_lock_reason") == "SYNTHETIC_WIDGET_ID",
+            lambda current: current.get("selected_lock_reason") == "REPEATED_USE_UNSUPPORTED",
             timeout=10.0,
             poll_name="pos dupe lock",
         )
         ambiguous = status.get("selected_lock_reason")
-    if ambiguous != "SYNTHETIC_WIDGET_ID":
+    if ambiguous != "REPEATED_USE_UNSUPPORTED":
         raise AssertionError(
-            f"duplicate align textbutton lock was not SYNTHETIC_WIDGET_ID: {ambiguous!r}"
+            f"duplicate align textbutton lock was not REPEATED_USE_UNSUPPORTED: {ambiguous!r}"
         )
     report["locks"]["ambiguous"] = ambiguous
 

--- a/src/renforge/editor_align_runner.py
+++ b/src/renforge/editor_align_runner.py
@@ -153,7 +153,8 @@ def run_editor_align_live_scenario(client: Any, *, fixture_path: Path) -> dict[s
     }
 
     # Measured live: two use-statements share id "align_dupe_target". The first
-    # instance is still selectable by focus bounds and locks as SYNTHETIC_WIDGET_ID
+    # instance now resolves through the SL2 cache path and locks as
+    # REPEATED_USE_UNSUPPORTED (issue #42)
     # (list_ui may only name the second instance).
     dupe_info = list_ui_info(client, FIXTURE_SCREEN)
     dupe_elements = dupe_info.get("elements") if isinstance(dupe_info, dict) else None

--- a/src/renforge/editor_align_runner.py
+++ b/src/renforge/editor_align_runner.py
@@ -16,6 +16,7 @@ from renforge.editor_live_common import (
     inject_editor_live_resources,
     list_ui_info,
     observe_selected as _observe_selected,
+    repeated_use_lock,
     select_lock,
     sha256_file as _sha256_file,
     wait_bounds,
@@ -173,27 +174,7 @@ def run_editor_align_live_scenario(client: Any, *, fixture_path: Path) -> dict[s
             break
     if dupe_pick is None:
         raise AssertionError(f"could not locate first dupe bounds: {dupe_elements!r}")
-    dupe_select = client.request(
-        "editor_task0_select",
-        {
-            "x": int(dupe_pick["x"]) + max(2, int(dupe_pick["width"]) // 4),
-            "y": int(dupe_pick["y"]) + int(dupe_pick["height"]) // 2,
-        },
-    )
-    ambiguous = dupe_select.get("lock_reason") if isinstance(dupe_select, dict) else None
-    if ambiguous in (None, ""):
-        status = _wait_for_status(
-            client,
-            lambda current: current.get("selected_lock_reason") == "REPEATED_USE_UNSUPPORTED",
-            timeout=10.0,
-            poll_name="pos dupe lock",
-        )
-        ambiguous = status.get("selected_lock_reason")
-    if ambiguous != "REPEATED_USE_UNSUPPORTED":
-        raise AssertionError(
-            f"duplicate align textbutton lock was not REPEATED_USE_UNSUPPORTED: {ambiguous!r}"
-        )
-    report["locks"]["ambiguous"] = ambiguous
+    report["locks"]["ambiguous"] = repeated_use_lock(client, label="align textbutton", bounds=dupe_pick)
 
     # Measured live: Side is not in the ancestry allowlist → UNKNOWN_ANCESTRY_TYPE.
     side_bounds = wait_bounds(client, "align_side", timeout=3.0, fixture_screen=FIXTURE_SCREEN)

--- a/src/renforge/editor_anchor_runner.py
+++ b/src/renforge/editor_anchor_runner.py
@@ -16,6 +16,7 @@ from renforge.editor_live_common import (
     inject_editor_live_resources,
     list_ui_info,
     observe_selected as _observe_selected,
+    repeated_use_lock,
     select_lock,
     sha256_file as _sha256_file,
     wait_bounds,
@@ -130,27 +131,7 @@ def run_editor_anchor_live_scenario(client: Any, *, fixture_path: Path) -> dict[
             break
     if dupe_pick is None:
         raise AssertionError(f"could not locate first dupe bounds: {dupe_elements!r}")
-    dupe_select = client.request(
-        "editor_task0_select",
-        {
-            "x": int(dupe_pick["x"]) + max(2, int(dupe_pick["width"]) // 4),
-            "y": int(dupe_pick["y"]) + int(dupe_pick["height"]) // 2,
-        },
-    )
-    ambiguous = dupe_select.get("lock_reason") if isinstance(dupe_select, dict) else None
-    if ambiguous in (None, ""):
-        status = _wait_for_status(
-            client,
-            lambda current: current.get("selected_lock_reason") == "REPEATED_USE_UNSUPPORTED",
-            timeout=10.0,
-            poll_name="pos dupe lock",
-        )
-        ambiguous = status.get("selected_lock_reason")
-    if ambiguous != "REPEATED_USE_UNSUPPORTED":
-        raise AssertionError(
-            f"duplicate anchor textbutton lock was not REPEATED_USE_UNSUPPORTED: {ambiguous!r}"
-        )
-    report["locks"]["ambiguous"] = ambiguous
+    report["locks"]["ambiguous"] = repeated_use_lock(client, label="anchor textbutton", bounds=dupe_pick)
 
     # Measured live: Side is not in the ancestry allowlist → UNKNOWN_ANCESTRY_TYPE.
     side_bounds = wait_bounds(client, "anchor_side", timeout=3.0, fixture_screen=FIXTURE_SCREEN)

--- a/src/renforge/editor_anchor_runner.py
+++ b/src/renforge/editor_anchor_runner.py
@@ -110,7 +110,8 @@ def run_editor_anchor_live_scenario(client: Any, *, fixture_path: Path) -> dict[
     }
 
     # Measured live: two use-statements share id "anchor_dupe_target". The first
-    # instance is still selectable by focus bounds and locks as SYNTHETIC_WIDGET_ID
+    # instance now resolves through the SL2 cache path and locks as
+    # REPEATED_USE_UNSUPPORTED (issue #42)
     # (list_ui may only name the second instance).
     dupe_info = list_ui_info(client, FIXTURE_SCREEN)
     dupe_elements = dupe_info.get("elements") if isinstance(dupe_info, dict) else None

--- a/src/renforge/editor_anchor_runner.py
+++ b/src/renforge/editor_anchor_runner.py
@@ -140,14 +140,14 @@ def run_editor_anchor_live_scenario(client: Any, *, fixture_path: Path) -> dict[
     if ambiguous in (None, ""):
         status = _wait_for_status(
             client,
-            lambda current: current.get("selected_lock_reason") == "SYNTHETIC_WIDGET_ID",
+            lambda current: current.get("selected_lock_reason") == "REPEATED_USE_UNSUPPORTED",
             timeout=10.0,
             poll_name="pos dupe lock",
         )
         ambiguous = status.get("selected_lock_reason")
-    if ambiguous != "SYNTHETIC_WIDGET_ID":
+    if ambiguous != "REPEATED_USE_UNSUPPORTED":
         raise AssertionError(
-            f"duplicate anchor textbutton lock was not SYNTHETIC_WIDGET_ID: {ambiguous!r}"
+            f"duplicate anchor textbutton lock was not REPEATED_USE_UNSUPPORTED: {ambiguous!r}"
         )
     report["locks"]["ambiguous"] = ambiguous
 

--- a/src/renforge/editor_bar_runner.py
+++ b/src/renforge/editor_bar_runner.py
@@ -197,7 +197,7 @@ def run_editor_bar_live_scenario(client: Any, *, fixture_path: Path) -> dict[str
     }
 
     # Measured live: two use-statements with the same id surface as
-    # bar_dupe_target / bar_dupe_target#2 and resolve with SYNTHETIC_WIDGET_ID.
+    # bar_dupe_target / bar_dupe_target#2 and resolve with REPEATED_USE_UNSUPPORTED.
     dupe_info = _list_info(client)
     dupe_elements = dupe_info.get("elements") if isinstance(dupe_info, dict) else None
     dupe_candidates = [

--- a/src/renforge/editor_bar_runner.py
+++ b/src/renforge/editor_bar_runner.py
@@ -12,6 +12,7 @@ from renforge.editor_task0_runner import (
     _source_generation,
     _wait_for_status,
 )
+from renforge.editor_live_common import repeated_use_lock
 
 FIXTURE_SCREEN = "renforge_editor_bar_fixture"
 TARGET_ID = "bar_target"
@@ -214,25 +215,7 @@ def run_editor_bar_live_scenario(client: Any, *, fixture_path: Path) -> dict[str
     dupe_bounds = dupe.get("bounds")
     if not isinstance(dupe_bounds, dict):
         raise AssertionError(f"duplicate bar has no focus bounds: {dupe!r}")
-    dupe_select = client.request(
-        "editor_task0_select",
-        {
-            "x": int(dupe_bounds["x"]) + max(2, int(dupe_bounds["width"]) // 4),
-            "y": int(dupe_bounds["y"]) + int(dupe_bounds["height"]) // 2,
-        },
-    )
-    ambiguous = dupe_select.get("lock_reason") if isinstance(dupe_select, dict) else None
-    if ambiguous in (None, ""):
-        status = _wait_for_status(
-            client,
-            lambda current: current.get("selected_lock_reason") == "REPEATED_USE_UNSUPPORTED",
-            timeout=10.0,
-            poll_name="bar dupe lock",
-        )
-        ambiguous = status.get("selected_lock_reason")
-    if ambiguous != "REPEATED_USE_UNSUPPORTED":
-        raise AssertionError(f"duplicate bar lock was not REPEATED_USE_UNSUPPORTED: {ambiguous!r}")
-    report["locks"]["ambiguous"] = ambiguous
+    report["locks"]["ambiguous"] = repeated_use_lock(client, label="bar", bounds=dupe_bounds)
 
     # Measured live: Side is not in the ancestry allowlist → UNKNOWN_ANCESTRY_TYPE.
     side_bounds = _wait_bounds(client, "bar_side", timeout=3.0)

--- a/src/renforge/editor_bar_runner.py
+++ b/src/renforge/editor_bar_runner.py
@@ -225,13 +225,13 @@ def run_editor_bar_live_scenario(client: Any, *, fixture_path: Path) -> dict[str
     if ambiguous in (None, ""):
         status = _wait_for_status(
             client,
-            lambda current: current.get("selected_lock_reason") not in (None, ""),
+            lambda current: current.get("selected_lock_reason") == "REPEATED_USE_UNSUPPORTED",
             timeout=10.0,
             poll_name="bar dupe lock",
         )
         ambiguous = status.get("selected_lock_reason")
-    if ambiguous != "SYNTHETIC_WIDGET_ID":
-        raise AssertionError(f"duplicate bar lock was not SYNTHETIC_WIDGET_ID: {ambiguous!r}")
+    if ambiguous != "REPEATED_USE_UNSUPPORTED":
+        raise AssertionError(f"duplicate bar lock was not REPEATED_USE_UNSUPPORTED: {ambiguous!r}")
     report["locks"]["ambiguous"] = ambiguous
 
     # Measured live: Side is not in the ancestry allowlist → UNKNOWN_ANCESTRY_TYPE.

--- a/src/renforge/editor_button_runner.py
+++ b/src/renforge/editor_button_runner.py
@@ -12,6 +12,7 @@ from renforge.editor_task0_runner import (
     _source_generation,
     _wait_for_status,
 )
+from renforge.editor_live_common import repeated_use_lock
 
 FIXTURE_SCREEN = "renforge_editor_button_fixture"
 TARGET_ID = "button_target"
@@ -259,26 +260,12 @@ def run_editor_button_live_scenario(client: Any, *, fixture_path: Path) -> dict[
     dupe_bounds = dupe.get("bounds")
     if not isinstance(dupe_bounds, dict):
         raise AssertionError(f"duplicate button has no focus bounds: {dupe!r}")
-    dupe_select = client.request(
-        "editor_task0_select",
-        {
-            "x": int(dupe_bounds["x"]) + 3,
-            "y": int(dupe_bounds["y"]) + int(dupe_bounds["height"]) - 2,
-        },
+    # The button block needs a hit point near its bottom-left corner.
+    report["locks"]["ambiguous"] = repeated_use_lock(
+        client,
+        label="button",
+        point=(int(dupe_bounds["x"]) + 3, int(dupe_bounds["y"]) + int(dupe_bounds["height"]) - 2),
     )
-    ambiguous = dupe_select.get("lock_reason") if isinstance(dupe_select, dict) else None
-    if ambiguous in (None, "", "ANALYZING"):
-        # The repetition lock is decided by the host, so it settles after select.
-        status = _wait_for_status(
-            client,
-            lambda current: current.get("selected_lock_reason") == "REPEATED_USE_UNSUPPORTED",
-            timeout=10.0,
-            poll_name="button dupe lock",
-        )
-        ambiguous = status.get("selected_lock_reason")
-    if ambiguous != "REPEATED_USE_UNSUPPORTED":
-        raise AssertionError(f"duplicate button was not locked as repeated use: {dupe_select!r}")
-    report["locks"]["ambiguous"] = ambiguous
 
     unknown = client.request(
         "editor_task0_validate_runtime_key",

--- a/src/renforge/editor_button_runner.py
+++ b/src/renforge/editor_button_runner.py
@@ -267,8 +267,17 @@ def run_editor_button_live_scenario(client: Any, *, fixture_path: Path) -> dict[
         },
     )
     ambiguous = dupe_select.get("lock_reason") if isinstance(dupe_select, dict) else None
-    if ambiguous not in {"SYNTHETIC_WIDGET_ID", "MULTI_INSTANCE_UNSUPPORTED"}:
-        raise AssertionError(f"duplicate button was not locked ambiguously: {dupe_select!r}")
+    if ambiguous in (None, "", "ANALYZING"):
+        # The repetition lock is decided by the host, so it settles after select.
+        status = _wait_for_status(
+            client,
+            lambda current: current.get("selected_lock_reason") == "REPEATED_USE_UNSUPPORTED",
+            timeout=10.0,
+            poll_name="button dupe lock",
+        )
+        ambiguous = status.get("selected_lock_reason")
+    if ambiguous != "REPEATED_USE_UNSUPPORTED":
+        raise AssertionError(f"duplicate button was not locked as repeated use: {dupe_select!r}")
     report["locks"]["ambiguous"] = ambiguous
 
     unknown = client.request(

--- a/src/renforge/editor_live_common.py
+++ b/src/renforge/editor_live_common.py
@@ -134,6 +134,44 @@ def select_lock(
     return str(lock_reason)
 
 
+def repeated_use_lock(
+    client: Any,
+    *,
+    label: str,
+    bounds: dict[str, Any] | None = None,
+    point: tuple[int, int] | None = None,
+) -> str:
+    """Select one instance of a repeated `use` and return its settled lock.
+
+    The repetition lock is decided by the host rather than the bridge, so it is
+    normally absent from the immediate select reply and has to be polled
+    (issue #42). Pass `point` when a fixture needs a specific hit location;
+    otherwise the click lands left of centre, which keeps it inside the first
+    instance when two share a row.
+    """
+    if point is None:
+        if bounds is None:
+            raise AssertionError(f"{label} dupe lock needs bounds or an explicit point")
+        point = (
+            int(bounds["x"]) + max(2, int(bounds["width"]) // 4),
+            int(bounds["y"]) + int(bounds["height"]) // 2,
+        )
+    reply = client.request("editor_task0_select", {"x": point[0], "y": point[1]})
+    lock_reason = reply.get("lock_reason") if isinstance(reply, dict) else None
+    if lock_reason in (None, "", "ANALYZING"):
+        lock_reason = _wait_for_status(
+            client,
+            lambda current: current.get("selected_lock_reason") == "REPEATED_USE_UNSUPPORTED",
+            timeout=10.0,
+            poll_name=f"{label} dupe lock",
+        ).get("selected_lock_reason")
+    if lock_reason != "REPEATED_USE_UNSUPPORTED":
+        raise AssertionError(
+            f"duplicate {label} lock was not REPEATED_USE_UNSUPPORTED: {lock_reason!r}"
+        )
+    return str(lock_reason)
+
+
 def observe_selected(client: Any) -> dict[str, Any]:
     reply = client.request("editor_task0_observe_selected", {})
     if not isinstance(reply, dict) or reply.get("ok") is not True:

--- a/src/renforge/editor_loop_runner.py
+++ b/src/renforge/editor_loop_runner.py
@@ -1,0 +1,252 @@
+"""Live proof for repeated loop and `use` instance disambiguation (issue #42).
+
+The spike answers two separate questions and reaches two different verdicts.
+
+**Selection — proven.** Ren'Py keys each `SLFor` iteration in its SL2 cache by
+the author's own loop index and gives every `use` call site its own cache dict.
+That path identifies one runtime instance of a repeated statement without any
+synthetic identity, which `screen.widgets` cannot do because it keeps a single
+displayable per widget id.
+
+**Instance-specific source write — blocked.** Every repetition shape stores the
+authored position in exactly one place shared by all N instances, so no write
+can move one instance alone:
+
+- literal position in a loop  → N coincident instances, one literal
+- loop-derived position       → an expression, locked by the expression gate
+- layout-positioned in a loop → locked by the container gate
+- repeated `use`              → N call sites, one authored line
+
+Moving one instance would require synthesising a per-instance expression, which
+the roadmap forbids: the editor does not normalise the author's source. The gate
+therefore stays locked, and this runner proves the lock holds and is precise.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import shutil
+import time
+from pathlib import Path
+from typing import Any
+
+from renforge.editor_task0_runner import _require_ok, _wait_for_status
+
+FIXTURE_SCREEN = "renforge_editor_loop_fixture"
+EDITOR_RESOURCE = Path(__file__).resolve().parent / "bridge" / "editor.rpy"
+FIXTURE_RESOURCE = (
+    Path(__file__).resolve().parents[2]
+    / "tests"
+    / "live_fixtures"
+    / "renforge_editor_loop_fixture.rpy"
+)
+
+# Fixture lines that back each repetition case, asserted so the proof fails loudly
+# if the fixture is edited without revisiting the verdict.
+LITERAL_LOOP_LINE = 24
+EXPRESSION_LOOP_LINE = 29
+VBOX_LOOP_LINE = 40
+REPEATED_USE_LINE = 8
+UNIQUE_LINE = 60
+
+
+def inject_editor_loop_resources(project_root: Path) -> dict[str, str]:
+    game_dir = project_root / "game"
+    game_dir.mkdir(parents=True, exist_ok=True)
+    editor_target = game_dir / "zz_renforge_editor_loop.rpy"
+    fixture_target = game_dir / "zz_renforge_editor_loop_fixture.rpy"
+    shutil.copyfile(EDITOR_RESOURCE, editor_target)
+    shutil.copyfile(FIXTURE_RESOURCE, fixture_target)
+    return {"editor": str(editor_target), "fixture": str(fixture_target)}
+
+
+def _elements(client: Any) -> list[dict[str, Any]]:
+    info = client.list_ui_elements_info(screen=FIXTURE_SCREEN)
+    if not isinstance(info, dict):
+        raise AssertionError(f"list_ui_elements_info returned non-dict: {info!r}")
+    elements = info.get("elements")
+    return elements if isinstance(elements, list) else []
+
+
+def _bounds_in_band(client: Any, band: dict[str, int], *, timeout: float = 6.0) -> list[dict[str, int]]:
+    """Focus rects in one region of the fixture.
+
+    Instances are located geometrically rather than by widget id on purpose:
+    `list_ui_elements` names only the last instance of a repeated statement and
+    invents synthetic ids for its siblings, which is the very lossiness this
+    proof exists to characterise.
+    """
+    axis, value = ("x", band["x"]) if "x" in band else ("y", band["y"])
+    deadline = time.monotonic() + timeout
+    last: list[dict[str, Any]] = []
+    while time.monotonic() < deadline:
+        last = _elements(client)
+        found = []
+        for element in last:
+            bounds = element.get("bounds")
+            if not isinstance(bounds, dict) or int(bounds[axis]) != value:
+                continue
+            found.append(
+                {
+                    "x": int(bounds["x"]),
+                    "y": int(bounds["y"]),
+                    "width": int(bounds["width"]),
+                    "height": int(bounds["height"]),
+                }
+            )
+        if found:
+            return sorted(found, key=lambda item: (item["y"], item["x"]))
+        time.sleep(0.05)
+    raise AssertionError(f"no bounds in band {band!r}: {last!r}")
+
+
+def _select_at(client: Any, bounds: dict[str, int], expected_lock: str | None) -> dict[str, Any]:
+    """Select the instance under a rect and return its settled status."""
+    reply = client.request(
+        "editor_task0_select",
+        {
+            "x": int(bounds["x"]) + max(2, int(bounds["width"]) // 4),
+            "y": int(bounds["y"]) + int(bounds["height"]) // 2,
+        },
+    )
+    if not isinstance(reply, dict):
+        raise AssertionError(f"select returned non-dict: {reply!r}")
+    if expected_lock is None:
+        return _wait_for_status(
+            client,
+            lambda current: current.get("selected_runtime_key") is not None,
+            timeout=10.0,
+            poll_name="loop select",
+        )
+    return _wait_for_status(
+        client,
+        lambda current: current.get("selected_lock_reason") == expected_lock,
+        timeout=10.0,
+        poll_name=f"loop {expected_lock}",
+    )
+
+
+def _instance_facts(status: dict[str, Any]) -> dict[str, Any]:
+    runtime_key = status.get("selected_runtime_key")
+    if not isinstance(runtime_key, dict):
+        raise AssertionError(f"selection carries no runtime key: {status!r}")
+    discriminator = runtime_key.get("instance_discriminator")
+    if not isinstance(discriminator, dict):
+        raise AssertionError(f"selection carries no discriminator: {runtime_key!r}")
+    source_location = runtime_key.get("source_location") or [None, None]
+    return {
+        "widget_id": runtime_key.get("widget_id"),
+        "source_line": source_location[1],
+        "kind": discriminator.get("kind"),
+        "instance_count": discriminator.get("instance_count"),
+        "instance_key": discriminator.get("instance_key"),
+        "lock_reason": status.get("selected_lock_reason"),
+    }
+
+
+def _prove_repetition(
+    client: Any,
+    *,
+    widget_id: str,
+    band: dict[str, int],
+    expected_kind: str,
+    expected_lock: str,
+    expected_count: int,
+    expected_line: int,
+) -> dict[str, Any]:
+    """Select every instance of one repeated statement and record its identity."""
+    rects = _bounds_in_band(client, band)
+    observed = []
+    for bounds in rects:
+        facts = _instance_facts(_select_at(client, bounds, expected_lock))
+        if facts["kind"] != expected_kind:
+            raise AssertionError(f"{widget_id} kind was {facts['kind']!r}, want {expected_kind!r}")
+        if facts["instance_count"] != expected_count:
+            raise AssertionError(
+                f"{widget_id} instance_count was {facts['instance_count']!r}, want {expected_count}"
+            )
+        if facts["source_line"] != expected_line:
+            raise AssertionError(
+                f"{widget_id} source line was {facts['source_line']!r}, want {expected_line}"
+            )
+        observed.append({"rect": bounds, **facts})
+    return {
+        "widget_id": widget_id,
+        "instances": observed,
+        "selectable_instance_count": len(observed),
+        "distinct_instance_keys": len({str(item["instance_key"]) for item in observed}),
+    }
+
+
+def run_editor_loop_live_scenario(client: Any, *, fixture_path: Path) -> dict[str, Any]:
+    """Prove instances are distinguishable and that the write gate holds."""
+    baseline_sha = hashlib.sha256(fixture_path.read_bytes()).hexdigest()
+    _require_ok(client.request("editor_task0_start", {"screen": FIXTURE_SCREEN}), "loop start")
+
+    report: dict[str, Any] = {"baseline_sha256": baseline_sha}
+
+    # A vertically stacked loop is the only repetition whose instances can each
+    # be clicked, so it carries the "select the intended instance" evidence.
+    report["vbox_loop"] = _prove_repetition(
+        client,
+        widget_id="loop_vbox_target",
+        band={"x": 900},
+        expected_kind="loop",
+        expected_lock="LOOP_INSTANCE_UNSUPPORTED",
+        expected_count=3,
+        expected_line=VBOX_LOOP_LINE,
+    )
+    report["expression_loop"] = _prove_repetition(
+        client,
+        widget_id="loop_expr_target",
+        band={"y": 300},
+        expected_kind="loop",
+        expected_lock="LOOP_INSTANCE_UNSUPPORTED",
+        expected_count=3,
+        expected_line=EXPRESSION_LOOP_LINE,
+    )
+    report["repeated_use"] = _prove_repetition(
+        client,
+        widget_id="loop_used_target",
+        band={"y": 500},
+        expected_kind="use",
+        expected_lock="REPEATED_USE_UNSUPPORTED",
+        expected_count=2,
+        expected_line=REPEATED_USE_LINE,
+    )
+
+    # A literal position inside a loop cannot depend on the loop variable, so the
+    # three instances coincide. Only the topmost is clickable; the discriminator
+    # still reports all three, which is exactly why the write stays blocked.
+    literal_rects = _bounds_in_band(client, {"y": 160})
+    literal_facts = _instance_facts(
+        _select_at(client, literal_rects[0], "LOOP_INSTANCE_UNSUPPORTED")
+    )
+    if literal_facts["source_line"] != LITERAL_LOOP_LINE:
+        raise AssertionError(f"literal loop line was {literal_facts['source_line']!r}")
+    report["literal_loop"] = {
+        "coincident_rects": literal_rects,
+        "distinct_origins": len({(r["x"], r["y"]) for r in literal_rects}),
+        **literal_facts,
+    }
+
+    # Control: a non-repeated statement on the same screen stays static and is
+    # not caught by the repetition gate.
+    unique_facts = _instance_facts(_select_at(client, _bounds_in_band(client, {"y": 600})[0], None))
+    if unique_facts["kind"] != "static" or unique_facts["instance_count"] != 1:
+        raise AssertionError(f"unique control was not static: {unique_facts!r}")
+    if unique_facts["lock_reason"] in ("LOOP_INSTANCE_UNSUPPORTED", "REPEATED_USE_UNSUPPORTED"):
+        raise AssertionError(f"unique control hit a repetition lock: {unique_facts!r}")
+    if unique_facts["source_line"] != UNIQUE_LINE:
+        raise AssertionError(f"unique control line was {unique_facts['source_line']!r}")
+    report["unique_control"] = unique_facts
+
+    # The gate held: nothing in this scenario was allowed to touch the source.
+    report["source_unchanged"] = (
+        hashlib.sha256(fixture_path.read_bytes()).hexdigest() == baseline_sha
+    )
+    report["verdict"] = {
+        "selection": "proven",
+        "instance_specific_source_write": "blocked",
+    }
+    return report

--- a/src/renforge/editor_multiline_textbutton_runner.py
+++ b/src/renforge/editor_multiline_textbutton_runner.py
@@ -277,14 +277,14 @@ def run_editor_multiline_textbutton_live_scenario(client: Any, *, fixture_path: 
     if ambiguous in (None, ""):
         status = _wait_for_status(
             client,
-            lambda current: current.get("selected_lock_reason") == "SYNTHETIC_WIDGET_ID",
+            lambda current: current.get("selected_lock_reason") == "REPEATED_USE_UNSUPPORTED",
             timeout=10.0,
             poll_name="ml tb dupe lock",
         )
         ambiguous = status.get("selected_lock_reason")
-    if ambiguous != "SYNTHETIC_WIDGET_ID":
+    if ambiguous != "REPEATED_USE_UNSUPPORTED":
         raise AssertionError(
-            f"duplicate multiline textbutton lock was not SYNTHETIC_WIDGET_ID: {ambiguous!r}"
+            f"duplicate multiline textbutton lock was not REPEATED_USE_UNSUPPORTED: {ambiguous!r}"
         )
     report["locks"]["ambiguous"] = ambiguous
 

--- a/src/renforge/editor_multiline_textbutton_runner.py
+++ b/src/renforge/editor_multiline_textbutton_runner.py
@@ -247,7 +247,8 @@ def run_editor_multiline_textbutton_live_scenario(client: Any, *, fixture_path: 
     }
 
     # Measured live: two use-statements share id "ml_tb_dupe_target". The first
-    # instance is still selectable by focus bounds and locks as SYNTHETIC_WIDGET_ID
+    # instance now resolves through the SL2 cache path and locks as
+    # REPEATED_USE_UNSUPPORTED (issue #42)
     # (list_ui may only name the second instance).
     dupe_info = _list_info(client)
     dupe_elements = dupe_info.get("elements") if isinstance(dupe_info, dict) else None

--- a/src/renforge/editor_multiline_textbutton_runner.py
+++ b/src/renforge/editor_multiline_textbutton_runner.py
@@ -13,6 +13,7 @@ from renforge.editor_task0_runner import (
     _source_generation,
     _wait_for_status,
 )
+from renforge.editor_live_common import repeated_use_lock
 
 FIXTURE_SCREEN = "renforge_editor_multiline_textbutton_fixture"
 TARGET_ID = "ml_tb_target"
@@ -267,27 +268,7 @@ def run_editor_multiline_textbutton_live_scenario(client: Any, *, fixture_path: 
             break
     if dupe_pick is None:
         raise AssertionError(f"could not locate first dupe bounds: {dupe_elements!r}")
-    dupe_select = client.request(
-        "editor_task0_select",
-        {
-            "x": int(dupe_pick["x"]) + max(2, int(dupe_pick["width"]) // 4),
-            "y": int(dupe_pick["y"]) + int(dupe_pick["height"]) // 2,
-        },
-    )
-    ambiguous = dupe_select.get("lock_reason") if isinstance(dupe_select, dict) else None
-    if ambiguous in (None, ""):
-        status = _wait_for_status(
-            client,
-            lambda current: current.get("selected_lock_reason") == "REPEATED_USE_UNSUPPORTED",
-            timeout=10.0,
-            poll_name="ml tb dupe lock",
-        )
-        ambiguous = status.get("selected_lock_reason")
-    if ambiguous != "REPEATED_USE_UNSUPPORTED":
-        raise AssertionError(
-            f"duplicate multiline textbutton lock was not REPEATED_USE_UNSUPPORTED: {ambiguous!r}"
-        )
-    report["locks"]["ambiguous"] = ambiguous
+    report["locks"]["ambiguous"] = repeated_use_lock(client, label="multiline textbutton", bounds=dupe_pick)
 
     # Measured live: Side is not in the ancestry allowlist → UNKNOWN_ANCESTRY_TYPE.
     side_bounds = _wait_bounds(client, "ml_tb_side", timeout=3.0)

--- a/src/renforge/editor_offset_runner.py
+++ b/src/renforge/editor_offset_runner.py
@@ -16,6 +16,7 @@ from renforge.editor_live_common import (
     inject_editor_live_resources,
     list_ui_info,
     observe_selected as _observe_selected,
+    repeated_use_lock,
     select_lock,
     sha256_file as _sha256_file,
     wait_bounds,
@@ -145,27 +146,7 @@ def run_editor_offset_live_scenario(client: Any, *, fixture_path: Path) -> dict[
             break
     if dupe_pick is None:
         raise AssertionError(f"could not locate first dupe bounds: {dupe_elements!r}")
-    dupe_select = client.request(
-        "editor_task0_select",
-        {
-            "x": int(dupe_pick["x"]) + max(2, int(dupe_pick["width"]) // 4),
-            "y": int(dupe_pick["y"]) + int(dupe_pick["height"]) // 2,
-        },
-    )
-    ambiguous = dupe_select.get("lock_reason") if isinstance(dupe_select, dict) else None
-    if ambiguous in (None, ""):
-        status = _wait_for_status(
-            client,
-            lambda current: current.get("selected_lock_reason") == "REPEATED_USE_UNSUPPORTED",
-            timeout=10.0,
-            poll_name="offset dupe lock",
-        )
-        ambiguous = status.get("selected_lock_reason")
-    if ambiguous != "REPEATED_USE_UNSUPPORTED":
-        raise AssertionError(
-            f"duplicate offset textbutton lock was not REPEATED_USE_UNSUPPORTED: {ambiguous!r}"
-        )
-    report["locks"]["ambiguous"] = ambiguous
+    report["locks"]["ambiguous"] = repeated_use_lock(client, label="offset textbutton", bounds=dupe_pick)
 
     # Measured live: Side is not in the ancestry allowlist → UNKNOWN_ANCESTRY_TYPE.
     side_bounds = wait_bounds(client, "offset_side", timeout=3.0, fixture_screen=FIXTURE_SCREEN)

--- a/src/renforge/editor_offset_runner.py
+++ b/src/renforge/editor_offset_runner.py
@@ -125,7 +125,8 @@ def run_editor_offset_live_scenario(client: Any, *, fixture_path: Path) -> dict[
     }
 
     # Measured live: two use-statements share id "offset_dupe_target". The first
-    # instance is still selectable by focus bounds and locks as SYNTHETIC_WIDGET_ID
+    # instance now resolves through the SL2 cache path and locks as
+    # REPEATED_USE_UNSUPPORTED (issue #42)
     # (list_ui may only name the second instance).
     dupe_info = list_ui_info(client, FIXTURE_SCREEN)
     dupe_elements = dupe_info.get("elements") if isinstance(dupe_info, dict) else None
@@ -155,14 +156,14 @@ def run_editor_offset_live_scenario(client: Any, *, fixture_path: Path) -> dict[
     if ambiguous in (None, ""):
         status = _wait_for_status(
             client,
-            lambda current: current.get("selected_lock_reason") == "SYNTHETIC_WIDGET_ID",
+            lambda current: current.get("selected_lock_reason") == "REPEATED_USE_UNSUPPORTED",
             timeout=10.0,
             poll_name="offset dupe lock",
         )
         ambiguous = status.get("selected_lock_reason")
-    if ambiguous != "SYNTHETIC_WIDGET_ID":
+    if ambiguous != "REPEATED_USE_UNSUPPORTED":
         raise AssertionError(
-            f"duplicate offset textbutton lock was not SYNTHETIC_WIDGET_ID: {ambiguous!r}"
+            f"duplicate offset textbutton lock was not REPEATED_USE_UNSUPPORTED: {ambiguous!r}"
         )
     report["locks"]["ambiguous"] = ambiguous
 

--- a/src/renforge/editor_pos_runner.py
+++ b/src/renforge/editor_pos_runner.py
@@ -115,9 +115,9 @@ def run_editor_pos_live_scenario(client: Any, *, fixture_path: Path) -> dict[str
         "container": select_lock(client, "pos_container", "CONTAINER_POSITION_UNSUPPORTED", fixture_screen=FIXTURE_SCREEN),
     }
 
-    # Measured live: two use-statements share id "pos_dupe_target". The first
-    # instance is still selectable by focus bounds and locks as SYNTHETIC_WIDGET_ID
-    # (list_ui may only name the second instance).
+    # Measured live: two use-statements share id "pos_dupe_target". Both
+    # instances now resolve through the SL2 cache path and lock with the
+    # precise REPEATED_USE_UNSUPPORTED reason (issue #42).
     dupe_info = list_ui_info(client, FIXTURE_SCREEN)
     dupe_elements = dupe_info.get("elements") if isinstance(dupe_info, dict) else None
     # Prefer the unnamed first instance (NullAction-ish id) then fall back to
@@ -146,14 +146,14 @@ def run_editor_pos_live_scenario(client: Any, *, fixture_path: Path) -> dict[str
     if ambiguous in (None, ""):
         status = _wait_for_status(
             client,
-            lambda current: current.get("selected_lock_reason") == "SYNTHETIC_WIDGET_ID",
+            lambda current: current.get("selected_lock_reason") == "REPEATED_USE_UNSUPPORTED",
             timeout=10.0,
             poll_name="pos dupe lock",
         )
         ambiguous = status.get("selected_lock_reason")
-    if ambiguous != "SYNTHETIC_WIDGET_ID":
+    if ambiguous != "REPEATED_USE_UNSUPPORTED":
         raise AssertionError(
-            f"duplicate pos textbutton lock was not SYNTHETIC_WIDGET_ID: {ambiguous!r}"
+            f"duplicate pos textbutton lock was not REPEATED_USE_UNSUPPORTED: {ambiguous!r}"
         )
     report["locks"]["ambiguous"] = ambiguous
 

--- a/src/renforge/editor_pos_runner.py
+++ b/src/renforge/editor_pos_runner.py
@@ -16,6 +16,7 @@ from renforge.editor_live_common import (
     inject_editor_live_resources,
     list_ui_info,
     observe_selected as _observe_selected,
+    repeated_use_lock,
     select_lock,
     sha256_file as _sha256_file,
     wait_bounds,
@@ -135,27 +136,7 @@ def run_editor_pos_live_scenario(client: Any, *, fixture_path: Path) -> dict[str
             break
     if dupe_pick is None:
         raise AssertionError(f"could not locate first dupe bounds: {dupe_elements!r}")
-    dupe_select = client.request(
-        "editor_task0_select",
-        {
-            "x": int(dupe_pick["x"]) + max(2, int(dupe_pick["width"]) // 4),
-            "y": int(dupe_pick["y"]) + int(dupe_pick["height"]) // 2,
-        },
-    )
-    ambiguous = dupe_select.get("lock_reason") if isinstance(dupe_select, dict) else None
-    if ambiguous in (None, ""):
-        status = _wait_for_status(
-            client,
-            lambda current: current.get("selected_lock_reason") == "REPEATED_USE_UNSUPPORTED",
-            timeout=10.0,
-            poll_name="pos dupe lock",
-        )
-        ambiguous = status.get("selected_lock_reason")
-    if ambiguous != "REPEATED_USE_UNSUPPORTED":
-        raise AssertionError(
-            f"duplicate pos textbutton lock was not REPEATED_USE_UNSUPPORTED: {ambiguous!r}"
-        )
-    report["locks"]["ambiguous"] = ambiguous
+    report["locks"]["ambiguous"] = repeated_use_lock(client, label="pos textbutton", bounds=dupe_pick)
 
     # Measured live: Side is not in the ancestry allowlist → UNKNOWN_ANCESTRY_TYPE.
     side_bounds = wait_bounds(client, "pos_side", timeout=3.0, fixture_screen=FIXTURE_SCREEN)

--- a/src/renforge/editor_slider_runner.py
+++ b/src/renforge/editor_slider_runner.py
@@ -231,13 +231,13 @@ def run_editor_slider_live_scenario(client: Any, *, fixture_path: Path) -> dict[
     if ambiguous in (None, ""):
         status = _wait_for_status(
             client,
-            lambda current: current.get("selected_lock_reason") == "SYNTHETIC_WIDGET_ID",
+            lambda current: current.get("selected_lock_reason") == "REPEATED_USE_UNSUPPORTED",
             timeout=10.0,
             poll_name="slider dupe lock",
         )
         ambiguous = status.get("selected_lock_reason")
-    if ambiguous != "SYNTHETIC_WIDGET_ID":
-        raise AssertionError(f"duplicate slider lock was not SYNTHETIC_WIDGET_ID: {ambiguous!r}")
+    if ambiguous != "REPEATED_USE_UNSUPPORTED":
+        raise AssertionError(f"duplicate slider lock was not REPEATED_USE_UNSUPPORTED: {ambiguous!r}")
     report["locks"]["ambiguous"] = ambiguous
 
     # Measured live: Side is not in the ancestry allowlist → UNKNOWN_ANCESTRY_TYPE.

--- a/src/renforge/editor_slider_runner.py
+++ b/src/renforge/editor_slider_runner.py
@@ -203,7 +203,7 @@ def run_editor_slider_live_scenario(client: Any, *, fixture_path: Path) -> dict[
     }
 
     # Measured live: two use-statements with the same id surface as
-    # slider_dupe_target / slider_dupe_target#2 and resolve with SYNTHETIC_WIDGET_ID.
+    # slider_dupe_target / slider_dupe_target#2 and resolve with REPEATED_USE_UNSUPPORTED.
     dupe_info = _list_info(client)
     dupe_elements = dupe_info.get("elements") if isinstance(dupe_info, dict) else None
     dupe_candidates = [

--- a/src/renforge/editor_slider_runner.py
+++ b/src/renforge/editor_slider_runner.py
@@ -13,6 +13,7 @@ from renforge.editor_task0_runner import (
     _source_generation,
     _wait_for_status,
 )
+from renforge.editor_live_common import repeated_use_lock
 
 FIXTURE_SCREEN = "renforge_editor_slider_fixture"
 TARGET_ID = "slider_target"
@@ -220,25 +221,7 @@ def run_editor_slider_live_scenario(client: Any, *, fixture_path: Path) -> dict[
     dupe_bounds = dupe.get("bounds")
     if not isinstance(dupe_bounds, dict):
         raise AssertionError(f"duplicate slider has no focus bounds: {dupe!r}")
-    dupe_select = client.request(
-        "editor_task0_select",
-        {
-            "x": int(dupe_bounds["x"]) + max(2, int(dupe_bounds["width"]) // 4),
-            "y": int(dupe_bounds["y"]) + int(dupe_bounds["height"]) // 2,
-        },
-    )
-    ambiguous = dupe_select.get("lock_reason") if isinstance(dupe_select, dict) else None
-    if ambiguous in (None, ""):
-        status = _wait_for_status(
-            client,
-            lambda current: current.get("selected_lock_reason") == "REPEATED_USE_UNSUPPORTED",
-            timeout=10.0,
-            poll_name="slider dupe lock",
-        )
-        ambiguous = status.get("selected_lock_reason")
-    if ambiguous != "REPEATED_USE_UNSUPPORTED":
-        raise AssertionError(f"duplicate slider lock was not REPEATED_USE_UNSUPPORTED: {ambiguous!r}")
-    report["locks"]["ambiguous"] = ambiguous
+    report["locks"]["ambiguous"] = repeated_use_lock(client, label="slider", bounds=dupe_bounds)
 
     # Measured live: Side is not in the ancestry allowlist → UNKNOWN_ANCESTRY_TYPE.
     side_bounds = _wait_bounds(client, "slider_side", timeout=3.0)

--- a/src/renforge/editor_task0_runner.py
+++ b/src/renforge/editor_task0_runner.py
@@ -299,17 +299,15 @@ def run_editor_task0_live_scenario(
     clipped_select = client.request("editor_task0_select", {"x": clipped_center[0], "y": clipped_center[1]})
     report["clipped_lock"] = clipped_select.get("lock_reason")
 
-    dupe_select = client.request("editor_task0_select", {"x": dupe_pick[0], "y": dupe_pick[1]})
-    dupe_lock = dupe_select.get("lock_reason")
-    if dupe_lock in (None, "", "ANALYZING"):
-        # The repetition lock is decided by the host, so it settles after select.
-        dupe_lock = _wait_for_status(
-            client,
-            lambda current: current.get("selected_lock_reason") == "REPEATED_USE_UNSUPPORTED",
-            timeout=10.0,
-            poll_name="task0 dupe lock",
-        ).get("selected_lock_reason")
-    report["dupe_lock"] = dupe_lock
+    # Deferred: editor_live_common imports this module's polling helpers, so a
+    # module-level import here would be circular.
+    from renforge.editor_live_common import repeated_use_lock
+
+    report["dupe_lock"] = repeated_use_lock(
+        client,
+        label="task0",
+        point=(dupe_pick[0], dupe_pick[1]),
+    )
 
     validate_unknown = client.request(
         "editor_task0_validate_runtime_key",

--- a/src/renforge/editor_task0_runner.py
+++ b/src/renforge/editor_task0_runner.py
@@ -300,7 +300,16 @@ def run_editor_task0_live_scenario(
     report["clipped_lock"] = clipped_select.get("lock_reason")
 
     dupe_select = client.request("editor_task0_select", {"x": dupe_pick[0], "y": dupe_pick[1]})
-    report["dupe_lock"] = dupe_select.get("lock_reason")
+    dupe_lock = dupe_select.get("lock_reason")
+    if dupe_lock in (None, "", "ANALYZING"):
+        # The repetition lock is decided by the host, so it settles after select.
+        dupe_lock = _wait_for_status(
+            client,
+            lambda current: current.get("selected_lock_reason") == "REPEATED_USE_UNSUPPORTED",
+            timeout=10.0,
+            poll_name="task0 dupe lock",
+        ).get("selected_lock_reason")
+    report["dupe_lock"] = dupe_lock
 
     validate_unknown = client.request(
         "editor_task0_validate_runtime_key",

--- a/src/renforge/editor_vbar_runner.py
+++ b/src/renforge/editor_vbar_runner.py
@@ -202,7 +202,7 @@ def run_editor_vbar_live_scenario(client: Any, *, fixture_path: Path) -> dict[st
     }
 
     # Measured live: two use-statements with the same id surface as
-    # vbar_dupe_target / vbar_dupe_target#2 and resolve with SYNTHETIC_WIDGET_ID.
+    # vbar_dupe_target / vbar_dupe_target#2 and resolve with REPEATED_USE_UNSUPPORTED.
     dupe_info = _list_info(client)
     dupe_elements = dupe_info.get("elements") if isinstance(dupe_info, dict) else None
     dupe_candidates = [

--- a/src/renforge/editor_vbar_runner.py
+++ b/src/renforge/editor_vbar_runner.py
@@ -13,6 +13,7 @@ from renforge.editor_task0_runner import (
     _source_generation,
     _wait_for_status,
 )
+from renforge.editor_live_common import repeated_use_lock
 
 FIXTURE_SCREEN = "renforge_editor_vbar_fixture"
 TARGET_ID = "vbar_target"
@@ -219,25 +220,7 @@ def run_editor_vbar_live_scenario(client: Any, *, fixture_path: Path) -> dict[st
     dupe_bounds = dupe.get("bounds")
     if not isinstance(dupe_bounds, dict):
         raise AssertionError(f"duplicate vbar has no focus bounds: {dupe!r}")
-    dupe_select = client.request(
-        "editor_task0_select",
-        {
-            "x": int(dupe_bounds["x"]) + max(2, int(dupe_bounds["width"]) // 4),
-            "y": int(dupe_bounds["y"]) + int(dupe_bounds["height"]) // 2,
-        },
-    )
-    ambiguous = dupe_select.get("lock_reason") if isinstance(dupe_select, dict) else None
-    if ambiguous in (None, ""):
-        status = _wait_for_status(
-            client,
-            lambda current: current.get("selected_lock_reason") == "REPEATED_USE_UNSUPPORTED",
-            timeout=10.0,
-            poll_name="vbar dupe lock",
-        )
-        ambiguous = status.get("selected_lock_reason")
-    if ambiguous != "REPEATED_USE_UNSUPPORTED":
-        raise AssertionError(f"duplicate vbar lock was not REPEATED_USE_UNSUPPORTED: {ambiguous!r}")
-    report["locks"]["ambiguous"] = ambiguous
+    report["locks"]["ambiguous"] = repeated_use_lock(client, label="vbar", bounds=dupe_bounds)
 
     # Measured live: Side is not in the ancestry allowlist → UNKNOWN_ANCESTRY_TYPE.
     side_bounds = _wait_bounds(client, "vbar_side", timeout=3.0)

--- a/src/renforge/editor_vbar_runner.py
+++ b/src/renforge/editor_vbar_runner.py
@@ -230,13 +230,13 @@ def run_editor_vbar_live_scenario(client: Any, *, fixture_path: Path) -> dict[st
     if ambiguous in (None, ""):
         status = _wait_for_status(
             client,
-            lambda current: current.get("selected_lock_reason") == "SYNTHETIC_WIDGET_ID",
+            lambda current: current.get("selected_lock_reason") == "REPEATED_USE_UNSUPPORTED",
             timeout=10.0,
             poll_name="vbar dupe lock",
         )
         ambiguous = status.get("selected_lock_reason")
-    if ambiguous != "SYNTHETIC_WIDGET_ID":
-        raise AssertionError(f"duplicate vbar lock was not SYNTHETIC_WIDGET_ID: {ambiguous!r}")
+    if ambiguous != "REPEATED_USE_UNSUPPORTED":
+        raise AssertionError(f"duplicate vbar lock was not REPEATED_USE_UNSUPPORTED: {ambiguous!r}")
     report["locks"]["ambiguous"] = ambiguous
 
     # Measured live: Side is not in the ancestry allowlist → UNKNOWN_ANCESTRY_TYPE.

--- a/tests/live_fixtures/renforge_editor_loop_fixture.rpy
+++ b/tests/live_fixtures/renforge_editor_loop_fixture.rpy
@@ -1,0 +1,60 @@
+default renforge_editor_loop_clicks = 0
+default renforge_editor_loop_items = ["ALPHA", "BETA", "GAMMA"]
+
+
+# Inner screen reached through a repeated `use`. Its position is a literal, so a
+# single authored line backs every call site.
+screen renforge_editor_loop_used():
+    textbutton "USED" id "loop_used_target" xpos 60 ypos 40 action NullAction()
+
+
+screen renforge_editor_loop_fixture():
+    layer "screens"
+    zorder 640
+
+    fixed:
+        id "loop_root"
+        xfill True
+        yfill True
+
+        # Case A: one source line, N runtime widgets, literal position.
+        # Every instance lands on the same coordinates because the literal
+        # cannot depend on the loop variable.
+        for loop_label in renforge_editor_loop_items:
+            textbutton loop_label id "loop_literal_target" xpos 200 ypos 160 action SetVariable("renforge_editor_loop_clicks", renforge_editor_loop_clicks + 1)
+
+        # Case B: same loop, position derived from the loop index. This is the
+        # only way N instances occupy N distinct places, and it is an expression.
+        for loop_index, loop_label in enumerate(renforge_editor_loop_items):
+            textbutton loop_label id "loop_expr_target" xpos 200 + loop_index * 160 ypos 300 action NullAction()
+
+        # Case C: loop with an explicit index expression, which Ren'Py uses to key
+        # the SL2 cache. Position is still layout-computed inside the vbox.
+        vbox:
+            id "loop_vbox_parent"
+            xpos 900
+            ypos 120
+            spacing 10
+
+            for loop_label index loop_label in renforge_editor_loop_items:
+                textbutton loop_label id "loop_vbox_target" action NullAction()
+
+        # Case D: repeated `use` of a screen whose target carries a literal
+        # position. Two distinct call sites, one authored line.
+        fixed:
+            id "loop_use_left"
+            xpos 200
+            ypos 460
+            xysize (300, 90)
+            use renforge_editor_loop_used
+
+        fixed:
+            id "loop_use_right"
+            xpos 620
+            ypos 460
+            xysize (300, 90)
+            use renforge_editor_loop_used
+
+        # Control: a unique, non-repeated target on the same screen, so the probe
+        # can show the discriminator distinguishes repetition from uniqueness.
+        textbutton "UNIQUE" id "loop_unique_target" xpos 200 ypos 600 action NullAction()

--- a/tests/test_editor_align_live.py
+++ b/tests/test_editor_align_live.py
@@ -82,6 +82,6 @@ def test_align_seven_step_live_proof(demo_copy: Path) -> None:
     locks = report["locks"]
     assert locks["computed"] == "ALIGN_LITERAL_REQUIRED"
     assert locks["container"] == "CONTAINER_POSITION_UNSUPPORTED"
-    assert locks["ambiguous"] == "SYNTHETIC_WIDGET_ID"
+    assert locks["ambiguous"] == "REPEATED_USE_UNSUPPORTED"
     assert locks["unproven"] == "UNKNOWN_ANCESTRY_TYPE"
     assert report["byte_identical_undo"]["matches_baseline"] is True

--- a/tests/test_editor_anchor_live.py
+++ b/tests/test_editor_anchor_live.py
@@ -82,6 +82,6 @@ def test_anchor_seven_step_live_proof(demo_copy: Path) -> None:
     locks = report["locks"]
     assert locks["computed"] == "XPOS_LITERAL_REQUIRED"
     assert locks["container"] == "CONTAINER_POSITION_UNSUPPORTED"
-    assert locks["ambiguous"] == "SYNTHETIC_WIDGET_ID"
+    assert locks["ambiguous"] == "REPEATED_USE_UNSUPPORTED"
     assert locks["unproven"] == "UNKNOWN_ANCESTRY_TYPE"
     assert report["byte_identical_undo"]["matches_baseline"] is True

--- a/tests/test_editor_bar_live.py
+++ b/tests/test_editor_bar_live.py
@@ -129,7 +129,7 @@ def test_bar_seven_step_live_proof(demo_copy: Path) -> None:
     assert locks["computed"] == "XPOS_LITERAL_REQUIRED"
     assert locks["style"] == "BAR_STYLE_POSITION_UNSUPPORTED"
     assert locks["container"] == "CONTAINER_POSITION_UNSUPPORTED"
-    assert locks["ambiguous"] == "SYNTHETIC_WIDGET_ID"
+    assert locks["ambiguous"] == "REPEATED_USE_UNSUPPORTED"
     assert locks["unproven"] == "UNKNOWN_ANCESTRY_TYPE"
 
     undo = report["byte_identical_undo"]

--- a/tests/test_editor_button_live.py
+++ b/tests/test_editor_button_live.py
@@ -116,7 +116,7 @@ def test_button_seven_step_live_proof(demo_copy: Path) -> None:
     assert locks["computed"] == "XPOS_LITERAL_REQUIRED"
     assert locks["position_in_block"] == "POSITION_IN_BLOCK"
     assert locks["container"] == "CONTAINER_POSITION_UNSUPPORTED"
-    assert locks["ambiguous"] in {"SYNTHETIC_WIDGET_ID", "MULTI_INSTANCE_UNSUPPORTED"}
+    assert locks["ambiguous"] == "REPEATED_USE_UNSUPPORTED"
     assert locks["unproven"] == "UNKNOWN_ANCESTRY_TYPE"
 
     undo = report["byte_identical_undo"]

--- a/tests/test_editor_coordinator.py
+++ b/tests/test_editor_coordinator.py
@@ -717,6 +717,47 @@ def test_analyze_target_denies_unproven_crop_states(tmp_path: Path, crop_state: 
         coordinator.close()
 
 
+def test_repetition_lock_outranks_a_source_form_lock(tmp_path: Path) -> None:
+    """Issue #42: a repeated statement locks for being repeated, not for its form.
+
+    Both gates are true for a repeated `use` whose position is an expression.
+    Reporting the source-form reason would hide the one that actually blocks the
+    edit, and would make the message depend on which gate ran last.
+    """
+    project, source = _make_project(tmp_path)
+    source.write_text(
+        "screen test_screen:\n"
+        '    textbutton "Play" id "start_btn" xpos left_x ypos 10 action NullAction()\n',
+        encoding="utf-8",
+    )
+    observation = _base_observation()
+    observation["runtime_key"]["instance_discriminator"] = {
+        "kind": "use",
+        "instance_count": 2,
+        "repeated": True,
+        "instance_key": ["0", "17", "12"],
+    }
+    probe = _Probe(
+        observe_reply={
+            **observation,
+            "frame_id": "independent-frame-42",
+            "object_id": "obj-independent-42",
+        }
+    )
+    coordinator = EditorCoordinator(project, _make_sdk(tmp_path))
+    coordinator.attach_runtime_probe(probe)
+    endpoint = coordinator.start()
+    try:
+        with socket.create_connection((endpoint.host, endpoint.port), timeout=2.0) as sock:
+            auth = _auth(sock, endpoint)
+            analysis = _analyze(sock, auth, observation, request_id="an-repeat-precedence")
+            assert analysis["ok"] is True
+            assert analysis["result"]["lock_reason"]["code"] == "REPEATED_USE_UNSUPPORTED"
+            assert analysis["result"]["capabilities"] == {"move": False}
+    finally:
+        coordinator.close()
+
+
 def test_runtime_key_ordinal_drift_is_ignored_for_single_static_instance(tmp_path: Path) -> None:
     project, source = _make_project(tmp_path)
     observation = _base_observation()

--- a/tests/test_editor_loop_live.py
+++ b/tests/test_editor_loop_live.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import os
+import shutil
+import time
+from pathlib import Path
+
+import pytest
+
+from renforge.editor_loop_runner import (
+    FIXTURE_SCREEN,
+    inject_editor_loop_resources,
+    run_editor_loop_live_scenario,
+)
+
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("RENFORGE_LOOP_LIVE"),
+    reason="set RENFORGE_LOOP_LIVE=1 to run the loop / repeated-use disambiguation proof",
+)
+
+_DEMO = Path(__file__).resolve().parents[1] / "examples" / "demo_game"
+
+
+@pytest.fixture
+def demo_copy(tmp_path: Path) -> Path:
+    destination = tmp_path / "demo"
+    shutil.copytree(_DEMO, destination, ignore=shutil.ignore_patterns("*.rpyc", "cache"))
+    inject_editor_loop_resources(destination)
+    return destination
+
+
+def test_loop_instance_disambiguation_live_proof(demo_copy: Path) -> None:
+    from renforge.bridge.launcher import launch_with_bridge
+    from renforge.project import RenpyProject
+    from renforge.sdk import get_or_install_sdk
+
+    sdk = get_or_install_sdk("8.5.3", project_root=demo_copy)
+    project = RenpyProject(demo_copy)
+    fixture_path = demo_copy / "game" / "zz_renforge_editor_loop_fixture.rpy"
+
+    with launch_with_bridge(sdk, project, startup_timeout=120, editor=True) as session:
+        for _ in range(40):
+            launcher = session.client.inspect_screen("_renforge_editor_launcher")
+            if launcher.get("active") is True:
+                break
+            time.sleep(0.25)
+        else:
+            pytest.fail("editor launcher never became active")
+
+        launcher_click = session.client.click_element(
+            text="RF",
+            exact=True,
+            screen="_renforge_editor_launcher",
+        )
+        assert launcher_click.get("ok") is True, launcher_click
+        for _ in range(40):
+            overlay = session.client.inspect_screen("_renforge_editor_overlay")
+            if overlay.get("active") is True:
+                break
+            time.sleep(0.05)
+        else:
+            pytest.fail("editor overlay never became active")
+
+        for _ in range(20):
+            available = session.client.eval_expr(f'renpy.has_screen("{FIXTURE_SCREEN}")')
+            if available is True:
+                break
+            time.sleep(0.1)
+        else:
+            pytest.fail("loop fixture screen never became available")
+
+        report = run_editor_loop_live_scenario(session.client, fixture_path=fixture_path)
+
+    # Selection is proven: each instance of a repeated statement is reachable and
+    # carries its own key, even though they share one source line and one id.
+    vbox = report["vbox_loop"]
+    assert vbox["selectable_instance_count"] == 3
+    assert vbox["distinct_instance_keys"] == 3
+    assert {instance["widget_id"] for instance in vbox["instances"]} == {"loop_vbox_target"}
+    assert {instance["source_line"] for instance in vbox["instances"]} == {40}
+
+    expression = report["expression_loop"]
+    assert expression["distinct_instance_keys"] == 3
+
+    used = report["repeated_use"]
+    assert used["selectable_instance_count"] == 2
+    assert used["distinct_instance_keys"] == 2
+    # Two distinct call sites converge on a single authored line — the reason an
+    # instance-specific write is impossible rather than merely unimplemented.
+    assert {instance["source_line"] for instance in used["instances"]} == {8}
+
+    # A literal position inside a loop yields coincident instances.
+    literal = report["literal_loop"]
+    assert literal["instance_count"] == 3
+    assert literal["distinct_origins"] == 1
+    assert literal["lock_reason"] == "LOOP_INSTANCE_UNSUPPORTED"
+
+    control = report["unique_control"]
+    assert control["kind"] == "static"
+    assert control["instance_count"] == 1
+
+    # The write gate held throughout.
+    assert report["source_unchanged"] is True
+    assert report["verdict"]["instance_specific_source_write"] == "blocked"

--- a/tests/test_editor_multiline_textbutton_live.py
+++ b/tests/test_editor_multiline_textbutton_live.py
@@ -121,7 +121,7 @@ def test_multiline_textbutton_seven_step_live_proof(demo_copy: Path) -> None:
     locks = report["locks"]
     assert locks["computed"] == "XPOS_LITERAL_REQUIRED"
     assert locks["container"] == "CONTAINER_POSITION_UNSUPPORTED"
-    assert locks["ambiguous"] == "SYNTHETIC_WIDGET_ID"
+    assert locks["ambiguous"] == "REPEATED_USE_UNSUPPORTED"
     assert locks["unproven"] == "UNKNOWN_ANCESTRY_TYPE"
 
     undo = report["byte_identical_undo"]

--- a/tests/test_editor_offset_live.py
+++ b/tests/test_editor_offset_live.py
@@ -115,7 +115,7 @@ def test_offset_seven_step_live_proof(demo_copy: Path) -> None:
     locks = report["locks"]
     assert locks["computed"] == "OFFSET_LITERAL_REQUIRED"
     assert locks["container"] == "CONTAINER_POSITION_UNSUPPORTED"
-    assert locks["ambiguous"] == "SYNTHETIC_WIDGET_ID"
+    assert locks["ambiguous"] == "REPEATED_USE_UNSUPPORTED"
     assert locks["unproven"] == "UNKNOWN_ANCESTRY_TYPE"
 
     undo = report["byte_identical_undo"]

--- a/tests/test_editor_pos_live.py
+++ b/tests/test_editor_pos_live.py
@@ -117,7 +117,7 @@ def test_pos_seven_step_live_proof(demo_copy: Path) -> None:
     locks = report["locks"]
     assert locks["computed"] == "POS_LITERAL_REQUIRED"
     assert locks["container"] == "CONTAINER_POSITION_UNSUPPORTED"
-    assert locks["ambiguous"] == "SYNTHETIC_WIDGET_ID"
+    assert locks["ambiguous"] == "REPEATED_USE_UNSUPPORTED"
     assert locks["unproven"] == "UNKNOWN_ANCESTRY_TYPE"
 
     undo = report["byte_identical_undo"]

--- a/tests/test_editor_slider_live.py
+++ b/tests/test_editor_slider_live.py
@@ -133,7 +133,7 @@ def test_slider_seven_step_live_proof(demo_copy: Path) -> None:
     assert locks["style"] == "BAR_STYLE_POSITION_UNSUPPORTED"
     assert locks["missing_position"] == "BAR_STYLE_POSITION_UNSUPPORTED"
     assert locks["container"] == "CONTAINER_POSITION_UNSUPPORTED"
-    assert locks["ambiguous"] == "SYNTHETIC_WIDGET_ID"
+    assert locks["ambiguous"] == "REPEATED_USE_UNSUPPORTED"
     assert locks["unproven"] == "UNKNOWN_ANCESTRY_TYPE"
 
     undo = report["byte_identical_undo"]

--- a/tests/test_editor_task0_live.py
+++ b/tests/test_editor_task0_live.py
@@ -83,7 +83,7 @@ def test_task0_live_editor_prerequisite(demo_copy: Path) -> None:
     assert report["top_select_widget"] == "task0_top"
     assert report["target_select_widget"] == "task0_target"
     assert report["clipped_lock"] == "CLIPPED_ANCESTRY_UNSUPPORTED"
-    assert report["dupe_lock"] in {"MULTI_INSTANCE_UNSUPPORTED", "SYNTHETIC_WIDGET_ID"}
+    assert report["dupe_lock"] == "REPEATED_USE_UNSUPPORTED"
     assert report["multi_instance_lock"] == "MULTI_INSTANCE_UNSUPPORTED"
     assert report["unique_rebind"]["ok"] is True
     assert report["unique_rebind"]["state"] == "all_targets_attested"

--- a/tests/test_editor_vbar_live.py
+++ b/tests/test_editor_vbar_live.py
@@ -133,7 +133,7 @@ def test_vbar_seven_step_live_proof(demo_copy: Path) -> None:
     assert locks["style"] == "BAR_STYLE_POSITION_UNSUPPORTED"
     assert locks["missing_position"] == "BAR_POSITION_NOT_DIRECTLY_AUTHORED"
     assert locks["container"] == "CONTAINER_POSITION_UNSUPPORTED"
-    assert locks["ambiguous"] == "SYNTHETIC_WIDGET_ID"
+    assert locks["ambiguous"] == "REPEATED_USE_UNSUPPORTED"
     assert locks["unproven"] == "UNKNOWN_ANCESTRY_TYPE"
 
     undo = report["byte_identical_undo"]


### PR DESCRIPTION
## Summary

Evidence-gated spike for **issue #42**, with two separate verdicts measured live on Ren'Py **8.5.3**.

**Selection — proven.** Ren'Py keys each `SLFor` iteration in its SL2 cache by the author's own loop index (`slast.py`: `newcaches[index] = ctx.new_cache = {}`) and gives every `use` call site its own cache dict. Walking that cache maps every focus entry to exactly one instance — 12/12 in the fixture, no collisions — using authored data rather than a synthetic id.

`screen.widgets` cannot do this: it stores a single displayable per widget id, so the last iteration overwrites its siblings. That is why these instances previously locked as `SYNTHETIC_WIDGET_ID` **by accident rather than by design**.

**Instance-specific source write — blocked.** This is a property of the source, not a gap in the implementation. Every repetition shape keeps the authored position in one place shared by all N instances:

| Shape | Measured | Why no write is possible |
|---|---|---|
| Literal position in a loop | 3 instances, all at `(200,160)` | One literal serves N; a write moves all of them |
| Loop-derived position | 3 instances at `x = 200 + i·160` | The position is an expression, locked by the expression gate |
| Layout-positioned in a loop | 3 instances in a `vbox` | Locked by the container gate |
| Repeated `use` | 2 call sites, both resolving to line 8 | One authored line backs both sites |

Moving one instance alone would require synthesising a per-instance expression, which the roadmap's design rule forbids — the editor does not normalise the author's source. **The gate stays locked**, as the issue's acceptance criteria allow.

## What changed

- The gate is now **precise**: `LOOP_INSTANCE_UNSUPPORTED` / `REPEATED_USE_UNSUPPORTED` replace the incidental `SYNTHETIC_WIDGET_ID`. Both were previously dead code — the bridge hardcoded `{"kind": "static", "instance_count": 1}` for every widget, so the discriminator was simply untrue.
- The runtime key carries `kind`, `instance_count` and `instance_key`, which is what a designed failed-gate UI needs (#52).
- **Identity outranks source form.** When a statement is both repeated and expression-positioned, the analysis reports the repetition lock; otherwise the reason depended on which gate ran last.
- **Rebinding disambiguates by instance key** instead of returning `AMBIGUOUS_REBIND`.

## Blast radius

Seven existing fixtures use a repeated `use` for their duplicate target, so their expected lock moves from `SYNTHETIC_WIDGET_ID` to `REPEATED_USE_UNSUPPORTED`. Three runners (`bar`, `button`, `task0`) read the immediate select reply; the repetition lock is now decided host-side, so they poll for the settled status like the other runners already did.

## Known limit

`instance_key` holds SL2 AST serials, which Ren'Py reassigns on every script reload. It is stable within one script generation — enough to rebind during a session — and is deliberately **omitted for unique statements** so it never enters their rebinding equality.

## Validation

```text
pytest tests/                                    609 passed, 32 skipped
all 11 live proofs (RENFORGE_*_LIVE=1)           620 passed, 21 skipped
```

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Prouver la désambiguïsation à l’exécution des instances répétées de boucles et de `use`, en gardant la sélection précise tout en verrouillant explicitement les modifications de source spécifiques à une instance.

New Features:
- Ajouter une discrimination des instances basée sur le cache pour les cibles de focus, incluant des métadonnées boucle vs `use` par instance et des signatures de rebind stables.
- Introduire un runner et un fixture pour boucle en direct / `use` répété afin de démontrer la sélection par instance et la porte d’écriture bloquée dans de vraies sessions Ren'Py.

Bug Fixes:
- Remplacer `SYNTHETIC_WIDGET_ID` (incidental) et l’ambiguïté générique multi‑instances par des raisons de verrouillage précises `LOOP_INSTANCE_UNSUPPORTED` et `REPEATED_USE_UNSUPPORTED`.
- S’assurer que les opérations de rebind distinguent les instances répétées par clés d’instance, éliminant `AMBIGUOUS_REBIND` lorsque la désambiguïsation à l’exécution est disponible.

Enhancements:
- Dériver l’identité des widgets pour les instructions répétées à partir du chemin de cache SL2 plutôt que de `screen.widgets`, permettant un mapping du focus par instance sans IDs synthétiques.
- Faire en sorte que les verrous de répétition prévalent sur les verrous de forme source, de sorte que l’analyse signale systématiquement la répétition comme raison de blocage lorsque les deux portes s’appliquent.
- Affiner la gestion des candidats au focus pour traiter les répétitions de boucle/`use` connues comme non ambiguës tout en continuant à signaler les doublons non identifiés.
- Mettre à jour l’analyse du coordinateur pour préserver les raisons de verrouillage d’exécution par rapport aux portes de forme source, alignant les messages visibles par l’utilisateur sur la véritable condition de blocage.

Documentation:
- Étendre la feuille de route et les spécifications de périmètre V1 pour documenter la sélection de répétition prouvée, les verrous précis `LOOP_INSTANCE_UNSUPPORTED` / `REPEATED_USE_UNSUPPORTED`, et la justification de conception pour le blocage des écritures spécifiques à une instance.

Tests:
- Ajouter des tests unitaires et en conditions réelles pour la priorité des verrous de répétition par rapport aux verrous de forme source, ainsi que pour la désambiguïsation basée sur le cache des instances de boucle et de `use` répété à travers fixtures et runners.
- Mettre à jour les tests existants du runner de l’éditeur en direct et de preuve pour s’attendre à `REPEATED_USE_UNSUPPORTED` au lieu de `SYNTHETIC_WIDGET_ID` dans les scénarios de `use` répété.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Prove runtime disambiguation of repeated loop and `use` instances, keeping selection precise while explicitly locking instance-specific source edits.

New Features:
- Add cache-based instance discrimination for focus targets, including per-instance loop vs `use` metadata and stable rebinding signatures.
- Introduce a live loop/repeated-`use` runner and fixture to demonstrate per-instance selection and the blocked write gate in real Ren'Py sessions.

Bug Fixes:
- Replace incidental `SYNTHETIC_WIDGET_ID` and generic multi-instance ambiguity with precise `LOOP_INSTANCE_UNSUPPORTED` and `REPEATED_USE_UNSUPPORTED` lock reasons.
- Ensure rebind operations distinguish repeated instances by instance keys, eliminating `AMBIGUOUS_REBIND` when runtime disambiguation is available.

Enhancements:
- Derive widget identity for repeated statements from the SL2 cache path rather than `screen.widgets`, enabling per-instance focus mapping without synthetic IDs.
- Make repetition locks outrank source-form locks so analysis consistently reports repetition as the blocking reason when both gates apply.
- Refine focus candidate handling to treat known loop/`use` repetitions as non-ambiguous while still flagging unidentified duplicates.
- Update coordinator analysis to preserve runtime lock reasons over source-form gates, aligning user-visible messages with the true blocking condition.

Documentation:
- Extend roadmap and V1 scope specs to document proven repetition selection, precise `LOOP_INSTANCE_UNSUPPORTED` / `REPEATED_USE_UNSUPPORTED` locks, and the design rationale for blocking instance-specific writes.

Tests:
- Add unit and live tests for repetition lock precedence over source-form locks and for cache-based disambiguation of loop and repeated `use` instances across fixtures and runners.
- Update existing live editor runner and proof tests to expect `REPEATED_USE_UNSUPPORTED` instead of `SYNTHETIC_WIDGET_ID` for repeated `use` scenarios.

</details>