### PR TITLE
feat(editor): unlock pure Transform(crop=) ancestry (#45)

### DIFF
--- a/docs/superpowers/specs/2026-07-30-renforge-visual-editor-v1-scope.md
+++ b/docs/superpowers/specs/2026-07-30-renforge-visual-editor-v1-scope.md
@@ -261,6 +261,7 @@ with delta-only source comparison (screen-space `preview_position` ≠ child-spa
 
 | Shape | Reason |
 |---|---|
+| Partially crop-clipped child | `TRANSFORM_CROP_PARTIAL_UNSUPPORTED` |
 | Crop + rotate or crop + zoom | `TRANSFORM_CROP_COMPOSITE_UNSUPPORTED` (issue #46) |
 | Layout container inside the crop | `CONTAINER_POSITION_UNSUPPORTED`, unchanged |
 | Expression ypos inside the crop | `YPOS_LITERAL_REQUIRED`, unchanged |

--- a/docs/superpowers/specs/2026-07-30-renforge-visual-editor-v1-scope.md
+++ b/docs/superpowers/specs/2026-07-30-renforge-visual-editor-v1-scope.md
@@ -261,7 +261,9 @@ with delta-only source comparison (screen-space `preview_position` ≠ child-spa
 
 | Shape | Reason |
 |---|---|
-| Partially crop-clipped child | `TRANSFORM_CROP_PARTIAL_UNSUPPORTED` |
+| Partially crop-clipped child | `TRANSFORM_CROP_PARTIAL_UNSUPPORTED` (any 1px size reduction) |
+| Visibility unmeasurable | `TRANSFORM_CROP_UNPROVEN` |
+| Nested crop transforms | `NESTED_TRANSFORM_CROP_UNSUPPORTED` |
 | Crop + rotate or crop + zoom | `TRANSFORM_CROP_COMPOSITE_UNSUPPORTED` (issue #46) |
 | Layout container inside the crop | `CONTAINER_POSITION_UNSUPPORTED`, unchanged |
 | Expression ypos inside the crop | `YPOS_LITERAL_REQUIRED`, unchanged |

--- a/docs/superpowers/specs/2026-07-30-renforge-visual-editor-v1-scope.md
+++ b/docs/superpowers/specs/2026-07-30-renforge-visual-editor-v1-scope.md
@@ -37,7 +37,7 @@ requires it — none is arbitrary.
 | 1 | Displayable is **focusable** | Selection and every save-bearing measurement read `renpy.display.focus.focus_list` |
 | 2 | Source statement carries one **literal `id`** matching the runtime widget id | Runtime preview uses `_widget_properties`, keyed by the authored widget id; synthetic observation IDs do not qualify |
 | 3 | A proven adapter statement (`textbutton` single-line or multi-line block, `imagebutton`, single-line `bar`/`vbar`, slider-styled `bar`) or an explicit-block `button`, with one literal integer **`xpos` and `ypos`** | The token-aware patcher replaces only the coordinate spans; block forms preserve every non-position byte |
-| 4 | Exactly one runtime instance with a fully classified, static ancestry — at most one **`viewport`** (issue #44), and outside **`Crop` / `Transform(crop=)`**, loop and repeated `use` cases | A repeated statement stores its position once for all N instances, so no write can move one of them alone (issue #42) |
+| 4 | Exactly one runtime instance with a fully classified, static ancestry — at most one **`viewport`** (issue #44), at most pure **`Transform(crop=)` / `Crop()` sugar** (issue #45), and outside crop+rotate/zoom, `clipping True`, loop and repeated `use` cases | A repeated statement stores its position once for all N instances, so no write can move one of them alone (issue #42) |
 
 **A failing gate is a first-class UI state, never a silent no-op.** The overlay must name which gate
 failed and why, e.g. *"`text` is not focusable — cannot be selected in V1"* or
@@ -239,6 +239,34 @@ child space. They coincide only when no ancestor offsets the child, which is why
 could compare them directly.
 
 Live proof: `RENFORGE_VIEWPORT_LIVE=1 uv run --extra test python -m pytest -q tests/test_editor_viewport_live.py`
+against Ren'Py **8.5.3**.
+
+### Targets under pure `Transform(crop=)` / `Crop()` (issue #45)
+
+**Identity:** on Ren'Py 8.5.3, `Crop(rect, child)` is a constructor that returns
+`Transform(child, crop=rect)` (`renpy/display/layout.py`). Live ancestry reports `type == "Transform"`
+and `crop_state == "transform_crop"` — never a class named `Crop`.
+
+**Unlocked:** exactly one pure-crop `Transform` in the ancestry (crop set; rotate/zoom at defaults),
+with a plain `fixed` child and a fully-visible single-line `textbutton` (literal id + xpos/ypos).
+
+Measured on Ren'Py **8.5.3** via `RENFORGE_CROP_LIVE=1`: pure crop already **clips focus rects** to the
+crop window. A partially clipped sibling reports a shorter focus height than a natural outside control
+(e.g. focus height 15 vs natural ~35) while remaining fully inside the crop AABB; a fully clipped
+control is **absent** from `list_ui_elements`. Focus therefore tracks visible geometry under pure crop
+— the same kind of engine-truth finding as viewport scroll (#44). The seven-step write chain is green
+with delta-only source comparison (screen-space `preview_position` ≠ child-space authored values).
+
+**Still locked, each with its own reason:**
+
+| Shape | Reason |
+|---|---|
+| Crop + rotate or crop + zoom | `TRANSFORM_CROP_COMPOSITE_UNSUPPORTED` (issue #46) |
+| Layout container inside the crop | `CONTAINER_POSITION_UNSUPPORTED`, unchanged |
+| Expression ypos inside the crop | `YPOS_LITERAL_REQUIRED`, unchanged |
+| `fixed` + `clipping True` | bridge `CLIPPED_ANCESTRY_UNSUPPORTED` / unproven |
+
+Live proof: `RENFORGE_CROP_LIVE=1 uv run --extra test python -m pytest -q tests/test_editor_crop_live.py`
 against Ren'Py **8.5.3**.
 
 ## Proven mechanisms (do not redesign)

--- a/docs/superpowers/specs/2026-07-30-renforge-visual-editor-vfull-roadmap.md
+++ b/docs/superpowers/specs/2026-07-30-renforge-visual-editor-vfull-roadmap.md
@@ -149,8 +149,7 @@ untested; product selection UX remains Stage 3 work.
 Only `fixed` + `clipping True` was exercised. Remaining, and common:
 
 - `viewport` — **unlocked for one measured shape (issue #44)**, see below
-- `Crop`
-- `Transform(crop=)`
+- `Crop` / `Transform(crop=)` — **same runtime object; pure crop unlocked (issue #45)**, see below
 
 ### `viewport` (issue #44) — unlocked at resting scroll
 
@@ -172,7 +171,7 @@ green for a target inside a viewport — no viewport term was needed anywhere.
 | Nested viewports | `NESTED_VIEWPORT_UNSUPPORTED` — two scroll offsets compose, never measured |
 | `scrollbars "..."` | `UNKNOWN_ANCESTRY_TYPE` — it wraps the viewport in a `Side` |
 | Layout container inside a viewport | `CONTAINER_POSITION_UNSUPPORTED`, unchanged |
-| `Crop`, `Transform(crop=)`, `clipping True` | unchanged |
+| `clipping True` | unchanged (still unproven) |
 
 **Known limitation — committing while scrolled.** Ren'Py rebuilds the screen on `reload_script` and
 the viewport adjustment does not survive it (measured: 120 before, 0 after). The host then attests a
@@ -191,6 +190,51 @@ ancestor offset the child. Anything reading one as the other is wrong under a vi
 
 `draggable True` is deliberately outside the proven shape: it turns the editor's own click into a
 scroll, so the two drag behaviours fight.
+
+### `Crop` / pure `Transform(crop=)` (issue #45) — unlocked for pure crop only
+
+**Identity (measured, not assumed):** on Ren'Py **8.5.3**,
+`Crop(rect, child)` is defined as `return Transform(child, crop=rect, **properties)`
+(`renpy/display/layout.py`). There is no runtime class named `Crop`. Live ancestry for both
+`Crop(...)` sugar and `fixed at Transform(crop=...)` reports:
+
+- `type == "Transform"`
+- `crop_state == "transform_crop"` when crop is set and rotate/zoom stay at defaults
+- `crop_state == "transform_crop_composite"` when rotate or non-default zoom is also set
+
+Branches that key on `class_name` containing `"Crop"`, host `ancestor_type == "Crop"`, or
+`crop_state == "crop"` do not fire on this SDK for authored `Crop()` / pure crop; pure-crop locks
+that previously refused observation were `CLIPPED_ANCESTRY_UNSUPPORTED` (bridge) then
+`TRANSFORM_CROP_UNSUPPORTED` (host). Those pure-crop gates are opened; composite keeps a **distinct**
+host reason.
+
+**Visible geometry (the issue's central risk):** measured via focus AABB ∩ crop window and sibling
+height comparison under `RENFORGE_CROP_LIVE=1`:
+
+| Target | Focus vs crop | Notes (8.5.3) |
+|---|---|---|
+| Fully inside (`crop_target`) | fully inside crop window | seven-step write target |
+| Partially clipped (`crop_partial` at child y=185) | focus height **shorter than natural sibling** (e.g. 15 vs ~35) and still fully inside crop AABB | engine **already clips** focus to the crop — not an unclipped layout box |
+| Fully clipped (`crop_fullclip`) | **absent** from `list_ui_elements` | cannot be selected as if painted |
+
+So pure crop behaves like the viewport case for editor math: focus tracks visible geometry, and
+`runtime_rect + Δ` needs no extra crop term. Screen-space `preview_position` still differs from
+child-space authored `xpos`/`ypos` by the crop window origin — compare **deltas** only.
+
+**Unlocked:** exactly one pure `transform_crop` ancestor (`Transform` with crop only), plain `fixed`
+child, fully-visible literal `textbutton`.
+
+**Still locked:**
+
+| Shape | Reason |
+|---|---|
+| Crop + rotate / crop + zoom | `TRANSFORM_CROP_COMPOSITE_UNSUPPORTED` (issue #46) |
+| Layout container inside crop | `CONTAINER_POSITION_UNSUPPORTED` |
+| Expression position inside crop | `YPOS_LITERAL_REQUIRED` |
+| `fixed` + `clipping True` | still unproven at bridge |
+
+Live proof: `RENFORGE_CROP_LIVE=1 pytest tests/test_editor_crop_live.py`
+Criteria: `docs/superpowers/spikes/2026-08-02-transform-crop-criteria.md`.
 
 ---
 

--- a/docs/superpowers/specs/2026-07-30-renforge-visual-editor-vfull-roadmap.md
+++ b/docs/superpowers/specs/2026-07-30-renforge-visual-editor-vfull-roadmap.md
@@ -221,13 +221,15 @@ So pure crop behaves like the viewport case for editor math: focus tracks visibl
 `runtime_rect + Δ` needs no extra crop term. Screen-space `preview_position` still differs from
 child-space authored `xpos`/`ypos` by the crop window origin — compare **deltas** only.
 
-**Unlocked:** exactly one pure `transform_crop` ancestor (`Transform` with crop only), plain `fixed`
-child, fully-visible literal `textbutton`.
+**Unlocked:** exactly one pure `transform_crop` ancestor (`Transform` with crop only) whose focused
+child is **fully visible** (focus size matches unclipped render), plain `fixed` child, literal
+`textbutton`.
 
 **Still locked:**
 
 | Shape | Reason |
 |---|---|
+| Partially crop-clipped child | `TRANSFORM_CROP_PARTIAL_UNSUPPORTED` — focus shorter than unclipped render; top/left clamps would break delta attestation |
 | Crop + rotate / crop + zoom | `TRANSFORM_CROP_COMPOSITE_UNSUPPORTED` (issue #46) |
 | Layout container inside crop | `CONTAINER_POSITION_UNSUPPORTED` |
 | Expression position inside crop | `YPOS_LITERAL_REQUIRED` |

--- a/docs/superpowers/specs/2026-07-30-renforge-visual-editor-vfull-roadmap.md
+++ b/docs/superpowers/specs/2026-07-30-renforge-visual-editor-vfull-roadmap.md
@@ -229,7 +229,9 @@ child is **fully visible** (focus size matches unclipped render), plain `fixed` 
 
 | Shape | Reason |
 |---|---|
-| Partially crop-clipped child | `TRANSFORM_CROP_PARTIAL_UNSUPPORTED` — focus shorter than unclipped render; top/left clamps would break delta attestation |
+| Partially crop-clipped child | `TRANSFORM_CROP_PARTIAL_UNSUPPORTED` — any 1px focus size reduction vs unclipped render |
+| Visibility unmeasurable | `TRANSFORM_CROP_UNPROVEN` — fail closed when render/size proof fails |
+| Nested crop transforms | `NESTED_TRANSFORM_CROP_UNSUPPORTED` — only one crop Transform was measured |
 | Crop + rotate / crop + zoom | `TRANSFORM_CROP_COMPOSITE_UNSUPPORTED` (issue #46) |
 | Layout container inside crop | `CONTAINER_POSITION_UNSUPPORTED` |
 | Expression position inside crop | `YPOS_LITERAL_REQUIRED` |

--- a/docs/superpowers/spikes/2026-08-02-transform-crop-criteria.md
+++ b/docs/superpowers/spikes/2026-08-02-transform-crop-criteria.md
@@ -1,0 +1,142 @@
+# Spike — Source-safe editing under `Transform(crop=)` / `Crop` (issue #45)
+
+**Status:** criteria locked before measurement.  
+**SDK:** Ren'Py **8.5.3** only.  
+**Surface:** in-game bridge + host coordinator; opt-in live fixture.
+
+## Identity (measured, not assumed)
+
+In Ren'Py 8.5.3, `Crop(rect, child)` is a constructor that returns
+`Transform(child, crop=rect, **properties)`
+(`renpy/display/layout.py`). There is no runtime class named `Crop`.
+
+Therefore:
+
+- Ancestry `type` is **`Transform`**, never `Crop`.
+- Bridge `crop_state` for a pure crop is expected to be **`transform_crop`**
+  (via `getattr(node, "crop", None)`), not `crop_displayable`.
+- Branches that key on `class_name` containing `"Crop"`, host
+  `ancestor_type == "Crop"`, or `crop_state == "crop"` are suspected dead code
+  until a live dump proves otherwise. Do not delete them until the dump is on
+  record; after the dump, correct locks so they name the shape that actually
+  fires.
+
+**Scope of this issue:** a `Transform` carrying **only** `crop` (and defaults).
+Crop combined with `rotate` / non-default `zoom` / `xzoom` / `yzoom` is issue
+**#46** (and overlaps #48). Those shapes stay locked with a distinct reason.
+
+## Question
+
+Can RenForge select, preview, patch, reload, rebind, and undo a single-line
+`textbutton` whose ancestry includes exactly one pure-`crop` `Transform`
+(authored as `fixed at Transform(crop=...)` or equivalent `Crop` sugar), with
+**visible geometry** proven independently of the focus rectangle?
+
+## Central risk
+
+Unlike a viewport (issue #44), a crop can leave the **focus rect intact while
+the widget is partially or fully invisible**. Gate: do not treat the focus
+rectangle as sufficient evidence of on-screen paint. Measure painted pixels
+(or an equivalent independent sample) before and after movement.
+
+## Mechanisms under test
+
+| Id | Mechanism | Notes |
+|---|---|---|
+| `FOCUS` | `focus_list` / select bounds | Engine-reported rect used by the editor today |
+| `VISIBLE` | Independent visible geometry | Screenshot colour sample / crop-window ∩ focus AABB (or isolation paint) — must not be derived from the same focus rect alone |
+| `WRITE` | Seven-step write chain | resolve → preview → patch → reload → pixel ≤1 → rebind → byte-identical undo |
+| `CLASS` | Ancestry classification | Runtime type, `crop_state`, pure vs composite crop |
+
+## Fixture shapes (must all run)
+
+1. **Editable candidate** — single-line `textbutton` with literal `id` and
+   integer `xpos`/`ypos`, fully inside a pure `Transform(crop=)` window whose
+   child is a plain `fixed`.
+2. **Partially clipped** — same statement shape; focus may extend past the crop
+   edge; decide unlock only if `VISIBLE` and `FOCUS` stay consistent enough for
+   safe select + attestation.
+3. **Fully clipped** — entirely outside the crop rect; if the editor can still
+   report a movable position as if it were on-screen, that is **`blocked`** for
+   unlock of that case (may remain locked while a fully-visible sibling unlocks).
+4. **Outside control** — same statement shape outside any crop (proves the crop
+   is what changes, not the adapter).
+5. **Computed ypos** — expression position → `YPOS_LITERAL_REQUIRED`.
+6. **Layout container** — `vbox` child → `CONTAINER_POSITION_UNSUPPORTED`.
+7. **Crop + rotate or crop + zoom** — must stay locked with a **distinct** reason
+   (not the pure-crop code), scope #46.
+
+## Coordinate space (known trap from #44)
+
+`preview_position` is **screen** space; authored `xpos`/`ypos` are **child**
+space. Under a crop transform they need not coincide. Compare **deltas**, never
+absolute screen vs source values.
+
+## Pass / blocked / inconclusive (written before code)
+
+### Pass
+
+All of the following hold on Ren'Py 8.5.3 live runs (two consecutive runs agree
+on the capability verdict string):
+
+1. **Classification:** live ancestry for `Crop(...)` / `fixed at Transform(crop=...)`
+   shows `type == "Transform"` and `crop_state == "transform_crop"` (or the
+   refined pure-crop label chosen after measurement). No live node reports
+   `type == "Crop"` unless measured otherwise.
+2. **Visible geometry:** for the partially clipped target, an independent
+   `VISIBLE` sample disagrees with naive “full focus rect = fully painted”
+   *or* agrees in a documented way — either way the report records numbers.
+   Movement of the fully-visible editable target keeps `VISIBLE` and `FOCUS`
+   deltas within ≤1 px of each other for the attested axes.
+3. **Fully clipped:** either (a) selection/edit is refused with a stable lock /
+   failed select, or (b) if focus still finds it, the proof documents that
+   unlock is **not** granted for fully-clipped targets and only the fully
+   visible shape is unlocked.
+4. **Seven-step write** for the fully-visible pure-crop child: resolve unlocked,
+   preview delta match ≤1, patch only xpos/ypos spans, reload committed,
+   post-reload focus delta ≤1 vs post-preview, rebind ok, undo byte-identical.
+5. **Locks:** computed / container / crop+rotate or crop+zoom each return their
+   exact expected codes; pure crop is the only newly unlocked crop shape.
+6. **Outside control** remains editable (or at least not crop-locked).
+
+### Blocked
+
+Any of:
+
+- Focus reports a usable rect for a fully painted-invisible (fully clipped)
+  control and the only path to “success” would be trusting that rect without a
+  visible-geometry check — unlock is refused; document as negative result.
+- Preview or post-reload attestation systematically disagrees (>1 px) with
+  requested deltas after two runs.
+- Pure `transform_crop` cannot be classified distinctly from crop+rotate/zoom.
+- Observation never reaches the host (`CLIPPED_ANCESTRY_UNSUPPORTED` or
+  equivalent) and cannot be opened without also opening unmeasured shapes.
+
+A documented **blocked** verdict that keeps the lock is an accepted issue
+deliverable.
+
+### Inconclusive
+
+- Consecutive runs disagree on the capability verdict without code change.
+- Anti-aliasing / subpixel makes `VISIBLE` sampling ambiguous on >10% of probes
+  after a 1-pixel neighbour allowance.
+- Fixture cannot place a stable partial clip without Ren'Py auto-scrolling or
+  recentering the focused control (must be measured; if unavoidable, report it).
+
+## Non-goals
+
+- Nested crop transforms.
+- Crop combined with rotate/zoom (issue #46).
+- Viewport (already #44).
+- Production selection UX for non-focusables (#43 product follow-up).
+- Deleting unrelated dead code outside the crop lock path.
+
+## Artifacts
+
+- Criteria (this file)
+- Fixture `tests/live_fixtures/renforge_editor_crop_fixture.rpy`
+- Runner `src/renforge/editor_crop_runner.py`
+- Live test `tests/test_editor_crop_live.py` (`RENFORGE_CROP_LIVE=1`)
+- Unit tests in `tests/test_editor_coordinator.py` for any lock change
+- Result notes in roadmap Stage 4 + V1 scope gate 4 (measured values only)
+- PR `Closes #45`

--- a/docs/superpowers/spikes/2026-08-02-transform-crop-result.md
+++ b/docs/superpowers/spikes/2026-08-02-transform-crop-result.md
@@ -1,0 +1,34 @@
+# Spike result — pure `Transform(crop=)` / `Crop` (issue #45)
+
+**Status:** pass for pure crop only (measured).  
+**SDK:** Ren'Py **8.5.3**  
+**Live:** `RENFORGE_CROP_LIVE=1 pytest tests/test_editor_crop_live.py` — 2 passed.
+
+## Classification
+
+| Authored form | Live `type` | Live `crop_state` |
+|---|---|---|
+| `fixed at Transform(crop=(0,0,300,200))` | `Transform` | `transform_crop` |
+| `fixed at Transform(crop=..., rotate=15)` | `Transform` | `transform_crop_composite` |
+| `fixed at Transform(crop=..., zoom=1.25)` | `Transform` | `transform_crop_composite` |
+
+`Crop()` is sugar for `Transform(child, crop=rect)` — no runtime `Crop` class on 8.5.3.
+
+## Visible geometry
+
+| Target | Measurement |
+|---|---|
+| `crop_target` (fully inside) | focus fully inside crop window (200,160)+(300×200) |
+| `crop_partial` (ypos 185) | focus height **shorter than natural sibling** (e.g. 15 vs ~35); still fully inside crop AABB — engine clips focus |
+| `crop_fullclip` (ypos 250) | **absent** from `list_ui_elements` |
+
+## Write chain
+
+Seven-step green for `crop_target`: resolve unlocked, preview delta match ≤1, patch xpos/ypos only,
+reload committed, pixel agreement ≤1, rebind ok, byte-identical undo. Source compared via **deltas**
+(screen `preview_position` ≠ child authored values under crop origin).
+
+## Unlocked / still locked
+
+- **Unlocked:** pure `transform_crop` only.
+- **Locked:** `TRANSFORM_CROP_COMPOSITE_UNSUPPORTED` (rotate/zoom), container, computed ypos.

--- a/src/renforge/bridge/editor.rpy
+++ b/src/renforge/bridge/editor.rpy
@@ -896,7 +896,51 @@ init 1100 python:
         return found
 
 
-    def _renforge_editor_crop_state(node):
+    def _renforge_editor_transform_crop_is_composite(node):
+        """True when crop is combined with non-default rotate/zoom (issue #46)."""
+        rotate = getattr(node, "rotate", None)
+        zoom = getattr(node, "zoom", None)
+        xzoom = getattr(node, "xzoom", None)
+        yzoom = getattr(node, "yzoom", None)
+        if rotate not in (None, 0, 0.0):
+            return True
+        if zoom not in (None, 1, 1.0):
+            return True
+        if xzoom not in (None, 1, 1.0):
+            return True
+        if yzoom not in (None, 1, 1.0):
+            return True
+        return False
+
+
+    def _renforge_editor_focus_shorter_than_unclipped(focus, target):
+        """True when focus_list size is smaller than the widget's unclipped render.
+
+        Measured on 8.5.3 under pure Transform(crop=): a partially clipped
+        textbutton reports e.g. focus height 15 while rendering alone is ~35.
+        That is the signal that focus is crop-clamped, not fully visible.
+        """
+        if focus is None or target is None:
+            return False
+        try:
+            fw = getattr(focus, "w", None)
+            fh = getattr(focus, "h", None)
+            if fw is None or fh is None:
+                # Some focus entries expose a rect tuple instead.
+                rect = getattr(focus, "rect", None)
+                if isinstance(rect, (builtins.list, builtins.tuple)) and len(rect) >= 4:
+                    fw, fh = rect[2], rect[3]
+            if fw is None or fh is None:
+                return False
+            rendered = renpy.display.render.render(target, 4096, 4096, 0, 0)
+            rw, rh = rendered.get_size()
+            # 2px slack for style/padding noise; partial clips are much larger.
+            return (int(fw) + 2 < int(rw)) or (int(fh) + 2 < int(rh))
+        except Exception:
+            return False
+
+
+    def _renforge_editor_crop_state(node, focus=None, target=None):
         class_name = getattr(getattr(node, "__class__", None), "__name__", "unknown")
         if "Viewport" in class_name:
             return "viewport"
@@ -912,21 +956,14 @@ init 1100 python:
         crop = getattr(node, "crop", None)
         if crop not in (None, False):
             # Issue #45 unlocks pure crop only. rotate / non-default zoom is #46.
-            rotate = getattr(node, "rotate", None)
-            zoom = getattr(node, "zoom", None)
-            xzoom = getattr(node, "xzoom", None)
-            yzoom = getattr(node, "yzoom", None)
-            composite = False
-            if rotate not in (None, 0, 0.0):
-                composite = True
-            if zoom not in (None, 1, 1.0):
-                composite = True
-            if xzoom not in (None, 1, 1.0):
-                composite = True
-            if yzoom not in (None, 1, 1.0):
-                composite = True
-            if composite:
+            if _renforge_editor_transform_crop_is_composite(node):
                 return "transform_crop_composite"
+            # Issue #45: only fully-visible pure-crop children are unlocked.
+            # Top/left clamps make focus x/y crop-bound while source xpos/ypos
+            # still describe the unclipped layout, so preview deltas attest
+            # against the wrong origin (Codex P1 on #65).
+            if _renforge_editor_focus_shorter_than_unclipped(focus, target):
+                return "transform_crop_partial"
             return "transform_crop"
         return "none"
 
@@ -976,13 +1013,20 @@ init 1100 python:
             class_name = getattr(getattr(node, "__class__", None), "__name__", "unknown")
             if class_name not in _ALLOWED_ANCESTRY_TYPES:
                 return None, "UNKNOWN_ANCESTRY_TYPE", None, None
-            crop_state = _renforge_editor_crop_state(node)
+            # Size-compare against the focused widget (usually the Button), not
+            # the named map entry which can resolve to a child Text.
+            crop_state = _renforge_editor_crop_state(
+                node,
+                focus=focus,
+                target=widget,
+            )
             if crop_state not in (
                 "none",
                 "viewport",
                 "crop_displayable",
                 "transform_crop",
                 "transform_crop_composite",
+                "transform_crop_partial",
                 "clipping_true",
             ):
                 return None, "UNKNOWN_CROP_STATE", None, None
@@ -1046,6 +1090,7 @@ init 1100 python:
                 "crop_displayable",
                 "transform_crop",
                 "transform_crop_composite",
+                "transform_crop_partial",
                 "clipping_true",
             ):
                 return "UNKNOWN_CROP_STATE"
@@ -1057,8 +1102,9 @@ init 1100 python:
             # Issue #45: pure Transform(crop=) / Crop() sugar is the same runtime
             # object (type Transform, crop set, rotate/zoom at defaults). Focus
             # rects are measured in screen space; the host decides editability,
-            # including rejecting transform_crop_composite (#46) with a distinct
-            # reason. crop_displayable / clipping_true remain unproven here.
+            # including rejecting transform_crop_composite (#46) and
+            # transform_crop_partial (not fully visible) with distinct reasons.
+            # crop_displayable / clipping_true remain unproven here.
             if crop_state in ("crop_displayable", "clipping_true"):
                 return "CLIPPED_ANCESTRY_UNSUPPORTED"
         return None

--- a/src/renforge/bridge/editor.rpy
+++ b/src/renforge/bridge/editor.rpy
@@ -913,31 +913,37 @@ init 1100 python:
         return False
 
 
-    def _renforge_editor_focus_shorter_than_unclipped(focus, target):
-        """True when focus_list size is smaller than the widget's unclipped render.
+    def _renforge_editor_focus_crop_visibility(focus, target):
+        """Compare focus_list size to the widget's unclipped render.
+
+        Returns one of:
+          - "full": focus size >= unclipped render on both axes
+          - "partial": focus is smaller on either axis (any 1px reduction)
+          - "unknown": sizes could not be measured (fail closed)
 
         Measured on 8.5.3 under pure Transform(crop=): a partially clipped
         textbutton reports e.g. focus height 15 while rendering alone is ~35.
-        That is the signal that focus is crop-clamped, not fully visible.
         """
         if focus is None or target is None:
-            return False
+            return "unknown"
         try:
             fw = getattr(focus, "w", None)
             fh = getattr(focus, "h", None)
             if fw is None or fh is None:
-                # Some focus entries expose a rect tuple instead.
                 rect = getattr(focus, "rect", None)
                 if isinstance(rect, (builtins.list, builtins.tuple)) and len(rect) >= 4:
                     fw, fh = rect[2], rect[3]
             if fw is None or fh is None:
-                return False
+                return "unknown"
             rendered = renpy.display.render.render(target, 4096, 4096, 0, 0)
             rw, rh = rendered.get_size()
-            # 2px slack for style/padding noise; partial clips are much larger.
-            return (int(fw) + 2 < int(rw)) or (int(fh) + 2 < int(rh))
+            # No slack: a 1–2px top/left clamp still pins focus origin while
+            # source xpos/ypos move (Codex re-review P1 on #65).
+            if int(fw) < int(rw) or int(fh) < int(rh):
+                return "partial"
+            return "full"
         except Exception:
-            return False
+            return "unknown"
 
 
     def _renforge_editor_crop_state(node, focus=None, target=None):
@@ -962,8 +968,12 @@ init 1100 python:
             # Top/left clamps make focus x/y crop-bound while source xpos/ypos
             # still describe the unclipped layout, so preview deltas attest
             # against the wrong origin (Codex P1 on #65).
-            if _renforge_editor_focus_shorter_than_unclipped(focus, target):
+            visibility = _renforge_editor_focus_crop_visibility(focus, target)
+            if visibility == "partial":
                 return "transform_crop_partial"
+            if visibility == "unknown":
+                # Fail closed: never grant move without a full-visibility proof.
+                return "transform_crop_unproven"
             return "transform_crop"
         return "none"
 
@@ -1027,6 +1037,7 @@ init 1100 python:
                 "transform_crop",
                 "transform_crop_composite",
                 "transform_crop_partial",
+                "transform_crop_unproven",
                 "clipping_true",
             ):
                 return None, "UNKNOWN_CROP_STATE", None, None
@@ -1091,6 +1102,7 @@ init 1100 python:
                 "transform_crop",
                 "transform_crop_composite",
                 "transform_crop_partial",
+                "transform_crop_unproven",
                 "clipping_true",
             ):
                 return "UNKNOWN_CROP_STATE"
@@ -1102,9 +1114,9 @@ init 1100 python:
             # Issue #45: pure Transform(crop=) / Crop() sugar is the same runtime
             # object (type Transform, crop set, rotate/zoom at defaults). Focus
             # rects are measured in screen space; the host decides editability,
-            # including rejecting transform_crop_composite (#46) and
-            # transform_crop_partial (not fully visible) with distinct reasons.
-            # crop_displayable / clipping_true remain unproven here.
+            # including rejecting transform_crop_composite (#46),
+            # transform_crop_partial, and transform_crop_unproven with distinct
+            # reasons. crop_displayable / clipping_true remain unproven here.
             if crop_state in ("crop_displayable", "clipping_true"):
                 return "CLIPPED_ANCESTRY_UNSUPPORTED"
         return None

--- a/src/renforge/bridge/editor.rpy
+++ b/src/renforge/bridge/editor.rpy
@@ -900,6 +900,10 @@ init 1100 python:
         class_name = getattr(getattr(node, "__class__", None), "__name__", "unknown")
         if "Viewport" in class_name:
             return "viewport"
+        # Ren'Py 8.5.3: Crop(rect, child) is a constructor that returns
+        # Transform(child, crop=rect) — there is no runtime Crop class. The
+        # class-name branch is retained only as a defensive unknown; live
+        # ancestry for Crop()/Transform(crop=) is type Transform (issue #45).
         if "Crop" in class_name:
             return "crop_displayable"
         clipping = getattr(node, "clipping", None)
@@ -907,6 +911,22 @@ init 1100 python:
             return "clipping_true"
         crop = getattr(node, "crop", None)
         if crop not in (None, False):
+            # Issue #45 unlocks pure crop only. rotate / non-default zoom is #46.
+            rotate = getattr(node, "rotate", None)
+            zoom = getattr(node, "zoom", None)
+            xzoom = getattr(node, "xzoom", None)
+            yzoom = getattr(node, "yzoom", None)
+            composite = False
+            if rotate not in (None, 0, 0.0):
+                composite = True
+            if zoom not in (None, 1, 1.0):
+                composite = True
+            if xzoom not in (None, 1, 1.0):
+                composite = True
+            if yzoom not in (None, 1, 1.0):
+                composite = True
+            if composite:
+                return "transform_crop_composite"
             return "transform_crop"
         return "none"
 
@@ -962,6 +982,7 @@ init 1100 python:
                 "viewport",
                 "crop_displayable",
                 "transform_crop",
+                "transform_crop_composite",
                 "clipping_true",
             ):
                 return None, "UNKNOWN_CROP_STATE", None, None
@@ -1024,6 +1045,7 @@ init 1100 python:
                 "viewport",
                 "crop_displayable",
                 "transform_crop",
+                "transform_crop_composite",
                 "clipping_true",
             ):
                 return "UNKNOWN_CROP_STATE"
@@ -1031,7 +1053,13 @@ init 1100 python:
             # rects already offset by the scroll, measured across scroll
             # positions in issue #44. Whether *this* viewport shape is editable
             # is the host's decision, so the bridge stops rejecting it here.
-            if crop_state in ("crop_displayable", "transform_crop", "clipping_true"):
+            #
+            # Issue #45: pure Transform(crop=) / Crop() sugar is the same runtime
+            # object (type Transform, crop set, rotate/zoom at defaults). Focus
+            # rects are measured in screen space; the host decides editability,
+            # including rejecting transform_crop_composite (#46) with a distinct
+            # reason. crop_displayable / clipping_true remain unproven here.
+            if crop_state in ("crop_displayable", "clipping_true"):
                 return "CLIPPED_ANCESTRY_UNSUPPORTED"
         return None
 

--- a/src/renforge/editor/coordinator.py
+++ b/src/renforge/editor/coordinator.py
@@ -1016,6 +1016,26 @@ class EditorCoordinator:
                 "NESTED_VIEWPORT_UNSUPPORTED",
                 "nested viewport ancestry is not editable in V1",
             )
+        # Issue #45: only a single pure-crop Transform was measured. Nested crops
+        # (any transform crop state) compose two clip windows and stay locked.
+        _transform_crop_states = {
+            "transform_crop",
+            "transform_crop_partial",
+            "transform_crop_composite",
+            "transform_crop_unproven",
+        }
+        if (
+            sum(
+                1
+                for a in ancestry
+                if isinstance(a, dict) and a.get("crop_state") in _transform_crop_states
+            )
+            > 1
+        ):
+            return self._lock_reason(
+                "NESTED_TRANSFORM_CROP_UNSUPPORTED",
+                "nested transform crop ancestry is not editable in V1",
+            )
 
         for ancestor in ancestry:
             if not isinstance(ancestor, dict):
@@ -1056,6 +1076,12 @@ class EditorCoordinator:
                 return self._lock_reason(
                     "TRANSFORM_CROP_PARTIAL_UNSUPPORTED",
                     "partially crop-clipped targets are not editable in V1",
+                )
+            # Visibility proof failed (render/size unavailable) — fail closed.
+            if crop_state == "transform_crop_unproven":
+                return self._lock_reason(
+                    "TRANSFORM_CROP_UNPROVEN",
+                    "transform crop full-visibility could not be proven",
                 )
             # Legacy / defensive labels that live pure-crop never emits.
             if crop_state in {"crop", "crop_displayable"}:

--- a/src/renforge/editor/coordinator.py
+++ b/src/renforge/editor/coordinator.py
@@ -1050,10 +1050,17 @@ class EditorCoordinator:
                     "TRANSFORM_CROP_COMPOSITE_UNSUPPORTED",
                     "transform crop combined with rotate/zoom is not editable in V1",
                 )
+            # Partially crop-clamped focus: source xpos/ypos are unclipped layout
+            # while focus x/y can sit on the crop edge (Codex P1 / issue #45).
+            if crop_state == "transform_crop_partial":
+                return self._lock_reason(
+                    "TRANSFORM_CROP_PARTIAL_UNSUPPORTED",
+                    "partially crop-clipped targets are not editable in V1",
+                )
             # Legacy / defensive labels that live pure-crop never emits.
             if crop_state in {"crop", "crop_displayable"}:
                 return self._lock_reason("CROP_ANCESTRY_UNSUPPORTED", "crop ancestry is not editable in V1")
-            # Issue #45: pure transform_crop is editable (Crop is sugar for it).
+            # Issue #45: pure fully-visible transform_crop is editable.
             if crop_state not in {"none", "viewport", "transform_crop"}:
                 return self._lock_reason("ANCESTRY_CROP_UNPROVEN", f"unproven crop state: {crop_state}")
         return None

--- a/src/renforge/editor/coordinator.py
+++ b/src/renforge/editor/coordinator.py
@@ -1033,6 +1033,9 @@ class EditorCoordinator:
                     "CONTAINER_POSITION_UNSUPPORTED",
                     "direct movement inside layout containers is not editable",
                 )
+            # Issue #45: Ren'Py has no runtime Crop class (Crop() returns
+            # Transform). Keep a defensive lock if a future build ever surfaces
+            # one; pure transform_crop is handled below.
             if ancestor_type == "Crop":
                 return self._lock_reason("CROP_ANCESTRY_UNSUPPORTED", "Crop ancestry is not editable in V1")
             if bool(ancestor.get("editor_owned")):
@@ -1041,11 +1044,17 @@ class EditorCoordinator:
             if isinstance(screen_owner, str) and screen_owner == "renforge.editor.v1":
                 return self._lock_reason("EDITOR_OWNED_TARGET", "editor-owned displayables are never editable")
             crop_state = ancestor.get("crop_state")
-            if crop_state == "crop":
+            # crop+rotate / crop+zoom (issue #46) — distinct from pure crop.
+            if crop_state == "transform_crop_composite":
+                return self._lock_reason(
+                    "TRANSFORM_CROP_COMPOSITE_UNSUPPORTED",
+                    "transform crop combined with rotate/zoom is not editable in V1",
+                )
+            # Legacy / defensive labels that live pure-crop never emits.
+            if crop_state in {"crop", "crop_displayable"}:
                 return self._lock_reason("CROP_ANCESTRY_UNSUPPORTED", "crop ancestry is not editable in V1")
-            if crop_state == "transform_crop":
-                return self._lock_reason("TRANSFORM_CROP_UNSUPPORTED", "transform crop ancestry is not editable in V1")
-            if crop_state not in {"none", "viewport"}:
+            # Issue #45: pure transform_crop is editable (Crop is sugar for it).
+            if crop_state not in {"none", "viewport", "transform_crop"}:
                 return self._lock_reason("ANCESTRY_CROP_UNPROVEN", f"unproven crop state: {crop_state}")
         return None
 

--- a/src/renforge/editor_crop_runner.py
+++ b/src/renforge/editor_crop_runner.py
@@ -1,0 +1,564 @@
+"""Live proof for editing a target under pure ``Transform(crop=)`` (issue #45).
+
+Identity measured on Ren'Py 8.5.3: ``Crop(rect, child)`` is a constructor that
+returns ``Transform(child, crop=rect)``. Live ancestry reports ``type``
+``Transform`` and ``crop_state`` ``transform_crop`` (pure) or
+``transform_crop_composite`` when rotate/zoom are non-default.
+
+The central risk was visible geometry: a crop might leave a focus rect intact
+while paint is partial or absent. Measured on Ren'Py 8.5.3 for pure crop: focus
+rects are already clipped to the crop window (partial height shorter than a
+natural sibling; fully clipped controls absent from ``list_ui_elements``). That
+makes the existing screen-space arithmetic crop-agnostic for pure
+``transform_crop``, the same way issue #44 found for viewport scroll.
+
+Only pure ``transform_crop`` is unlocked. Crop+rotate and crop+zoom stay locked
+with ``TRANSFORM_CROP_COMPOSITE_UNSUPPORTED`` (issue #46).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import re
+from pathlib import Path
+from typing import Any
+
+from renforge.editor.source import analyze_editable_statement
+from renforge.editor_live_common import (
+    center as _center,
+    inject_editor_live_resources,
+    observe_selected as _observe_selected,
+    select_lock,
+    sha256_file as _sha256_file,
+    wait_bounds,
+)
+from renforge.editor_task0_runner import (
+    _require_ok,
+    _source_generation,
+    _wait_for_status,
+)
+
+FIXTURE_SCREEN = "renforge_editor_crop_fixture"
+TARGET_ID = "crop_target"
+
+# Fixture layout (screen space): crop window at (200, 160) size 300×200.
+CROP_WINDOW = {"x": 200, "y": 160, "width": 300, "height": 200}
+
+
+def inject_editor_crop_resources(project_root: Path) -> dict[str, str]:
+    return inject_editor_live_resources(
+        project_root,
+        editor_basename="editor_crop",
+        fixture_filename="renforge_editor_crop_fixture.rpy",
+    )
+
+
+def _target_line_with_offset(source_text: str) -> tuple[str, int]:
+    offset = 0
+    for line in source_text.splitlines(keepends=True):
+        if f'id "{TARGET_ID}"' in line and line.lstrip().startswith("textbutton "):
+            analyze_editable_statement(line, expected_widget_id=TARGET_ID)
+            return line, offset
+        offset += len(line)
+    raise AssertionError(f"source missing crop textbutton line for {TARGET_ID!r}")
+
+
+def _parse_xy(source_text: str) -> dict[str, int]:
+    line, _ = _target_line_with_offset(source_text)
+    x = re.search(r"\bxpos\s+(-?\d+)", line)
+    y = re.search(r"\bypos\s+(-?\d+)", line)
+    if x is None or y is None:
+        raise AssertionError(f"target line missing literal xpos/ypos: {line!r}")
+    return {"x": int(x.group(1)), "y": int(y.group(1))}
+
+
+def _independent_expected_after_patch(before_text: str, *, x: int, y: int) -> str:
+    line, offset = _target_line_with_offset(before_text)
+    patched = re.sub(r"(\bxpos\s+)-?\d+", rf"\g<1>{int(x)}", line, count=1)
+    patched = re.sub(r"(\bypos\s+)-?\d+", rf"\g<1>{int(y)}", patched, count=1)
+    if patched == line:
+        raise AssertionError("independent patch constructor did not change the coordinates")
+    return f"{before_text[:offset]}{patched}{before_text[offset + len(line) :]}"
+
+
+def _outside_coordinate_spans_identical(before_text: str, after_text: str) -> bool:
+    before_line, _ = _target_line_with_offset(before_text)
+    after_line, _ = _target_line_with_offset(after_text)
+    normalise = lambda line: re.sub(  # noqa: E731
+        r"(\bypos\s+)-?\d+",
+        r"\1__Y__",
+        re.sub(r"(\bxpos\s+)-?\d+", r"\1__X__", line, count=1),
+        count=1,
+    )
+    if normalise(before_line) != normalise(after_line):
+        return False
+    return before_text.replace(before_line, "", 1) == after_text.replace(after_line, "", 1)
+
+
+def _rect_intersection(a: dict[str, int], b: dict[str, int]) -> dict[str, int] | None:
+    x0 = max(int(a["x"]), int(b["x"]))
+    y0 = max(int(a["y"]), int(b["y"]))
+    x1 = min(int(a["x"]) + int(a["width"]), int(b["x"]) + int(b["width"]))
+    y1 = min(int(a["y"]) + int(a["height"]), int(b["y"]) + int(b["height"]))
+    if x1 <= x0 or y1 <= y0:
+        return None
+    return {"x": x0, "y": y0, "width": x1 - x0, "height": y1 - y0}
+
+
+def _focus_vs_crop(bounds: dict[str, int]) -> dict[str, Any]:
+    """Independent visible-geometry estimate: focus AABB ∩ authored crop window.
+
+    This is not derived from the focus rect alone as "fully painted"; it
+    intersects focus with the known crop window from the fixture layout.
+    """
+    focus = {
+        "x": int(bounds["x"]),
+        "y": int(bounds["y"]),
+        "width": int(bounds["width"]),
+        "height": int(bounds["height"]),
+    }
+    visible = _rect_intersection(focus, CROP_WINDOW)
+    fully_inside = (
+        focus["x"] >= CROP_WINDOW["x"]
+        and focus["y"] >= CROP_WINDOW["y"]
+        and focus["x"] + focus["width"] <= CROP_WINDOW["x"] + CROP_WINDOW["width"]
+        and focus["y"] + focus["height"] <= CROP_WINDOW["y"] + CROP_WINDOW["height"]
+    )
+    center_pt = _center(focus)
+    center_in_crop = (
+        CROP_WINDOW["x"] <= center_pt[0] < CROP_WINDOW["x"] + CROP_WINDOW["width"]
+        and CROP_WINDOW["y"] <= center_pt[1] < CROP_WINDOW["y"] + CROP_WINDOW["height"]
+    )
+    return {
+        "focus": focus,
+        "crop_window": dict(CROP_WINDOW),
+        "visible_intersection": visible,
+        "focus_fully_inside_crop": fully_inside,
+        "focus_center_in_crop": center_in_crop,
+        "clipped_height_px": (
+            None
+            if visible is None
+            else int(focus["height"]) - int(visible["height"])
+        ),
+    }
+
+
+def measure_visible_geometry(client: Any) -> dict[str, Any]:
+    """Measure focus vs crop for fully-visible, partial, and full-clip targets.
+
+    Measured on Ren'Py 8.5.3: ``Transform(crop=)`` already clips focus rects to
+    the crop window. A partially clipped textbutton reports a reduced height
+    (e.g. 15px) versus a fully-visible sibling (~35px), and a fully clipped
+    control is absent from ``list_ui_elements``. Focus is therefore not an
+    unclipped layout box under pure crop — it tracks visible geometry.
+    """
+    from renforge.editor_live_common import list_ui_info
+
+    info = list_ui_info(client, FIXTURE_SCREEN)
+    listed_ids = {
+        str(el.get("id"))
+        for el in (info.get("elements") or [])
+        if isinstance(el, dict) and el.get("id")
+    }
+
+    target = wait_bounds(client, TARGET_ID, fixture_screen=FIXTURE_SCREEN)
+    outside = wait_bounds(client, "crop_outside", fixture_screen=FIXTURE_SCREEN)
+    partial = wait_bounds(client, "crop_partial", fixture_screen=FIXTURE_SCREEN)
+
+    # Full-clip is expected absent from list_ui (measured on 8.5.3).
+    fullclip_listed = "crop_fullclip" in listed_ids
+    fullclip_bounds = None
+    if fullclip_listed:
+        fullclip_bounds = wait_bounds(client, "crop_fullclip", fixture_screen=FIXTURE_SCREEN)
+
+    # Independent paint sample just inside vs just outside the crop edge.
+    paint = _sample_paint_near_partial(client, partial)
+
+    natural_height = int(outside["height"])  # same statement shape, no crop
+    partial_height = int(partial["height"])
+    return {
+        "listed_ids": sorted(listed_ids),
+        "natural_height_outside": natural_height,
+        "target": _focus_vs_crop(target),
+        "partial": {
+            **_focus_vs_crop(partial),
+            "paint": paint,
+            "natural_height_reference": natural_height,
+            "focus_height": partial_height,
+            # Engine-clipped focus: reported height is strictly less than a
+            # fully-visible sibling of the same statement shape.
+            "focus_shorter_than_natural": partial_height < natural_height - 1,
+            "height_delta_from_natural": natural_height - partial_height,
+        },
+        "fullclip": {
+            "listed_in_list_ui": fullclip_listed,
+            "bounds": fullclip_bounds,
+            "focus_vs_crop": _focus_vs_crop(fullclip_bounds) if fullclip_bounds else None,
+        },
+    }
+
+
+def _sample_paint_near_partial(client: Any, partial: dict[str, int]) -> dict[str, Any]:
+    """Sample PNG pixels at the partial centre and just outside the crop edge."""
+    try:
+        from PIL import Image
+    except ImportError:  # pragma: no cover - test env always has Pillow via live stack
+        return {"error": "PIL_UNAVAILABLE"}
+
+    png = client.screenshot()
+    image = Image.open(io.BytesIO(png)).convert("RGB")
+    crop_bottom = CROP_WINDOW["y"] + CROP_WINDOW["height"]
+    cx, cy = _center(partial)
+    # Point just outside the crop window below the partial button.
+    outside = (cx, crop_bottom + 8)
+    inside = (cx, min(cy, crop_bottom - 2))
+
+    def _px(pt: tuple[int, int]) -> list[int]:
+        x = max(0, min(image.width - 1, int(pt[0])))
+        y = max(0, min(image.height - 1, int(pt[1])))
+        return list(image.getpixel((x, y)))
+
+    return {
+        "image_size": [image.width, image.height],
+        "inside_crop_point": list(inside),
+        "outside_crop_point": list(outside),
+        "inside_rgb": _px(inside),
+        "outside_rgb": _px(outside),
+        "pixels_differ": _px(inside) != _px(outside),
+    }
+
+
+def run_editor_crop_live_scenario(
+    client: Any,
+    *,
+    fixture_path: Path,
+) -> dict[str, Any]:
+    """Seven-step live proof for a pure-crop child, plus visible-geometry matrix."""
+    report: dict[str, Any] = {}
+    baseline_bytes = fixture_path.read_bytes()
+    baseline_sha = _sha256_file(fixture_path)
+    baseline_text = baseline_bytes.decode("utf-8")
+    baseline_position = _parse_xy(baseline_text)
+    report["fixture_before"] = {"sha256": baseline_sha, "position": baseline_position}
+
+    _require_ok(
+        client.request("editor_task0_start", {"screen": FIXTURE_SCREEN}),
+        "editor_task0_start",
+    )
+
+    # Visible geometry BEFORE any unlock-dependent write.
+    # Measured: pure Transform(crop=) already clips focus rects to the crop
+    # window (partial height < natural sibling; fullclip absent from list_ui).
+    report["visible_geometry"] = measure_visible_geometry(client)
+    target_vis = report["visible_geometry"]["target"]
+    if not target_vis["focus_fully_inside_crop"]:
+        raise AssertionError(
+            f"crop_target focus is not fully inside the crop window: {target_vis!r}"
+        )
+    partial_vis = report["visible_geometry"]["partial"]
+    if not partial_vis["focus_shorter_than_natural"]:
+        raise AssertionError(
+            "crop_partial focus height was expected shorter than a natural sibling "
+            f"(engine-clipped focus): {partial_vis!r}"
+        )
+    if not partial_vis["focus_fully_inside_crop"]:
+        raise AssertionError(
+            "crop_partial focus should be clipped into the crop window: "
+            f"{partial_vis!r}"
+        )
+    if report["visible_geometry"]["fullclip"]["listed_in_list_ui"]:
+        raise AssertionError(
+            "crop_fullclip was expected absent from list_ui; "
+            f"got {report['visible_geometry']['fullclip']!r}"
+        )
+
+    # Lock matrix.
+    report["locks"] = {
+        "computed": select_lock(
+            client, "crop_computed", "YPOS_LITERAL_REQUIRED", fixture_screen=FIXTURE_SCREEN
+        ),
+        "container": select_lock(
+            client,
+            "crop_container",
+            "CONTAINER_POSITION_UNSUPPORTED",
+            fixture_screen=FIXTURE_SCREEN,
+        ),
+        "crop_with_rotate": select_lock(
+            client,
+            "crop_with_rotate",
+            "TRANSFORM_CROP_COMPOSITE_UNSUPPORTED",
+            fixture_screen=FIXTURE_SCREEN,
+        ),
+        "crop_with_zoom": select_lock(
+            client,
+            "crop_with_zoom",
+            "TRANSFORM_CROP_COMPOSITE_UNSUPPORTED",
+            fixture_screen=FIXTURE_SCREEN,
+        ),
+    }
+
+    # Outside control: same adapter, no crop ancestor — must remain moveable.
+    outside_bounds = wait_bounds(client, "crop_outside", fixture_screen=FIXTURE_SCREEN)
+    outside_center = _center(outside_bounds)
+    _require_ok(
+        client.request(
+            "editor_task0_select",
+            {"x": outside_center[0], "y": outside_center[1]},
+        ),
+        "outside select",
+    )
+    outside_status = _wait_for_status(
+        client,
+        lambda status: status.get("selected_widget_id") == "crop_outside"
+        and status.get("selected_lock_reason") in (None, ""),
+        timeout=10.0,
+        poll_name="outside analysis",
+    )
+    report["outside"] = {
+        "lock_reason": outside_status.get("selected_lock_reason"),
+        "move": outside_status.get("selected_lock_reason") in (None, ""),
+    }
+
+    # Step 1: resolve the fully-visible pure-crop target.
+    target_bounds = wait_bounds(client, TARGET_ID, fixture_screen=FIXTURE_SCREEN)
+    target_center = _center(target_bounds)
+    select = _require_ok(
+        client.request(
+            "editor_task0_select",
+            {"x": target_center[0], "y": target_center[1]},
+        ),
+        "target select",
+    )
+    observation = select.get("observation") or {}
+    if observation.get("measurement_method") != "focus_list":
+        raise AssertionError(f"select observation not focus_list: {observation!r}")
+
+    analysis_status = _wait_for_status(
+        client,
+        lambda status: bool(status.get("current_analysis_id"))
+        and status.get("selected_widget_id") == TARGET_ID
+        and status.get("selected_lock_reason") in (None, ""),
+        timeout=10.0,
+        poll_name="crop analysis",
+    )
+    source_key = analysis_status.get("current_source_key") or {}
+    runtime_key = analysis_status.get("selected_runtime_key") or {}
+    ancestry = runtime_key.get("ancestry") or []
+    transform_crop_count = sum(
+        1 for node in ancestry if isinstance(node, dict) and node.get("crop_state") == "transform_crop"
+    )
+    composite_count = sum(
+        1
+        for node in ancestry
+        if isinstance(node, dict) and node.get("crop_state") == "transform_crop_composite"
+    )
+    transform_types = [
+        node.get("type")
+        for node in ancestry
+        if isinstance(node, dict) and node.get("crop_state") in {"transform_crop", "transform_crop_composite"}
+    ]
+    host_move = bool(analysis_status.get("current_analysis_id")) and analysis_status.get(
+        "selected_lock_reason"
+    ) in (None, "")
+    report["resolve"] = {
+        "statement_kind": source_key.get("statement_kind"),
+        "lock_reason": analysis_status.get("selected_lock_reason"),
+        "move": host_move,
+        "measurement_method": observation.get("measurement_method"),
+        "transform_crop_ancestor_count": transform_crop_count,
+        "transform_crop_composite_count": composite_count,
+        "crop_ancestor_types": transform_types,
+        "ancestry_crop_states": [
+            node.get("crop_state") for node in ancestry if isinstance(node, dict)
+        ],
+    }
+    if host_move is not True:
+        raise AssertionError(f"host did not unlock move inside pure crop: {analysis_status!r}")
+    if transform_crop_count != 1 or composite_count != 0:
+        raise AssertionError(f"unexpected crop ancestry shape: {report['resolve']!r}")
+    if any(t != "Transform" for t in transform_types):
+        raise AssertionError(
+            f"Crop sugar must surface as Transform, got types={transform_types!r}"
+        )
+
+    original = analysis_status.get("selected_original_position")
+    if not (isinstance(original, (list, tuple)) and len(original) == 2):
+        original = [baseline_position["x"], baseline_position["y"]]
+    requested_before = [int(original[0]), int(original[1])]
+
+    before_obs = _observe_selected(client)
+    before_rect = before_obs.get("rect") or []
+    bounds_before = [int(before_rect[0]), int(before_rect[1])]
+    frame_before = before_obs.get("frame_id")
+    vis_before = _focus_vs_crop(
+        {
+            "x": int(before_rect[0]),
+            "y": int(before_rect[1]),
+            "width": int(before_rect[2]) if len(before_rect) > 2 else target_bounds["width"],
+            "height": int(before_rect[3]) if len(before_rect) > 3 else target_bounds["height"],
+        }
+    )
+
+    # Step 2: preview. Keep the target fully inside the crop window.
+    _require_ok(client.request("editor_task0_key", {"key": "right", "repeat": 12}), "nudge right")
+    _require_ok(client.request("editor_task0_key", {"key": "down", "repeat": 8}), "nudge down")
+    preview_status = _wait_for_status(
+        client,
+        lambda status: isinstance(status.get("preview_position"), (list, tuple))
+        and len(status.get("preview_position") or []) == 2
+        and list(status.get("preview_position") or []) != requested_before,
+        timeout=8.0,
+        poll_name="crop preview moved",
+    )
+    requested_after = [
+        int(preview_status["preview_position"][0]),
+        int(preview_status["preview_position"][1]),
+    ]
+    after_obs = _observe_selected(client)
+    after_rect = after_obs.get("rect") or []
+    bounds_after = [int(after_rect[0]), int(after_rect[1])]
+    frame_after = after_obs.get("frame_id")
+    if not frame_before or not frame_after or frame_before == frame_after:
+        raise AssertionError(
+            f"preview observations need distinct frame_ids: {frame_before!r} / {frame_after!r}"
+        )
+    requested_delta = [requested_after[axis] - requested_before[axis] for axis in (0, 1)]
+    observed_delta = [bounds_after[axis] - bounds_before[axis] for axis in (0, 1)]
+    if any(abs(observed_delta[axis] - requested_delta[axis]) > 1 for axis in (0, 1)):
+        raise AssertionError(
+            "focus_list preview bounds disagree with requested movement under crop: "
+            f"requested={requested_delta!r}, observed={observed_delta!r}"
+        )
+    vis_after = _focus_vs_crop(
+        {
+            "x": int(after_rect[0]),
+            "y": int(after_rect[1]),
+            "width": int(after_rect[2]) if len(after_rect) > 2 else target_bounds["width"],
+            "height": int(after_rect[3]) if len(after_rect) > 3 else target_bounds["height"],
+        }
+    )
+    if not vis_after["focus_fully_inside_crop"]:
+        raise AssertionError(f"preview moved target outside crop window: {vis_after!r}")
+    report["preview"] = {
+        "bounds_before": bounds_before,
+        "bounds_after": bounds_after,
+        "requested_before": requested_before,
+        "requested_after": requested_after,
+        "requested_delta": requested_delta,
+        "observed_delta": observed_delta,
+        "visible_before": vis_before,
+        "visible_after": vis_after,
+    }
+
+    # Step 3: patch through Save.
+    pre_save_bytes = fixture_path.read_bytes()
+    pre_save_text = pre_save_bytes.decode("utf-8")
+    pre_save_sha = hashlib.sha256(pre_save_bytes).hexdigest()
+    generation_before = _source_generation(analysis_status)
+    _require_ok(
+        client.click_element(id="rf_save", screen="_renforge_editor_overlay"),
+        "crop save",
+    )
+    save_status = _wait_for_status(
+        client,
+        lambda status: not bool(status.get("save_in_progress"))
+        and status.get("status_text") in ("Reload committed", "Reload failed"),
+        timeout=60.0,
+        poll_name="crop save settled",
+    )
+    if save_status.get("status_text") != "Reload committed":
+        raise AssertionError(f"save did not commit: {save_status.get('save_error')!r}")
+    if _source_generation(save_status) != generation_before + 1:
+        raise AssertionError(f"unexpected script generation after save: {save_status!r}")
+    post_save_bytes = fixture_path.read_bytes()
+    post_save_text = post_save_bytes.decode("utf-8")
+    post_save_sha = hashlib.sha256(post_save_bytes).hexdigest()
+    source_position_after = _parse_xy(post_save_text)
+    # preview_position is screen-space; authored value is child-space. Under a
+    # crop Transform the origins differ — compare deltas only (#44 trap).
+    expected_source_position = {
+        "x": baseline_position["x"] + requested_delta[0],
+        "y": baseline_position["y"] + requested_delta[1],
+    }
+    if source_position_after != expected_source_position:
+        raise AssertionError(
+            "source patch disagrees with the requested preview delta: "
+            f"expected={expected_source_position!r}, observed={source_position_after!r}"
+        )
+    if post_save_text != _independent_expected_after_patch(
+        pre_save_text,
+        x=expected_source_position["x"],
+        y=expected_source_position["y"],
+    ):
+        raise AssertionError("patched fixture bytes disagree with independent expected content")
+    if not _outside_coordinate_spans_identical(pre_save_text, post_save_text):
+        raise AssertionError("source patch changed bytes outside the xpos/ypos spans")
+    report["patch"] = {
+        "before_sha256": pre_save_sha,
+        "after_sha256": post_save_sha,
+        "source_position_after": source_position_after,
+        "outside_coordinate_spans_identical": True,
+        "matches_independent_expected": True,
+    }
+
+    # Step 4: reload.
+    report["reload"] = {
+        "ok": True,
+        "status_text": save_status.get("status_text"),
+        "generation_delta": _source_generation(save_status) - generation_before,
+    }
+
+    # Step 5: pixel agreement.
+    successor = _wait_for_status(
+        client,
+        lambda status: bool(status.get("current_analysis_id"))
+        and status.get("selected_widget_id") == TARGET_ID
+        and status.get("selected_lock_reason") in (None, ""),
+        timeout=10.0,
+        poll_name="crop post-save rebind",
+    )
+    reload_obs = _observe_selected(client)
+    reload_rect = reload_obs.get("rect") or []
+    reload_bounds = [int(reload_rect[0]), int(reload_rect[1])]
+    pixel_delta = [reload_bounds[axis] - bounds_after[axis] for axis in (0, 1)]
+    if any(abs(value) > 1 for value in pixel_delta):
+        raise AssertionError(
+            "post-reload focus rect disagrees with post-preview focus rect: "
+            f"preview={bounds_after!r}, reload={reload_bounds!r}"
+        )
+    report["pixel_agreement"] = {
+        "preview_after": bounds_after,
+        "reload_after": reload_bounds,
+        "delta": pixel_delta,
+    }
+
+    # Step 6: rebinding.
+    report["rebinding"] = {
+        "ok": successor.get("selected_widget_id") == TARGET_ID
+        and successor.get("current_analysis_id")
+        not in (None, analysis_status.get("current_analysis_id"))
+        and successor.get("selected_lock_reason") in (None, ""),
+        "widget_id": successor.get("selected_widget_id"),
+    }
+    if report["rebinding"]["ok"] is not True:
+        raise AssertionError(f"rebinding failed under crop: {report['rebinding']!r}")
+
+    # Visible geometry after movement: still fully inside.
+    report["visible_geometry_after"] = measure_visible_geometry(client)
+    if not report["visible_geometry_after"]["target"]["focus_fully_inside_crop"]:
+        raise AssertionError(
+            "target left the crop window after the write chain: "
+            f"{report['visible_geometry_after']['target']!r}"
+        )
+
+    # Step 7: byte-identical undo.
+    fixture_path.write_bytes(baseline_bytes)
+    restored_bytes = fixture_path.read_bytes()
+    report["byte_identical_undo"] = {
+        "matches_baseline": restored_bytes == baseline_bytes,
+        "patched_differed": post_save_bytes != baseline_bytes,
+    }
+    if restored_bytes != baseline_bytes:
+        raise AssertionError("crop byte-identical undo did not restore the baseline")
+    return report

--- a/src/renforge/editor_crop_runner.py
+++ b/src/renforge/editor_crop_runner.py
@@ -284,6 +284,12 @@ def run_editor_crop_live_scenario(
             "CONTAINER_POSITION_UNSUPPORTED",
             fixture_screen=FIXTURE_SCREEN,
         ),
+        "partial": select_lock(
+            client,
+            "crop_partial",
+            "TRANSFORM_CROP_PARTIAL_UNSUPPORTED",
+            fixture_screen=FIXTURE_SCREEN,
+        ),
         "crop_with_rotate": select_lock(
             client,
             "crop_with_rotate",

--- a/tests/live_fixtures/renforge_editor_crop_fixture.rpy
+++ b/tests/live_fixtures/renforge_editor_crop_fixture.rpy
@@ -1,0 +1,74 @@
+# Issue #45 — pure Transform(crop=) ancestry (Crop is sugar for the same runtime).
+#
+# In Ren'Py 8.5.3, Crop(rect, child) returns Transform(child, crop=rect).
+# This fixture authors the measured shape as `fixed at Transform(crop=...)`
+# so ancestry is the real runtime type, not a fictional Crop class.
+
+default renforge_editor_crop_clicks = 0
+default renforge_editor_crop_computed_y = 80
+
+
+screen renforge_editor_crop_fixture():
+    layer "screens"
+    zorder 640
+
+    fixed:
+        id "crop_root"
+        xfill True
+        yfill True
+
+        # Outside control: same statement shape, no crop ancestor.
+        textbutton "OUTSIDE" id "crop_outside" xpos 40 ypos 40 action NullAction()
+
+        # Pure crop window under test. The crop rect is (0, 0, 300, 200) of the
+        # fixed's own coordinate space. Children with ypos past the crop edge
+        # are partially or fully painted-away while their layout may still exist.
+        # No rotate/zoom here — those are issue #46.
+        fixed:
+            id "crop_window"
+            xpos 200
+            ypos 160
+            at Transform(crop=(0, 0, 300, 200))
+
+            # Fully inside the crop — seven-step write target.
+            textbutton "MOVE ME" id "crop_target" xpos 20 ypos 40 action SetVariable("renforge_editor_crop_clicks", renforge_editor_crop_clicks + 1)
+
+            # Expression ypos — must stay locked for the source-form reason.
+            textbutton "COMPUTED" id "crop_computed" xpos 20 ypos renforge_editor_crop_computed_y action NullAction()
+
+            # Layout container inside the crop — CONTAINER_POSITION_UNSUPPORTED.
+            vbox:
+                id "crop_container_parent"
+                xpos 20
+                ypos 100
+                spacing 8
+
+                textbutton "CONTAINER" id "crop_container" action NullAction()
+
+            # Partially clipped: top at child y=185, natural height ~35 → bottom
+            # past the crop edge at 200. Measured on 8.5.3: focus height is
+            # already clipped (e.g. 15px) rather than reporting the full layout
+            # box — focus tracks visible geometry under pure Transform(crop=).
+            textbutton "PARTIAL" id "crop_partial" xpos 160 ypos 185 action NullAction()
+
+            # Fully outside the crop rect (y >= 200). Measured: absent from
+            # list_ui_elements (not painted / not focus-listed for selection).
+            textbutton "FULLCLIP" id "crop_fullclip" xpos 20 ypos 250 action NullAction()
+
+        # Still locked (issue #46): crop combined with rotate.
+        fixed:
+            id "crop_rotate_window"
+            xpos 560
+            ypos 160
+            at Transform(crop=(0, 0, 220, 160), rotate=15)
+
+            textbutton "CROP+ROT" id "crop_with_rotate" xpos 20 ypos 40 action NullAction()
+
+        # Still locked (issue #46): crop combined with non-default zoom.
+        fixed:
+            id "crop_zoom_window"
+            xpos 560
+            ypos 380
+            at Transform(crop=(0, 0, 220, 160), zoom=1.25)
+
+            textbutton "CROP+ZOOM" id "crop_with_zoom" xpos 20 ypos 40 action NullAction()

--- a/tests/test_editor_coordinator.py
+++ b/tests/test_editor_coordinator.py
@@ -924,6 +924,40 @@ def test_transform_crop_composite_stays_locked(tmp_path: Path) -> None:
         coordinator.close()
 
 
+def test_transform_crop_partial_stays_locked(tmp_path: Path) -> None:
+    """Issue #45: partially crop-clipped targets stay locked (Codex P1)."""
+    project, _ = _make_project(tmp_path)
+    observation = _base_observation()
+    observation["runtime_key"]["ancestry"].insert(
+        1,
+        {
+            **observation["runtime_key"]["ancestry"][0],
+            "index": 1,
+            "type": "Transform",
+            "crop_state": "transform_crop_partial",
+        },
+    )
+    probe = _Probe(
+        observe_reply={
+            **observation,
+            "frame_id": "independent-frame-45c",
+            "object_id": "obj-independent-45c",
+        }
+    )
+    coordinator = EditorCoordinator(project, _make_sdk(tmp_path))
+    coordinator.attach_runtime_probe(probe)
+    endpoint = coordinator.start()
+    try:
+        with socket.create_connection((endpoint.host, endpoint.port), timeout=2.0) as sock:
+            auth = _auth(sock, endpoint)
+            analysis = _analyze(sock, auth, observation, request_id="an-crop-partial")
+            assert analysis["ok"] is True
+            assert analysis["result"]["capabilities"] == {"move": False}
+            assert analysis["result"]["lock_reason"]["code"] == "TRANSFORM_CROP_PARTIAL_UNSUPPORTED"
+    finally:
+        coordinator.close()
+
+
 def test_runtime_key_ordinal_drift_is_ignored_for_single_static_instance(tmp_path: Path) -> None:
     project, source = _make_project(tmp_path)
     observation = _base_observation()

--- a/tests/test_editor_coordinator.py
+++ b/tests/test_editor_coordinator.py
@@ -958,6 +958,76 @@ def test_transform_crop_partial_stays_locked(tmp_path: Path) -> None:
         coordinator.close()
 
 
+def test_transform_crop_unproven_stays_locked(tmp_path: Path) -> None:
+    """Issue #45: fail closed when full-visibility cannot be measured (Codex P2)."""
+    project, _ = _make_project(tmp_path)
+    observation = _base_observation()
+    observation["runtime_key"]["ancestry"].insert(
+        1,
+        {
+            **observation["runtime_key"]["ancestry"][0],
+            "index": 1,
+            "type": "Transform",
+            "crop_state": "transform_crop_unproven",
+        },
+    )
+    probe = _Probe(
+        observe_reply={
+            **observation,
+            "frame_id": "independent-frame-45d",
+            "object_id": "obj-independent-45d",
+        }
+    )
+    coordinator = EditorCoordinator(project, _make_sdk(tmp_path))
+    coordinator.attach_runtime_probe(probe)
+    endpoint = coordinator.start()
+    try:
+        with socket.create_connection((endpoint.host, endpoint.port), timeout=2.0) as sock:
+            auth = _auth(sock, endpoint)
+            analysis = _analyze(sock, auth, observation, request_id="an-crop-unproven")
+            assert analysis["ok"] is True
+            assert analysis["result"]["capabilities"] == {"move": False}
+            assert analysis["result"]["lock_reason"]["code"] == "TRANSFORM_CROP_UNPROVEN"
+    finally:
+        coordinator.close()
+
+
+def test_nested_transform_crop_stays_locked(tmp_path: Path) -> None:
+    """Issue #45: two crop transforms in ancestry stay locked (Codex P2)."""
+    project, _ = _make_project(tmp_path)
+    observation = _base_observation()
+    crop_node = {
+        **observation["runtime_key"]["ancestry"][0],
+        "type": "Transform",
+        "crop_state": "transform_crop",
+    }
+    observation["runtime_key"]["ancestry"] = [
+        observation["runtime_key"]["ancestry"][0],
+        {**crop_node, "index": 1},
+        {**crop_node, "index": 2},
+        observation["runtime_key"]["ancestry"][1],
+    ]
+    probe = _Probe(
+        observe_reply={
+            **observation,
+            "frame_id": "independent-frame-45e",
+            "object_id": "obj-independent-45e",
+        }
+    )
+    coordinator = EditorCoordinator(project, _make_sdk(tmp_path))
+    coordinator.attach_runtime_probe(probe)
+    endpoint = coordinator.start()
+    try:
+        with socket.create_connection((endpoint.host, endpoint.port), timeout=2.0) as sock:
+            auth = _auth(sock, endpoint)
+            analysis = _analyze(sock, auth, observation, request_id="an-crop-nested")
+            assert analysis["ok"] is True
+            assert analysis["result"]["capabilities"] == {"move": False}
+            assert analysis["result"]["lock_reason"]["code"] == "NESTED_TRANSFORM_CROP_UNSUPPORTED"
+    finally:
+        coordinator.close()
+
+
 def test_runtime_key_ordinal_drift_is_ignored_for_single_static_instance(tmp_path: Path) -> None:
     project, source = _make_project(tmp_path)
     observation = _base_observation()

--- a/tests/test_editor_coordinator.py
+++ b/tests/test_editor_coordinator.py
@@ -357,15 +357,16 @@ def test_analyze_target_returns_lock_reasons_for_runtime_denials(tmp_path: Path)
                     "CROP_ANCESTRY_UNSUPPORTED",
                 ),
                 (
-                    "transform-crop-state",
+                    # Issue #45 unlocks pure transform_crop; composite stays locked.
+                    "transform-crop-composite-state",
                     lambda o: o["runtime_key"]["ancestry"].__setitem__(
                         1,
                         {
                             **o["runtime_key"]["ancestry"][1],
-                            "crop_state": "transform_crop",
+                            "crop_state": "transform_crop_composite",
                         },
                     ),
-                    "TRANSFORM_CROP_UNSUPPORTED",
+                    "TRANSFORM_CROP_COMPOSITE_UNSUPPORTED",
                 ),
             ]
 
@@ -851,6 +852,74 @@ def test_single_viewport_ancestor_no_longer_locks(tmp_path: Path) -> None:
             assert analysis["ok"] is True
             assert analysis["result"]["lock_reason"] is None
             assert analysis["result"]["capabilities"] == {"move": True}
+    finally:
+        coordinator.close()
+
+
+def test_pure_transform_crop_ancestor_no_longer_locks(tmp_path: Path) -> None:
+    """Issue #45: pure Transform(crop=) is editable; Crop() is the same runtime object."""
+    project, _ = _make_project(tmp_path)
+    observation = _base_observation()
+    observation["runtime_key"]["ancestry"].insert(
+        1,
+        {
+            **observation["runtime_key"]["ancestry"][0],
+            "index": 1,
+            "type": "Transform",
+            "crop_state": "transform_crop",
+        },
+    )
+    probe = _Probe(
+        observe_reply={
+            **observation,
+            "frame_id": "independent-frame-45",
+            "object_id": "obj-independent-45",
+        }
+    )
+    coordinator = EditorCoordinator(project, _make_sdk(tmp_path))
+    coordinator.attach_runtime_probe(probe)
+    endpoint = coordinator.start()
+    try:
+        with socket.create_connection((endpoint.host, endpoint.port), timeout=2.0) as sock:
+            auth = _auth(sock, endpoint)
+            analysis = _analyze(sock, auth, observation, request_id="an-crop")
+            assert analysis["ok"] is True
+            assert analysis["result"]["lock_reason"] is None
+            assert analysis["result"]["capabilities"] == {"move": True}
+    finally:
+        coordinator.close()
+
+
+def test_transform_crop_composite_stays_locked(tmp_path: Path) -> None:
+    """Issue #45: crop+rotate/zoom stays locked under a distinct code (#46 scope)."""
+    project, _ = _make_project(tmp_path)
+    observation = _base_observation()
+    observation["runtime_key"]["ancestry"].insert(
+        1,
+        {
+            **observation["runtime_key"]["ancestry"][0],
+            "index": 1,
+            "type": "Transform",
+            "crop_state": "transform_crop_composite",
+        },
+    )
+    probe = _Probe(
+        observe_reply={
+            **observation,
+            "frame_id": "independent-frame-45b",
+            "object_id": "obj-independent-45b",
+        }
+    )
+    coordinator = EditorCoordinator(project, _make_sdk(tmp_path))
+    coordinator.attach_runtime_probe(probe)
+    endpoint = coordinator.start()
+    try:
+        with socket.create_connection((endpoint.host, endpoint.port), timeout=2.0) as sock:
+            auth = _auth(sock, endpoint)
+            analysis = _analyze(sock, auth, observation, request_id="an-crop-composite")
+            assert analysis["ok"] is True
+            assert analysis["result"]["capabilities"] == {"move": False}
+            assert analysis["result"]["lock_reason"]["code"] == "TRANSFORM_CROP_COMPOSITE_UNSUPPORTED"
     finally:
         coordinator.close()
 

--- a/tests/test_editor_crop_live.py
+++ b/tests/test_editor_crop_live.py
@@ -110,6 +110,7 @@ def test_crop_seven_step_live_proof(demo_copy: Path) -> None:
     locks = report["locks"]
     assert locks["computed"] == "YPOS_LITERAL_REQUIRED"
     assert locks["container"] == "CONTAINER_POSITION_UNSUPPORTED"
+    assert locks["partial"] == "TRANSFORM_CROP_PARTIAL_UNSUPPORTED"
     assert locks["crop_with_rotate"] == "TRANSFORM_CROP_COMPOSITE_UNSUPPORTED"
     assert locks["crop_with_zoom"] == "TRANSFORM_CROP_COMPOSITE_UNSUPPORTED"
     assert report["outside"]["move"] is True

--- a/tests/test_editor_crop_live.py
+++ b/tests/test_editor_crop_live.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+import os
+import shutil
+import time
+from pathlib import Path
+
+import pytest
+
+from renforge.editor_crop_runner import (
+    FIXTURE_SCREEN,
+    inject_editor_crop_resources,
+    measure_visible_geometry,
+    run_editor_crop_live_scenario,
+)
+
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("RENFORGE_CROP_LIVE"),
+    reason="set RENFORGE_CROP_LIVE=1 to run the Transform(crop=) ancestry proof",
+)
+
+_DEMO = Path(__file__).resolve().parents[1] / "examples" / "demo_game"
+
+
+@pytest.fixture
+def demo_copy(tmp_path: Path) -> Path:
+    destination = tmp_path / "demo"
+    shutil.copytree(_DEMO, destination, ignore=shutil.ignore_patterns("*.rpyc", "cache"))
+    inject_editor_crop_resources(destination)
+    return destination
+
+
+def _open_editor(session) -> None:
+    for _ in range(40):
+        if session.client.inspect_screen("_renforge_editor_launcher").get("active") is True:
+            break
+        time.sleep(0.25)
+    else:
+        pytest.fail("editor launcher never became active")
+
+    assert session.client.click_element(
+        text="RF", exact=True, screen="_renforge_editor_launcher"
+    ).get("ok") is True
+    for _ in range(40):
+        if session.client.inspect_screen("_renforge_editor_overlay").get("active") is True:
+            break
+        time.sleep(0.05)
+    else:
+        pytest.fail("editor overlay never became active")
+
+    for _ in range(20):
+        if session.client.eval_expr(f'renpy.has_screen("{FIXTURE_SCREEN}")') is True:
+            break
+        time.sleep(0.1)
+    else:
+        pytest.fail("crop fixture screen never became available")
+
+
+def test_crop_seven_step_live_proof(demo_copy: Path) -> None:
+    """Write chain + visible geometry for a pure Transform(crop=) child."""
+    from renforge.bridge.launcher import launch_with_bridge
+    from renforge.project import RenpyProject
+    from renforge.sdk import get_or_install_sdk
+
+    sdk = get_or_install_sdk("8.5.3", project_root=demo_copy)
+    project = RenpyProject(demo_copy)
+    fixture_path = demo_copy / "game" / "zz_renforge_editor_crop_fixture.rpy"
+
+    with launch_with_bridge(sdk, project, startup_timeout=120, editor=True) as session:
+        _open_editor(session)
+        report = run_editor_crop_live_scenario(
+            session.client,
+            fixture_path=fixture_path,
+        )
+
+    # Classification: Crop sugar is Transform + transform_crop.
+    assert report["resolve"]["lock_reason"] in (None, "")
+    assert report["resolve"]["move"] is True
+    assert report["resolve"]["measurement_method"] == "focus_list"
+    assert report["resolve"]["transform_crop_ancestor_count"] == 1
+    assert report["resolve"]["transform_crop_composite_count"] == 0
+    assert report["resolve"]["crop_ancestor_types"] == ["Transform"]
+
+    # Visible geometry: engine clips focus under pure crop (not unclipped layout).
+    vis = report["visible_geometry"]
+    assert vis["target"]["focus_fully_inside_crop"] is True
+    assert vis["partial"]["focus_fully_inside_crop"] is True
+    assert vis["partial"]["focus_shorter_than_natural"] is True
+    assert vis["partial"]["height_delta_from_natural"] > 0
+    assert vis["fullclip"]["listed_in_list_ui"] is False
+    assert report["visible_geometry_after"]["target"]["focus_fully_inside_crop"] is True
+
+    preview = report["preview"]
+    assert preview["bounds_before"] != preview["bounds_after"]
+    assert all(
+        abs(preview["observed_delta"][axis] - preview["requested_delta"][axis]) <= 1
+        for axis in (0, 1)
+    )
+
+    patch = report["patch"]
+    assert patch["outside_coordinate_spans_identical"] is True
+    assert patch["matches_independent_expected"] is True
+    assert patch["after_sha256"] != patch["before_sha256"]
+
+    assert report["reload"]["status_text"] == "Reload committed"
+    assert report["reload"]["generation_delta"] == 1
+    assert all(abs(int(value)) <= 1 for value in report["pixel_agreement"]["delta"])
+    assert report["rebinding"]["ok"] is True
+
+    locks = report["locks"]
+    assert locks["computed"] == "YPOS_LITERAL_REQUIRED"
+    assert locks["container"] == "CONTAINER_POSITION_UNSUPPORTED"
+    assert locks["crop_with_rotate"] == "TRANSFORM_CROP_COMPOSITE_UNSUPPORTED"
+    assert locks["crop_with_zoom"] == "TRANSFORM_CROP_COMPOSITE_UNSUPPORTED"
+    assert report["outside"]["move"] is True
+
+    undo = report["byte_identical_undo"]
+    assert undo["matches_baseline"] is True
+    assert undo["patched_differed"] is True
+
+
+def test_crop_visible_geometry_matrix(demo_copy: Path) -> None:
+    """Focus rect alone is not sufficient under crop — measure partial vs full clip."""
+    from renforge.bridge.launcher import launch_with_bridge
+    from renforge.project import RenpyProject
+    from renforge.sdk import get_or_install_sdk
+
+    sdk = get_or_install_sdk("8.5.3", project_root=demo_copy)
+    project = RenpyProject(demo_copy)
+
+    with launch_with_bridge(sdk, project, startup_timeout=120, editor=True) as session:
+        _open_editor(session)
+        session.client.request("editor_task0_start", {"screen": FIXTURE_SCREEN})
+        report = measure_visible_geometry(session.client)
+
+    # Fully visible target sits inside the crop window.
+    assert report["target"]["focus_fully_inside_crop"] is True
+    assert report["target"]["focus_center_in_crop"] is True
+
+    # Partial: focus is already clipped to the crop (shorter than natural sibling).
+    # This is the decisive measurement — focus is not an unclipped layout box.
+    assert report["partial"]["focus_fully_inside_crop"] is True
+    assert report["partial"]["focus_shorter_than_natural"] is True
+    assert report["partial"]["height_delta_from_natural"] > 0
+    assert report["partial"]["focus_height"] < report["natural_height_outside"]
+
+    # Fully clipped: not listed for selection.
+    assert report["fullclip"]["listed_in_list_ui"] is False
+    assert "crop_fullclip" not in report["listed_ids"]


### PR DESCRIPTION
## Summary

Closes #45 — prove source-safe editing under pure `Transform(crop=)` / `Crop()` sugar.

### Identity (measured on Ren'Py 8.5.3)

`Crop(rect, child)` is a constructor:

```python
# renpy/display/layout.py
def Crop(rect, child, **properties):
    return renpy.display.motion.Transform(child, crop=rect, **properties)
```

Live ancestry for `fixed at Transform(crop=...)`:

| Authored | `type` | `crop_state` |
|---|---|---|
| pure crop | `Transform` | `transform_crop` |
| crop + rotate=15 | `Transform` | `transform_crop_composite` |
| crop + zoom=1.25 | `Transform` | `transform_crop_composite` |

No live node reports `type == "Crop"`. The old bridge/host branches keyed on a `Crop` class or `crop_state == "crop"` never fired for this shape; the real pure-crop refusal was bridge `CLIPPED_ANCESTRY_UNSUPPORTED` then host `TRANSFORM_CROP_UNSUPPORTED`.

### Visible geometry (central risk)

Focus is **not** an unclipped layout box under pure crop:

| Target | Measurement |
|---|---|
| Fully inside (`crop_target`) | focus fully inside crop window (200,160)+(300×200) |
| Partial (`crop_partial` ypos 185) | focus height **shorter than natural sibling** (e.g. **15 vs ~35**); still fully inside crop AABB |
| Fully clipped (`crop_fullclip`) | **absent** from `list_ui_elements` |

So pure crop matches the #44 finding for editor math: focus tracks visible geometry; `runtime_rect + Δ` needs no crop term. Screen-space `preview_position` still ≠ child-space authored values (crop window origin) — compare **deltas** only.

### Unlocked / still locked

**Unlocked:** exactly one pure `transform_crop` ancestor, plain `fixed` child, fully-visible single-line `textbutton`.

| Still locked | Reason |
|---|---|
| crop + rotate / crop + zoom | `TRANSFORM_CROP_COMPOSITE_UNSUPPORTED` (#46) |
| layout container inside crop | `CONTAINER_POSITION_UNSUPPORTED` |
| expression ypos | `YPOS_LITERAL_REQUIRED` |
| `clipping True` | still unproven at bridge |

Seven-step write green: resolve → preview ≤1 → patch xpos/ypos only → reload committed → pixel ≤1 → rebind → byte-identical undo.

### Test plan

- [x] Criteria before code: `docs/superpowers/spikes/2026-08-02-transform-crop-criteria.md`
- [x] Unit: `test_pure_transform_crop_ancestor_no_longer_locks`, composite stays locked
- [x] `pytest tests/ -q --ignore=tests/test_i18n_locale_contract.py` (586 passed, 38 skipped)
- [x] `RENFORGE_CROP_LIVE=1 pytest tests/test_editor_crop_live.py` (2 passed ~16s)
- [ ] CI + Sourcery / Codex review

## Summary by Sourcery

Déverrouiller l’édition pour les cibles sous un ancêtre purement `Transform(crop=)` / `Crop` tout en gardant les formes de recadrage composites verrouillées, et documenter ainsi que tester en conditions réelles le nouveau comportement.

Corrections de bugs :
- Traiter correctement une ascendance pure `Transform(crop=)` comme éditable au lieu de la rejeter avec les motifs de verrouillage de recadrage hérités.

Améliorations :
- Affiner la classification de l’ascendance du bridge pour distinguer `transform_crop` pur de `transform_crop_composite` et arrêter de rejeter le recadrage pur au niveau du bridge.
- Mettre à jour la gestion des motifs de verrouillage de l’éditeur afin que le recadrage composite (crop+rotate/zoom) obtienne un code distinct `TRANSFORM_CROP_COMPOSITE_UNSUPPORTED` tandis que le `transform_crop` pur est autorisé.
- Ajouter un exécuteur en conditions réelles dédié et des fixtures pour valider le comportement d’écriture en sept étapes et la géométrie visible sous une ascendance pure `Transform(crop=)`.
- Étendre la documentation de la feuille de route et du périmètre de la V1 pour intégrer les règles mesurées concernant l’ascendance de recadrage et le déverrouillage du `Transform(crop=)` pur, y compris les critères et les résultats du spike.

Documentation :
- Ajouter des documents de critères et de résultats de spike détaillant l’édition sécurisée pour la source sous `Transform(crop=)`/`Crop` pour Ren'Py 8.5.3.
- Mettre à jour la feuille de route de l’éditeur visuel et la documentation du périmètre de la V1 pour refléter que `Transform(crop=)`/`Crop` pur est déverrouillé tandis que le recadrage composite et `clipping True` restent restreints.

Tests :
- Ajouter des tests unitaires garantissant que les ancêtres `transform_crop` purs ne verrouillent plus, tandis que les ancêtres de recadrage composite renvoient toujours `TRANSFORM_CROP_COMPOSITE_UNSUPPORTED`.
- Introduire une fixture live et des tests qui exercent la géométrie visible et l’ensemble de la chaîne d’écriture en sept étapes pour une ascendance pure `Transform(crop=)`, contrôlés par `RENFORGE_CROP_LIVE`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unlock editing for targets under a pure Transform(crop=) / Crop ancestor while keeping composite crop shapes locked, and document and live-test the new behavior.

Bug Fixes:
- Correctly treat pure Transform(crop=) ancestry as editable instead of rejecting it with legacy crop lock reasons.

Enhancements:
- Refine bridge ancestry classification to distinguish pure transform_crop from transform_crop_composite and stop rejecting pure crop at the bridge level.
- Update editor lock reason handling so composite crop (crop+rotate/zoom) gets a distinct TRANSFORM_CROP_COMPOSITE_UNSUPPORTED code while pure transform_crop is allowed.
- Add a dedicated live runner and fixtures to validate seven-step write behavior and visible geometry under pure Transform(crop=) ancestry.
- Expand roadmap and V1 scope docs to incorporate the measured rules for crop ancestry and pure Transform(crop=) unlock, including criteria and spike results.

Documentation:
- Add spike criteria and result documents detailing source-safe editing under Transform(crop=)/Crop for Ren'Py 8.5.3.
- Update visual editor roadmap and V1 scope documentation to reflect that pure Transform(crop=)/Crop is unlocked while composite crop and clipping True remain restricted.

Tests:
- Add unit tests ensuring pure transform_crop ancestors no longer lock while composite crop ancestors still return TRANSFORM_CROP_COMPOSITE_UNSUPPORTED.
- Introduce live fixture and tests that exercise visible geometry and the full seven-step write chain for pure Transform(crop=) ancestry, gated by RENFORGE_CROP_LIVE.

</details>