### PR TITLE
feat(editor): add source-safe bar resizing

### DIFF
--- a/src/renforge/bridge/editor.rpy
+++ b/src/renforge/bridge/editor.rpy
@@ -267,8 +267,11 @@ init 1100 python:
             state.selected_lock_reason = None
             state.selected_original_position = None
             state.selected_source_position = None
+            state.selected_original_size = None
+            state.selected_source_size = None
             state.selected_rect = None
             state.preview_position = None
+            state.preview_size = None
             state.pointer = [0, 0]
             state.drag_active = False
             state.drag_offset = [0, 0]
@@ -356,6 +359,12 @@ init 1100 python:
             state.pending_reload_started = False
         if not hasattr(state, "current_capabilities"):
             state.current_capabilities = {}
+        if not hasattr(state, "selected_original_size"):
+            state.selected_original_size = None
+        if not hasattr(state, "selected_source_size"):
+            state.selected_source_size = None
+        if not hasattr(state, "preview_size"):
+            state.preview_size = None
         return state
 
 
@@ -1409,7 +1418,21 @@ init 1100 python:
             next_y = int(source_position[1]) + int(position[1]) - int(runtime_baseline[1])
             source_key = target.get("source_key") or {}
             position_mode = source_key.get("position_mode") if builtins.isinstance(source_key, builtins.dict) else None
-            properties[str(widget_id)] = _renforge_editor_preview_properties(next_x, next_y, position_mode)
+            props = _renforge_editor_preview_properties(next_x, next_y, position_mode)
+            size = target.get("size")
+            runtime_size = target.get("runtime_size")
+            source_size = target.get("source_size")
+            if (
+                isinstance(size, (builtins.list, tuple))
+                and len(size) == 2
+                and isinstance(runtime_size, (builtins.list, tuple))
+                and len(runtime_size) == 2
+                and isinstance(source_size, (builtins.list, tuple))
+                and len(source_size) == 2
+            ):
+                props["xsize"] = int(source_size[0]) + int(size[0]) - int(runtime_size[0])
+                props["ysize"] = int(source_size[1]) + int(size[1]) - int(runtime_size[1])
+            properties[str(widget_id)] = props
         return properties
 
 
@@ -1454,9 +1477,19 @@ init 1100 python:
         runtime_baseline = target.get("runtime_baseline") or []
         state.save_button_state = "idle"
         target["position"] = next_position
+        size = target.get("size") or []
+        runtime_size = target.get("runtime_size") or []
+        size_dirty = (
+            len(size) == 2
+            and len(runtime_size) == 2
+            and [int(size[0]), int(size[1])] != [int(runtime_size[0]), int(runtime_size[1])]
+        )
         target["dirty"] = (
-            len(runtime_baseline) == 2
-            and next_position != [int(runtime_baseline[0]), int(runtime_baseline[1])]
+            (
+                len(runtime_baseline) == 2
+                and next_position != [int(runtime_baseline[0]), int(runtime_baseline[1])]
+            )
+            or size_dirty
         )
         _renforge_editor_show_target_overrides(target.get("screen"))
         if state.selected_target_key == target_key:
@@ -1540,14 +1573,27 @@ init 1100 python:
                 and len(source_position) == 2
             ):
                 return []
-            intents.append(
-                {
-                    "analysis_id": analysis_id,
-                    "source_key": source_key,
-                    "x": int(source_position[0]) + int(position[0]) - int(runtime_baseline[0]),
-                    "y": int(source_position[1]) + int(position[1]) - int(runtime_baseline[1]),
-                }
-            )
+            intent = {
+                "analysis_id": analysis_id,
+                "source_key": source_key,
+                "x": int(source_position[0]) + int(position[0]) - int(runtime_baseline[0]),
+                "y": int(source_position[1]) + int(position[1]) - int(runtime_baseline[1]),
+            }
+            size = target.get("size")
+            runtime_size = target.get("runtime_size")
+            source_size = target.get("source_size")
+            if (
+                isinstance(size, (builtins.list, tuple))
+                and len(size) == 2
+                and isinstance(runtime_size, (builtins.list, tuple))
+                and len(runtime_size) == 2
+                and isinstance(source_size, (builtins.list, tuple))
+                and len(source_size) == 2
+                and source_key.get("size_mode") == "xsize_ysize"
+            ):
+                intent["w"] = int(source_size[0]) + int(size[0]) - int(runtime_size[0])
+                intent["h"] = int(source_size[1]) + int(size[1]) - int(runtime_size[1])
+            intents.append(intent)
         return intents
 
 
@@ -1561,6 +1607,19 @@ init 1100 python:
         return state.save_enabled
 
 
+    def _renforge_editor_apply_history_command(command, *, use_before):
+        if not isinstance(command, builtins.dict):
+            return {"ok": False, "error": "NO_HISTORY"}
+        value = command.get("before") if use_before else command.get("after")
+        if command.get("kind") == "size":
+            result = _renforge_editor_set_target_size(command.get("target_key"), value)
+        else:
+            result = _renforge_editor_set_target_position(command.get("target_key"), value)
+        _renforge_editor_refresh_save_enabled()
+        renpy.restart_interaction()
+        return result
+
+
     def _renforge_editor_undo():
         state = _renforge_editor_state()
         if not _renforge_editor_can_undo():
@@ -1569,10 +1628,7 @@ init 1100 python:
         command = state.history_entries[state.history_index]
         state.history_index -= 1
         state.status_text = "Undo"
-        result = _renforge_editor_set_target_position(command["target_key"], command["before"])
-        _renforge_editor_refresh_save_enabled()
-        renpy.restart_interaction()
-        return result
+        return _renforge_editor_apply_history_command(command, use_before=True)
 
 
     def _renforge_editor_redo():
@@ -1583,10 +1639,7 @@ init 1100 python:
         state.history_index += 1
         command = state.history_entries[state.history_index]
         state.status_text = "Redo"
-        result = _renforge_editor_set_target_position(command["target_key"], command["after"])
-        _renforge_editor_refresh_save_enabled()
-        renpy.restart_interaction()
-        return result
+        return _renforge_editor_apply_history_command(command, use_before=False)
 
 
     def _renforge_editor_reset_selected():
@@ -2008,6 +2061,82 @@ init 1100 python:
         return {"ok": False, "error": "NO_FOCUSABLE_TARGET"}
 
 
+    def _renforge_editor_set_target_size(target_key, size):
+        state = _renforge_editor_state()
+        target = state.targets.get(target_key)
+        if not isinstance(target, builtins.dict) or size is None or len(size) != 2:
+            return {"ok": False, "error": "TARGET_NOT_FOUND"}
+        caps = target.get("capabilities") or {}
+        if caps.get("resize") is not True:
+            return {"ok": False, "error": "RESIZE_UNSUPPORTED"}
+        next_size = [max(1, int(size[0])), max(1, int(size[1]))]
+        runtime_baseline = target.get("runtime_baseline") or []
+        runtime_size = target.get("runtime_size") or []
+        state.save_button_state = "idle"
+        target["size"] = next_size
+        position = target.get("position") or []
+        pos_dirty = (
+            len(position) == 2
+            and len(runtime_baseline) == 2
+            and [int(position[0]), int(position[1])] != [int(runtime_baseline[0]), int(runtime_baseline[1])]
+        )
+        size_dirty = (
+            len(runtime_size) == 2
+            and next_size != [int(runtime_size[0]), int(runtime_size[1])]
+        )
+        target["dirty"] = pos_dirty or size_dirty
+        _renforge_editor_show_target_overrides(target.get("screen"))
+        if state.selected_target_key == target_key:
+            state.preview_size = list(next_size)
+            if state.selected_rect is not None and len(state.selected_rect) == 4:
+                state.selected_rect = [
+                    int(state.selected_rect[0]),
+                    int(state.selected_rect[1]),
+                    int(next_size[0]),
+                    int(next_size[1]),
+                ]
+            _renforge_editor_set_label(state.pointer[0], state.pointer[1])
+        return {"ok": True, "w": next_size[0], "h": next_size[1]}
+
+
+    def _renforge_editor_resize(dw, dh):
+        state = _renforge_editor_state()
+        if state.selected_target_key is None:
+            return {"ok": False, "error": "NO_SELECTION"}
+        target = state.targets.get(state.selected_target_key)
+        if not isinstance(target, builtins.dict):
+            return {"ok": False, "error": "TARGET_NOT_FOUND"}
+        caps = target.get("capabilities") or state.current_capabilities or {}
+        if caps.get("resize") is not True:
+            return {"ok": False, "error": "RESIZE_UNSUPPORTED"}
+        base = state.preview_size or state.selected_original_size or target.get("size") or target.get("runtime_size")
+        if not (isinstance(base, (builtins.list, tuple)) and len(base) == 2):
+            if state.selected_rect is not None and len(state.selected_rect) >= 4:
+                base = [int(state.selected_rect[2]), int(state.selected_rect[3])]
+            else:
+                return {"ok": False, "error": "NO_SIZE"}
+        before = [int(base[0]), int(base[1])]
+        after = [max(1, before[0] + int(dw)), max(1, before[1] + int(dh))]
+        if after == before:
+            return {"ok": True, "w": after[0], "h": after[1]}
+        target_key = state.selected_target_key
+        if state.history_index + 1 < len(state.history_entries):
+            state.history_entries = state.history_entries[: state.history_index + 1]
+        command = {
+            "target_key": target_key,
+            "kind": "size",
+            "before": before,
+            "after": after,
+        }
+        state.history_entries.append(command)
+        state.history = [list(entry.get("after") or []) for entry in state.history_entries]
+        state.history_index = len(state.history_entries) - 1
+        result = _renforge_editor_set_target_size(target_key, after)
+        _renforge_editor_refresh_save_enabled()
+        renpy.restart_interaction()
+        return result
+
+
     def _renforge_editor_nudge(dx, dy, shift):
         state = _renforge_editor_state()
         base = state.preview_position or state.selected_original_position
@@ -2298,6 +2427,27 @@ init 1100 python:
                         ):
                             state.selected_source_position = [int(original_position[0]), int(original_position[1])]
                             state.selected_original_position = [int(runtime_baseline[0]), int(runtime_baseline[1])]
+                            original_size = result.get("original_size")
+                            runtime_size = None
+                            if (
+                                isinstance(state.selected_rect, (builtins.list, tuple))
+                                and len(state.selected_rect) >= 4
+                            ):
+                                runtime_size = [int(state.selected_rect[2]), int(state.selected_rect[3])]
+                            if (
+                                isinstance(original_size, (builtins.list, tuple))
+                                and len(original_size) == 2
+                                and isinstance(runtime_size, builtins.list)
+                                and len(runtime_size) == 2
+                                and (state.current_capabilities or {}).get("resize") is True
+                            ):
+                                state.selected_source_size = [int(original_size[0]), int(original_size[1])]
+                                state.selected_original_size = list(runtime_size)
+                                state.preview_size = list(runtime_size)
+                            else:
+                                state.selected_source_size = None
+                                state.selected_original_size = None
+                                state.preview_size = None
                             state.selected_target_key = target_key
                             state.targets[target_key] = {
                                 "analysis_id": state.current_analysis_id,
@@ -2309,6 +2459,9 @@ init 1100 python:
                                 "runtime_baseline": list(state.selected_original_position),
                                 "source_position": list(state.selected_source_position),
                                 "position": list(state.selected_original_position),
+                                "runtime_size": list(state.selected_original_size) if state.selected_original_size is not None else None,
+                                "source_size": list(state.selected_source_size) if state.selected_source_size is not None else None,
+                                "size": list(state.selected_original_size) if state.selected_original_size is not None else None,
                                 "dirty": False,
                                 "generation": int(state.script_generation),
                             }
@@ -2692,6 +2845,36 @@ init 1100 python:
         }
 
 
+    def _renforge_editor_h_size(payload):
+        payload = payload or {}
+        state = _renforge_editor_state()
+        if not state.active:
+            return {"ok": False, "error": "editor is not active"}
+        if "w" in payload or "h" in payload or "width" in payload or "height" in payload:
+            base = state.preview_size or state.selected_original_size
+            if not (isinstance(base, (builtins.list, tuple)) and len(base) == 2):
+                if state.selected_rect is not None and len(state.selected_rect) >= 4:
+                    base = [int(state.selected_rect[2]), int(state.selected_rect[3])]
+                else:
+                    return {"ok": False, "error": "NO_SIZE"}
+            width = payload.get("w", payload.get("width", base[0]))
+            height = payload.get("h", payload.get("height", base[1]))
+            try:
+                width = int(width)
+                height = int(height)
+            except Exception:
+                return {"ok": False, "error": "SIZE_INVALID"}
+            return _renforge_editor_resize(width - int(base[0]), height - int(base[1]))
+        dw = payload.get("dw", 0)
+        dh = payload.get("dh", 0)
+        try:
+            dw = int(dw)
+            dh = int(dh)
+        except Exception:
+            return {"ok": False, "error": "SIZE_DELTA_INVALID"}
+        return _renforge_editor_resize(dw, dh)
+
+
     def _renforge_editor_h_key(payload):
         payload = payload or {}
         key_name = str(payload.get("key") or "").lower()
@@ -2871,10 +3054,10 @@ init 1100 python:
                     "known": observation.get("script_generation"),
                 }
             expected_position = expected.get("position")
+            rect = observation.get("rect") or []
             if isinstance(expected_position, (builtins.list, tuple)) and len(expected_position) == 2:
                 expected_x = int(expected_position[0])
                 expected_y = int(expected_position[1])
-                rect = observation.get("rect") or []
                 # Issue #39 requires pixel agreement within one logical pixel.
                 if not (abs(int(rect[0]) - expected_x) <= 1 and abs(int(rect[1]) - expected_y) <= 1):
                     return {
@@ -2883,6 +3066,23 @@ init 1100 python:
                         "widget_id": widget_id,
                         "expected": expected_position,
                         "observed": rect[:2] if isinstance(rect, builtins.list) and len(rect) >= 2 else None,
+                    }
+            expected_size = expected.get("size")
+            if isinstance(expected_size, (builtins.list, tuple)) and len(expected_size) == 2:
+                expected_w = int(expected_size[0])
+                expected_h = int(expected_size[1])
+                if not (
+                    isinstance(rect, builtins.list)
+                    and len(rect) >= 4
+                    and abs(int(rect[2]) - expected_w) <= 1
+                    and abs(int(rect[3]) - expected_h) <= 1
+                ):
+                    return {
+                        "ok": False,
+                        "error": "TARGET_SIZE_MISMATCH",
+                        "widget_id": widget_id,
+                        "expected": expected_size,
+                        "observed": rect[2:4] if isinstance(rect, builtins.list) and len(rect) >= 4 else None,
                     }
             attested.append(
                 {
@@ -2988,7 +3188,10 @@ init 1100 python:
             "status_text": state.status_text,
             "selected_original_position": state.selected_original_position,
             "selected_source_position": state.selected_source_position,
+            "selected_original_size": state.selected_original_size,
+            "selected_source_size": state.selected_source_size,
             "preview_position": state.preview_position,
+            "preview_size": state.preview_size,
             "history_index": state.history_index,
             "history_length": len(state.history_entries),
             "current_analysis_id": state.current_analysis_id,
@@ -3151,6 +3354,7 @@ init 1100 python:
         handlers["editor_task0_select"] = _renforge_editor_h_select
         handlers["editor_task0_drag"] = _renforge_editor_h_drag
         handlers["editor_task0_key"] = _renforge_editor_h_key
+        handlers["editor_task0_size"] = _renforge_editor_h_size
         handlers["editor_task0_undo"] = _renforge_editor_h_undo
         handlers["editor_task0_redo"] = _renforge_editor_h_redo
         handlers["editor_task0_reset"] = _renforge_editor_h_reset

--- a/src/renforge/bridge/editor.rpy
+++ b/src/renforge/bridge/editor.rpy
@@ -226,6 +226,8 @@ init 1100 python:
     _EDITOR_VIOLET = "#a78bfa"
     _EDITOR_AMBER = "#f59e0b"
     _EDITOR_LOCKED_TEXT = "LOCKED"
+    # Protocol value mirrored by renforge.editor.source.BAR_SIZE_MODE_XSIZE_YSIZE.
+    _BAR_SIZE_MODE_XSIZE_YSIZE = "xsize_ysize"
     _SNAP_ACQUIRE = 6
     _SNAP_RELEASE = 10
     _CACHE_WALK_MAX_DEPTH = 32
@@ -1589,7 +1591,7 @@ init 1100 python:
                 and len(runtime_size) == 2
                 and isinstance(source_size, (builtins.list, tuple))
                 and len(source_size) == 2
-                and source_key.get("size_mode") == "xsize_ysize"
+                and source_key.get("size_mode") == _BAR_SIZE_MODE_XSIZE_YSIZE
             ):
                 intent["w"] = int(source_size[0]) + int(size[0]) - int(runtime_size[0])
                 intent["h"] = int(source_size[1]) + int(size[1]) - int(runtime_size[1])
@@ -1613,6 +1615,17 @@ init 1100 python:
         value = command.get("before") if use_before else command.get("after")
         if command.get("kind") == "size":
             result = _renforge_editor_set_target_size(command.get("target_key"), value)
+        elif command.get("kind") == "reset":
+            result = _renforge_editor_set_target_position(command.get("target_key"), value)
+            size_key = "before_size" if use_before else "after_size"
+            size_value = command.get(size_key)
+            if isinstance(size_value, (builtins.list, tuple)) and len(size_value) == 2:
+                size_result = _renforge_editor_set_target_size(
+                    command.get("target_key"),
+                    size_value,
+                )
+                if not size_result.get("ok", False):
+                    result = size_result
         else:
             result = _renforge_editor_set_target_position(command.get("target_key"), value)
         _renforge_editor_refresh_save_enabled()
@@ -1649,15 +1662,34 @@ init 1100 python:
             return {"ok": False, "error": "RESET_UNAVAILABLE"}
         before = list(target.get("position") or [])
         baseline = list(target.get("runtime_baseline") or [])
-        if len(before) != 2 or len(baseline) != 2 or before == baseline:
+        before_size = list(target.get("size") or [])
+        baseline_size = list(target.get("runtime_size") or [])
+        position_dirty = len(before) == 2 and len(baseline) == 2 and before != baseline
+        size_dirty = (
+            len(before_size) == 2
+            and len(baseline_size) == 2
+            and before_size != baseline_size
+        )
+        if not position_dirty and not size_dirty:
             return {"ok": False, "error": "RESET_UNAVAILABLE"}
-        _renforge_editor_push_history(baseline)
+        if len(before) != 2 or len(baseline) != 2:
+            return {"ok": False, "error": "RESET_UNAVAILABLE"}
+        if state.history_index + 1 < len(state.history_entries):
+            state.history_entries = state.history_entries[: state.history_index + 1]
+        command = {
+            "target_key": state.selected_target_key,
+            "kind": "reset",
+            "before": before,
+            "after": baseline,
+            "before_size": before_size if len(before_size) == 2 else None,
+            "after_size": baseline_size if len(baseline_size) == 2 else None,
+        }
+        state.history_entries.append(command)
+        state.history = [list(entry.get("after") or []) for entry in state.history_entries]
+        state.history_index = len(state.history_entries) - 1
         state.status_text = "Reset"
         state.last_restore_method = "history_reset"
-        result = _renforge_editor_set_target_position(state.selected_target_key, baseline)
-        _renforge_editor_refresh_save_enabled()
-        renpy.restart_interaction()
-        return result
+        return _renforge_editor_apply_history_command(command, use_before=False)
 
 
     def _renforge_editor_adjust_opacity(delta):
@@ -2019,10 +2051,21 @@ init 1100 python:
             target = state.targets.get(target_key)
             if isinstance(target, builtins.dict):
                 position = list(target.get("position") or target.get("runtime_baseline") or rect[:2])
+                runtime_size = list(target.get("runtime_size") or rect[2:4])
+                size = list(target.get("size") or runtime_size)
                 state.selected_original_position = list(target.get("runtime_baseline") or rect[:2])
                 state.selected_source_position = list(target.get("source_position") or [])
+                state.selected_original_size = runtime_size if len(runtime_size) == 2 else None
+                state.selected_source_size = list(target.get("source_size") or []) or None
                 state.preview_position = position
-                state.selected_rect = [int(position[0]), int(position[1]), int(rect[2]), int(rect[3])]
+                state.preview_size = size if len(size) == 2 else None
+                selected_size = size if len(size) == 2 else rect[2:4]
+                state.selected_rect = [
+                    int(position[0]),
+                    int(position[1]),
+                    int(selected_size[0]),
+                    int(selected_size[1]),
+                ]
                 _renforge_editor_set_current_analysis(
                     state,
                     target.get("analysis_id"),
@@ -2099,23 +2142,35 @@ init 1100 python:
         return {"ok": True, "w": next_size[0], "h": next_size[1]}
 
 
-    def _renforge_editor_resize(dw, dh):
+    def _renforge_editor_resize_context():
         state = _renforge_editor_state()
         if state.selected_target_key is None:
-            return {"ok": False, "error": "NO_SELECTION"}
+            return None, None, {"ok": False, "error": "NO_SELECTION"}
         target = state.targets.get(state.selected_target_key)
         if not isinstance(target, builtins.dict):
-            return {"ok": False, "error": "TARGET_NOT_FOUND"}
+            return None, None, {"ok": False, "error": "TARGET_NOT_FOUND"}
         caps = target.get("capabilities") or state.current_capabilities or {}
         if caps.get("resize") is not True:
-            return {"ok": False, "error": "RESIZE_UNSUPPORTED"}
-        base = state.preview_size or state.selected_original_size or target.get("size") or target.get("runtime_size")
+            return target, None, {"ok": False, "error": "RESIZE_UNSUPPORTED"}
+        base = (
+            target.get("size")
+            or target.get("runtime_size")
+            or state.selected_original_size
+            or state.preview_size
+        )
         if not (isinstance(base, (builtins.list, tuple)) and len(base) == 2):
             if state.selected_rect is not None and len(state.selected_rect) >= 4:
                 base = [int(state.selected_rect[2]), int(state.selected_rect[3])]
             else:
-                return {"ok": False, "error": "NO_SIZE"}
-        before = [int(base[0]), int(base[1])]
+                return target, None, {"ok": False, "error": "NO_SIZE"}
+        return target, [int(base[0]), int(base[1])], None
+
+
+    def _renforge_editor_resize(dw, dh):
+        state = _renforge_editor_state()
+        _target, before, error = _renforge_editor_resize_context()
+        if error is not None:
+            return error
         after = [max(1, before[0] + int(dw)), max(1, before[1] + int(dh))]
         if after == before:
             return {"ok": True, "w": after[0], "h": after[1]}
@@ -2851,12 +2906,9 @@ init 1100 python:
         if not state.active:
             return {"ok": False, "error": "editor is not active"}
         if "w" in payload or "h" in payload or "width" in payload or "height" in payload:
-            base = state.preview_size or state.selected_original_size
-            if not (isinstance(base, (builtins.list, tuple)) and len(base) == 2):
-                if state.selected_rect is not None and len(state.selected_rect) >= 4:
-                    base = [int(state.selected_rect[2]), int(state.selected_rect[3])]
-                else:
-                    return {"ok": False, "error": "NO_SIZE"}
+            _target, base, error = _renforge_editor_resize_context()
+            if error is not None:
+                return error
             width = payload.get("w", payload.get("width", base[0]))
             height = payload.get("h", payload.get("height", base[1]))
             try:

--- a/src/renforge/editor/coordinator.py
+++ b/src/renforge/editor/coordinator.py
@@ -30,6 +30,7 @@ from .paths import EditorPathError, atomic_write_file, fsync_directory, resolve_
 from .runtime import RuntimeProbe
 from .shadow import ShadowLintResult, build_shadow_project, run_shadow_lint
 from .source import (
+    BAR_SIZE_MODE_XSIZE_YSIZE,
     DEFAULT_ALIGN_PARENT_SIZE,
     BarStatement,
     EditorSourceError,
@@ -609,12 +610,12 @@ class EditorCoordinator:
             # Issue #47: bar-only resize capability from pure xsize/ysize.
             if statement_kind == "bar" and isinstance(statement, BarStatement):
                 if (
-                    statement.size_mode == "xsize_ysize"
+                    statement.size_mode == BAR_SIZE_MODE_XSIZE_YSIZE
                     and statement.xsize is not None
                     and statement.ysize is not None
                 ):
                     original_size = [int(statement.xsize), int(statement.ysize)]
-                    source_key["size_mode"] = "xsize_ysize"
+                    source_key["size_mode"] = BAR_SIZE_MODE_XSIZE_YSIZE
                     source_key["authored_size"] = list(original_size)
                 else:
                     source_key["size_mode"] = None
@@ -724,7 +725,7 @@ class EditorCoordinator:
             and original_size is not None
             and runtime_size is not None
             and isinstance(source_key, dict)
-            and source_key.get("size_mode") == "xsize_ysize"
+            and source_key.get("size_mode") == BAR_SIZE_MODE_XSIZE_YSIZE
         )
         record = _AnalysisRecord(
             analysis_id=analysis_id,
@@ -809,7 +810,11 @@ class EditorCoordinator:
             if record.source_key != source_key:
                 raise EditorError("SOURCE_KEY_MISMATCH", "intent source_key does not match analyzed source key")
             if width is not None or height is not None:
-                if record.original_size is None or source_key.get("size_mode") != "xsize_ysize":
+                if (
+                    record.original_size is None
+                    or record.runtime_size is None
+                    or source_key.get("size_mode") != BAR_SIZE_MODE_XSIZE_YSIZE
+                ):
                     raise EditorError(
                         "ANALYSIS_RESIZE_UNSUPPORTED",
                         "analysis does not unlock resize for this target",

--- a/src/renforge/editor/coordinator.py
+++ b/src/renforge/editor/coordinator.py
@@ -31,6 +31,7 @@ from .runtime import RuntimeProbe
 from .shadow import ShadowLintResult, build_shadow_project, run_shadow_lint
 from .source import (
     DEFAULT_ALIGN_PARENT_SIZE,
+    BarStatement,
     EditorSourceError,
     align_geometry_matches_parent,
     analyze_button_statement,
@@ -72,6 +73,8 @@ class _AnalysisRecord:
     generation: int
     lock_reason: dict[str, Any] | None
     independent_frame_id: str
+    original_size: list[int] | None = None
+    runtime_size: list[int] | None = None
 
 
 @dataclass
@@ -515,6 +518,8 @@ class EditorCoordinator:
         source_key: dict[str, Any] | None = None
         runtime_position = self._extract_position(independent)
         original_position = list(runtime_position)
+        runtime_size: list[int] | None = self._extract_size(independent)
+        original_size: list[int] | None = None
 
         try:
             source_location = runtime_key.get("source_location")
@@ -601,6 +606,23 @@ class EditorCoordinator:
                 "baseline_sha256": source_sha,
                 "position_mode": position_mode,
             }
+            # Issue #47: bar-only resize capability from pure xsize/ysize.
+            if statement_kind == "bar" and isinstance(statement, BarStatement):
+                if (
+                    statement.size_mode == "xsize_ysize"
+                    and statement.xsize is not None
+                    and statement.ysize is not None
+                ):
+                    original_size = [int(statement.xsize), int(statement.ysize)]
+                    source_key["size_mode"] = "xsize_ysize"
+                    source_key["authored_size"] = list(original_size)
+                else:
+                    source_key["size_mode"] = None
+                    if statement.resize_lock_code is not None:
+                        source_key["resize_lock_reason"] = self._lock_reason(
+                            statement.resize_lock_code,
+                            statement.resize_lock_message or statement.resize_lock_code,
+                        )
             if uses_runtime_delta_position(position_mode):
                 # Shared authored + measured baseline fields for delta write-back.
                 authored = (
@@ -696,6 +718,14 @@ class EditorCoordinator:
             lock_reason = self._lock_reason("SOURCE_READ_FAILED", f"unable to read source: {exc}")
 
         analysis_id = uuid.uuid4().hex
+        can_move = lock_reason is None
+        can_resize = (
+            can_move
+            and original_size is not None
+            and runtime_size is not None
+            and isinstance(source_key, dict)
+            and source_key.get("size_mode") == "xsize_ysize"
+        )
         record = _AnalysisRecord(
             analysis_id=analysis_id,
             session_id=self._session_id,
@@ -706,6 +736,8 @@ class EditorCoordinator:
             generation=generation,
             lock_reason=lock_reason,
             independent_frame_id=str(independent.get("frame_id", "")),
+            original_size=list(original_size) if original_size is not None else None,
+            runtime_size=list(runtime_size) if runtime_size is not None else None,
         )
         with self._lock:
             self._analyses[analysis_id] = record
@@ -714,7 +746,8 @@ class EditorCoordinator:
             "analysis_id": analysis_id,
             "source_key": source_key,
             "original_position": original_position,
-            "capabilities": {"move": lock_reason is None},
+            "original_size": list(original_size) if original_size is not None else None,
+            "capabilities": {"move": can_move, "resize": can_resize},
             "lock_reason": lock_reason,
         }
 
@@ -733,7 +766,7 @@ class EditorCoordinator:
             raise EditorError("RUNTIME_PROBE_UNAVAILABLE", "runtime probe is not attached")
 
         seen_analysis_ids: set[str] = set()
-        selected_records: list[tuple[_AnalysisRecord, int, int, dict[str, Any]]] = []
+        selected_records: list[tuple[_AnalysisRecord, int, int, int | None, int | None, dict[str, Any]]] = []
         source_paths: set[str] = set()
         with self._lock:
             generation = self._script_generation
@@ -754,6 +787,13 @@ class EditorCoordinator:
             y = intent.get("y")
             if not isinstance(x, int) or not isinstance(y, int):
                 raise EditorError("INTENT_POSITION_INVALID", "intent x and y must be integers")
+            width = intent.get("w", intent.get("width"))
+            height = intent.get("h", intent.get("height"))
+            if width is not None or height is not None:
+                if type(width) is not int or type(height) is not int:
+                    raise EditorError("INTENT_SIZE_INVALID", "intent w and h must both be integers when resizing")
+                if int(width) <= 0 or int(height) <= 0:
+                    raise EditorError("BAR_SIZE_NON_POSITIVE", "intent size must be positive")
             with self._lock:
                 record = self._analyses.get(analysis_id)
             if record is None:
@@ -768,9 +808,24 @@ class EditorCoordinator:
                 raise EditorError("ANALYSIS_SOURCE_KEY_MISSING", "analysis does not include a writable source key")
             if record.source_key != source_key:
                 raise EditorError("SOURCE_KEY_MISMATCH", "intent source_key does not match analyzed source key")
+            if width is not None or height is not None:
+                if record.original_size is None or source_key.get("size_mode") != "xsize_ysize":
+                    raise EditorError(
+                        "ANALYSIS_RESIZE_UNSUPPORTED",
+                        "analysis does not unlock resize for this target",
+                    )
             relative_path = self._require_source_relative_path(source_key)
             source_paths.add(relative_path)
-            selected_records.append((record, x, y, source_key))
+            selected_records.append(
+                (
+                    record,
+                    x,
+                    y,
+                    int(width) if width is not None else None,
+                    int(height) if height is not None else None,
+                    source_key,
+                )
+            )
 
         if len(source_paths) != 1:
             raise EditorError("MULTI_FILE_UNSUPPORTED", "all intents must resolve to exactly one source file")
@@ -780,7 +835,7 @@ class EditorCoordinator:
         current_bytes = source_path.read_bytes()
         current_sha = sha256_bytes(current_bytes)
 
-        for record, _x, _y, source_key in selected_records:
+        for record, _x, _y, _w, _h, source_key in selected_records:
             baseline = source_key.get("baseline_sha256")
             if not isinstance(baseline, str):
                 raise EditorError("SOURCE_BASELINE_INVALID", "source_key baseline_sha256 is missing")
@@ -818,8 +873,23 @@ class EditorCoordinator:
                         int(record.runtime_position[0]) + int(x) - int(record.original_position[0]),
                         int(record.runtime_position[1]) + int(y) - int(record.original_position[1]),
                     ],
+                    **(
+                        {
+                            "size": [
+                                int(record.runtime_size[0]) + int(width) - int(record.original_size[0]),
+                                int(record.runtime_size[1]) + int(height) - int(record.original_size[1]),
+                            ]
+                        }
+                        if (
+                            width is not None
+                            and height is not None
+                            and record.original_size is not None
+                            and record.runtime_size is not None
+                        )
+                        else {}
+                    ),
                 }
-                for record, x, y, source_key in selected_records
+                for record, x, y, width, height, source_key in selected_records
             ],
             state="staged",
         )
@@ -1108,15 +1178,26 @@ class EditorCoordinator:
             raise EditorError("RECT_INVALID", "observation rect coordinates must be integers")
         return [x, y]
 
+    def _extract_size(self, observation: dict[str, Any]) -> list[int] | None:
+        rect = observation.get("rect")
+        if not isinstance(rect, list) or len(rect) < 4:
+            return None
+        width, height = rect[2], rect[3]
+        if type(width) is not int or type(height) is not int:
+            return None
+        if width <= 0 or height <= 0:
+            return None
+        return [int(width), int(height)]
+
     def _apply_same_file_intents(
         self,
         source_bytes: bytes,
-        selected_records: list[tuple[_AnalysisRecord, int, int, dict[str, Any]]],
+        selected_records: list[tuple[_AnalysisRecord, int, int, int | None, int | None, dict[str, Any]]],
     ) -> bytes:
         lines = source_bytes.decode("utf-8").splitlines(keepends=True)
         seen_targets: set[tuple[str, int, str]] = set()
 
-        for _record, x, y, source_key in selected_records:
+        for _record, x, y, width, height, source_key in selected_records:
             line_no = source_key.get("line")
             widget_id = source_key.get("widget_id")
             if not isinstance(line_no, int) or not isinstance(widget_id, str):
@@ -1146,6 +1227,11 @@ class EditorCoordinator:
                         "source_key statement_kind does not match source line",
                     )
             if actual_kind == "button":
+                if width is not None or height is not None:
+                    raise EditorError(
+                        "ANALYSIS_RESIZE_UNSUPPORTED",
+                        "resize is only supported for bar xsize/ysize",
+                    )
                 statement = analyze_button_statement(
                     source_text,
                     source_line=line_no,
@@ -1158,6 +1244,11 @@ class EditorCoordinator:
                     y=y,
                 ).decode("utf-8").splitlines(keepends=True)
             elif actual_kind == "textbutton" and is_textbutton_block_header(lines[line_no - 1]):
+                if width is not None or height is not None:
+                    raise EditorError(
+                        "ANALYSIS_RESIZE_UNSUPPORTED",
+                        "resize is only supported for bar xsize/ysize",
+                    )
                 statement = analyze_textbutton_block_statement(
                     source_text,
                     source_line=line_no,
@@ -1177,6 +1268,11 @@ class EditorCoordinator:
                 if kind == "textbutton" and uses_runtime_delta_position(
                     getattr(statement, "position_mode", "xy")
                 ):
+                    if width is not None or height is not None:
+                        raise EditorError(
+                            "ANALYSIS_RESIZE_UNSUPPORTED",
+                            "resize is only supported for bar xsize/ysize",
+                        )
                     lines[line_no - 1] = apply_textbutton_patch(
                         lines[line_no - 1].encode("utf-8"),
                         statement,
@@ -1191,6 +1287,8 @@ class EditorCoordinator:
                         statement,
                         x=x,
                         y=y,
+                        width=width,
+                        height=height,
                     ).decode("utf-8")
 
         return "".join(lines).encode("utf-8")

--- a/src/renforge/editor/source.py
+++ b/src/renforge/editor/source.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import ast
 from dataclasses import dataclass
-from typing import TypeVar
+from typing import TypeVar, TypedDict
 
 
 class EditorSourceError(ValueError):
@@ -19,6 +19,17 @@ DEFAULT_ALIGN_PARENT_SIZE: tuple[int, int] = (1280, 720)
 # Modes whose editor original_position is the measured focus_list top-left and whose
 # write-back is authored + (runtime − baseline). Preview uses absolute xpos/ypos.
 RUNTIME_DELTA_POSITION_MODES = frozenset({"align", "offset"})
+BAR_SIZE_MODE_XSIZE_YSIZE = "xsize_ysize"
+
+
+class _BarSizeModel(TypedDict):
+    xsize: int | None
+    ysize: int | None
+    xsize_span: tuple[int, int] | None
+    ysize_span: tuple[int, int] | None
+    size_mode: str | None
+    resize_lock_code: str | None
+    resize_lock_message: str | None
 
 
 def uses_runtime_delta_position(mode: str | None) -> bool:
@@ -1273,7 +1284,7 @@ _BAR_SIZE_CONSTRAINT_WORDS = frozenset(
 )
 
 
-def _analyze_bar_size_model(line: str) -> dict[str, object]:
+def _analyze_bar_size_model(line: str) -> _BarSizeModel:
     """Return bar size fields for issue #47 without affecting move unlock.
 
     Unlocked form: pure integer ``xsize`` + pure integer ``ysize``, both > 0,
@@ -1320,7 +1331,7 @@ def _analyze_bar_size_model(line: str) -> dict[str, object]:
         values[keyword] = int(value_token.text)
         spans[keyword] = (value_token.start, value_token.end)
 
-    empty: dict[str, object] = {
+    empty: _BarSizeModel = {
         "xsize": None,
         "ysize": None,
         "xsize_span": None,
@@ -1391,7 +1402,7 @@ def _analyze_bar_size_model(line: str) -> dict[str, object]:
         "ysize": values["ysize"],
         "xsize_span": spans["xsize"],
         "ysize_span": spans["ysize"],
-        "size_mode": "xsize_ysize",
+        "size_mode": BAR_SIZE_MODE_XSIZE_YSIZE,
         "resize_lock_code": None,
         "resize_lock_message": None,
     }
@@ -1412,17 +1423,13 @@ def analyze_bar_statement(line: str, *, expected_widget_id: str) -> BarStatement
         ypos=base.ypos,
         xpos_span=base.xpos_span,
         ypos_span=base.ypos_span,
-        xsize=size["xsize"] if isinstance(size["xsize"], int) else None,
-        ysize=size["ysize"] if isinstance(size["ysize"], int) else None,
-        xsize_span=size["xsize_span"] if isinstance(size["xsize_span"], tuple) else None,
-        ysize_span=size["ysize_span"] if isinstance(size["ysize_span"], tuple) else None,
-        size_mode=size["size_mode"] if isinstance(size["size_mode"], str) else None,
-        resize_lock_code=(
-            size["resize_lock_code"] if isinstance(size["resize_lock_code"], str) else None
-        ),
-        resize_lock_message=(
-            size["resize_lock_message"] if isinstance(size["resize_lock_message"], str) else None
-        ),
+        xsize=size["xsize"],
+        ysize=size["ysize"],
+        xsize_span=size["xsize_span"],
+        ysize_span=size["ysize_span"],
+        size_mode=size["size_mode"],
+        resize_lock_code=size["resize_lock_code"],
+        resize_lock_message=size["resize_lock_message"],
     )
 
 
@@ -1639,7 +1646,7 @@ def apply_bar_patch(
     ]
     if width is not None or height is not None:
         if (
-            statement.size_mode != "xsize_ysize"
+            statement.size_mode != BAR_SIZE_MODE_XSIZE_YSIZE
             or statement.xsize_span is None
             or statement.ysize_span is None
             or statement.xsize is None

--- a/src/renforge/editor/source.py
+++ b/src/renforge/editor/source.py
@@ -163,7 +163,15 @@ class BarStatement:
     ypos: int
     xpos_span: tuple[int, int]
     ypos_span: tuple[int, int]
-
+    # Optional authored size model (issue #47). Only pure integer xsize+ysize
+    # unlocks resize; every other form leaves these None and sets resize_lock.
+    xsize: int | None = None
+    ysize: int | None = None
+    xsize_span: tuple[int, int] | None = None
+    ysize_span: tuple[int, int] | None = None
+    size_mode: str | None = None
+    resize_lock_code: str | None = None
+    resize_lock_message: str | None = None
 
 @dataclass(frozen=True)
 class VbarStatement:
@@ -1089,6 +1097,7 @@ _BAR_POSITION_FOLLOWER_WORDS = frozenset(
         "style",
         "xsize",
         "ysize",
+        "xysize",
         "xmaximum",
         "ymaximum",
         "xminimum",
@@ -1248,13 +1257,172 @@ def _analyze_bar_like_statement(
     )
 
 
+def _bar_resize_lock(code: str, message: str) -> tuple[str, str]:
+    return code, message
+
+
+_BAR_SIZE_CONSTRAINT_WORDS = frozenset(
+    {
+        "xmaximum",
+        "ymaximum",
+        "xminimum",
+        "yminimum",
+        "xfill",
+        "yfill",
+    }
+)
+
+
+def _analyze_bar_size_model(line: str) -> dict[str, object]:
+    """Return bar size fields for issue #47 without affecting move unlock.
+
+    Unlocked form: pure integer ``xsize`` + pure integer ``ysize``, both > 0,
+    with no ``xysize`` and no size-constraint keywords on the same statement.
+    """
+    statement_text = _statement_text(line)
+    tokens = _lex_single_line(statement_text)
+    has_xysize = any(
+        token.depth == 0 and token.kind == "WORD" and token.text == "xysize" for token in tokens
+    )
+    constraint_hits = sorted(
+        {
+            token.text
+            for token in tokens
+            if token.depth == 0
+            and token.kind == "WORD"
+            and token.text in _BAR_SIZE_CONSTRAINT_WORDS
+        }
+    )
+    keyword_counts = {"xsize": 0, "ysize": 0}
+    values: dict[str, int] = {}
+    spans: dict[str, tuple[int, int]] = {}
+    invalid_literals: set[str] = set()
+
+    for index, token in enumerate(tokens):
+        if token.depth != 0 or token.kind != "WORD" or token.text not in keyword_counts:
+            continue
+        keyword = token.text
+        keyword_counts[keyword] += 1
+        value_index = _next_top_level_index(tokens, index)
+        if value_index is None:
+            invalid_literals.add(keyword)
+            continue
+        value_token = tokens[value_index]
+        if value_token.kind != "NUMBER":
+            invalid_literals.add(keyword)
+            continue
+        following_index = _next_top_level_index(tokens, value_index)
+        if following_index is not None:
+            following = tokens[following_index]
+            if following.kind != "WORD" or following.text not in _BAR_POSITION_FOLLOWER_WORDS:
+                invalid_literals.add(keyword)
+                continue
+        values[keyword] = int(value_token.text)
+        spans[keyword] = (value_token.start, value_token.end)
+
+    empty: dict[str, object] = {
+        "xsize": None,
+        "ysize": None,
+        "xsize_span": None,
+        "ysize_span": None,
+        "size_mode": None,
+        "resize_lock_code": None,
+        "resize_lock_message": None,
+    }
+
+    if has_xysize:
+        code, message = _bar_resize_lock(
+            "BAR_XYSIZE_UNSUPPORTED",
+            "bar xysize form is not writable; author separate xsize/ysize literals",
+        )
+        return {**empty, "resize_lock_code": code, "resize_lock_message": message}
+    if constraint_hits:
+        code, message = _bar_resize_lock(
+            "BAR_SIZE_CONSTRAINT_UNSUPPORTED",
+            "bar size constraints are not writable: " + ", ".join(constraint_hits),
+        )
+        return {**empty, "resize_lock_code": code, "resize_lock_message": message}
+
+    if keyword_counts["xsize"] == 0 and keyword_counts["ysize"] == 0:
+        code, message = _bar_resize_lock(
+            "BAR_SIZE_NOT_DIRECTLY_AUTHORED",
+            "bar size is not directly authored as literal xsize/ysize",
+        )
+        return {**empty, "resize_lock_code": code, "resize_lock_message": message}
+    if keyword_counts["xsize"] == 0 or keyword_counts["ysize"] == 0:
+        code, message = _bar_resize_lock(
+            "BAR_SIZE_NOT_DIRECTLY_AUTHORED",
+            "bar size requires both literal xsize and ysize",
+        )
+        return {**empty, "resize_lock_code": code, "resize_lock_message": message}
+    if keyword_counts["xsize"] != 1:
+        code, message = _bar_resize_lock(
+            "XSIZE_DUPLICATE",
+            "bar statement must contain exactly one xsize",
+        )
+        return {**empty, "resize_lock_code": code, "resize_lock_message": message}
+    if keyword_counts["ysize"] != 1:
+        code, message = _bar_resize_lock(
+            "YSIZE_DUPLICATE",
+            "bar statement must contain exactly one ysize",
+        )
+        return {**empty, "resize_lock_code": code, "resize_lock_message": message}
+    if "xsize" in invalid_literals or "xsize" not in values or "xsize" not in spans:
+        code, message = _bar_resize_lock(
+            "XSIZE_LITERAL_REQUIRED",
+            "xsize must be a pure integer literal",
+        )
+        return {**empty, "resize_lock_code": code, "resize_lock_message": message}
+    if "ysize" in invalid_literals or "ysize" not in values or "ysize" not in spans:
+        code, message = _bar_resize_lock(
+            "YSIZE_LITERAL_REQUIRED",
+            "ysize must be a pure integer literal",
+        )
+        return {**empty, "resize_lock_code": code, "resize_lock_message": message}
+    if values["xsize"] <= 0 or values["ysize"] <= 0:
+        code, message = _bar_resize_lock(
+            "BAR_SIZE_NON_POSITIVE",
+            "bar xsize and ysize must be positive integers",
+        )
+        return {**empty, "resize_lock_code": code, "resize_lock_message": message}
+
+    return {
+        "xsize": values["xsize"],
+        "ysize": values["ysize"],
+        "xsize_span": spans["xsize"],
+        "ysize_span": spans["ysize"],
+        "size_mode": "xsize_ysize",
+        "resize_lock_code": None,
+        "resize_lock_message": None,
+    }
+
+
 def analyze_bar_statement(line: str, *, expected_widget_id: str) -> BarStatement:
-    return _analyze_bar_like_statement(
+    base = _analyze_bar_like_statement(
         line,
         expected_widget_id=expected_widget_id,
         expected_source_kind="bar",
         statement_cls=BarStatement,
         human_kind="bar",
+    )
+    size = _analyze_bar_size_model(line)
+    return BarStatement(
+        widget_id=base.widget_id,
+        xpos=base.xpos,
+        ypos=base.ypos,
+        xpos_span=base.xpos_span,
+        ypos_span=base.ypos_span,
+        xsize=size["xsize"] if isinstance(size["xsize"], int) else None,
+        ysize=size["ysize"] if isinstance(size["ysize"], int) else None,
+        xsize_span=size["xsize_span"] if isinstance(size["xsize_span"], tuple) else None,
+        ysize_span=size["ysize_span"] if isinstance(size["ysize_span"], tuple) else None,
+        size_mode=size["size_mode"] if isinstance(size["size_mode"], str) else None,
+        resize_lock_code=(
+            size["resize_lock_code"] if isinstance(size["resize_lock_code"], str) else None
+        ),
+        resize_lock_message=(
+            size["resize_lock_message"] if isinstance(size["resize_lock_message"], str) else None
+        ),
     )
 
 
@@ -1327,19 +1495,32 @@ def analyze_slider_statement(line: str, *, expected_widget_id: str) -> SliderSta
 def _apply_integer_span_patch(
     source_bytes: bytes,
     *,
-    xpos_span: tuple[int, int],
-    ypos_span: tuple[int, int],
-    x: int,
-    y: int,
+    replacements: list[tuple[tuple[int, int], int]] | None = None,
+    xpos_span: tuple[int, int] | None = None,
+    ypos_span: tuple[int, int] | None = None,
+    x: int | None = None,
+    y: int | None = None,
 ) -> bytes:
+    """Replace one or more integer spans. Spans are absolute in ``source_bytes``."""
+    items: list[tuple[tuple[int, int], int]] = list(replacements or [])
+    if xpos_span is not None:
+        if x is None:
+            raise EditorSourceError("XPOS_LITERAL_REQUIRED", "xpos patch value is required")
+        items.append((xpos_span, int(x)))
+    if ypos_span is not None:
+        if y is None:
+            raise EditorSourceError("YPOS_LITERAL_REQUIRED", "ypos patch value is required")
+        items.append((ypos_span, int(y)))
+    if not items:
+        return source_bytes
     source_text = source_bytes.decode("utf-8")
-    replacements = [
-        (xpos_span[0], xpos_span[1], str(int(x))),
-        (ypos_span[0], ypos_span[1], str(int(y))),
-    ]
-    replacements.sort(key=lambda item: item[0], reverse=True)
+    ordered = sorted(
+        ((span[0], span[1], str(int(value))) for span, value in items),
+        key=lambda item: item[0],
+        reverse=True,
+    )
     patched = source_text
-    for start, end, replacement in replacements:
+    for start, end, replacement in ordered:
         patched = f"{patched[:start]}{replacement}{patched[end:]}"
     return patched.encode("utf-8")
 
@@ -1443,14 +1624,44 @@ def apply_imagebutton_patch(
     )
 
 
-def apply_bar_patch(source_bytes: bytes, statement: BarStatement, *, x: int, y: int) -> bytes:
-    return _apply_integer_span_patch(
-        source_bytes,
-        xpos_span=statement.xpos_span,
-        ypos_span=statement.ypos_span,
-        x=x,
-        y=y,
-    )
+def apply_bar_patch(
+    source_bytes: bytes,
+    statement: BarStatement,
+    *,
+    x: int,
+    y: int,
+    width: int | None = None,
+    height: int | None = None,
+) -> bytes:
+    replacements: list[tuple[tuple[int, int], int]] = [
+        (statement.xpos_span, int(x)),
+        (statement.ypos_span, int(y)),
+    ]
+    if width is not None or height is not None:
+        if (
+            statement.size_mode != "xsize_ysize"
+            or statement.xsize_span is None
+            or statement.ysize_span is None
+            or statement.xsize is None
+            or statement.ysize is None
+        ):
+            raise EditorSourceError(
+                "BAR_SIZE_NOT_DIRECTLY_AUTHORED",
+                "bar size patch requires unlocked xsize/ysize literals",
+            )
+        if width is None or height is None:
+            raise EditorSourceError(
+                "BAR_SIZE_NOT_DIRECTLY_AUTHORED",
+                "bar size patch requires both width and height",
+            )
+        if int(width) <= 0 or int(height) <= 0:
+            raise EditorSourceError(
+                "BAR_SIZE_NON_POSITIVE",
+                "bar xsize and ysize must be positive integers",
+            )
+        replacements.append((statement.xsize_span, int(width)))
+        replacements.append((statement.ysize_span, int(height)))
+    return _apply_integer_span_patch(source_bytes, replacements=replacements)
 
 
 def apply_vbar_patch(source_bytes: bytes, statement: VbarStatement, *, x: int, y: int) -> bytes:
@@ -1517,26 +1728,55 @@ def apply_editable_statement_patch(
     *,
     x: int,
     y: int,
+    width: int | None = None,
+    height: int | None = None,
 ) -> bytes:
     if kind == "textbutton":
         if not isinstance(statement, TextbuttonStatement):
             raise EditorSourceError("STATEMENT_KIND_MISMATCH", "statement does not match textbutton kind")
+        if width is not None or height is not None:
+            raise EditorSourceError(
+                "BAR_SIZE_NOT_DIRECTLY_AUTHORED",
+                "resize is only supported for bar xsize/ysize",
+            )
         return apply_textbutton_patch(source_bytes, statement, x=x, y=y)
     if kind == "imagebutton":
         if not isinstance(statement, ImagebuttonStatement):
             raise EditorSourceError("STATEMENT_KIND_MISMATCH", "statement does not match imagebutton kind")
+        if width is not None or height is not None:
+            raise EditorSourceError(
+                "BAR_SIZE_NOT_DIRECTLY_AUTHORED",
+                "resize is only supported for bar xsize/ysize",
+            )
         return apply_imagebutton_patch(source_bytes, statement, x=x, y=y)
     if kind == "bar":
         if not isinstance(statement, BarStatement):
             raise EditorSourceError("STATEMENT_KIND_MISMATCH", "statement does not match bar kind")
-        return apply_bar_patch(source_bytes, statement, x=x, y=y)
+        return apply_bar_patch(
+            source_bytes,
+            statement,
+            x=x,
+            y=y,
+            width=width,
+            height=height,
+        )
     if kind == "vbar":
         if not isinstance(statement, VbarStatement):
             raise EditorSourceError("STATEMENT_KIND_MISMATCH", "statement does not match vbar kind")
+        if width is not None or height is not None:
+            raise EditorSourceError(
+                "BAR_SIZE_NOT_DIRECTLY_AUTHORED",
+                "resize is only supported for bar xsize/ysize",
+            )
         return apply_vbar_patch(source_bytes, statement, x=x, y=y)
     if kind == "slider":
         if not isinstance(statement, SliderStatement):
             raise EditorSourceError("STATEMENT_KIND_MISMATCH", "statement does not match slider kind")
+        if width is not None or height is not None:
+            raise EditorSourceError(
+                "BAR_SIZE_NOT_DIRECTLY_AUTHORED",
+                "resize is only supported for bar xsize/ysize",
+            )
         return apply_slider_patch(source_bytes, statement, x=x, y=y)
     raise EditorSourceError("STATEMENT_KIND_MISMATCH", f"unsupported statement kind: {kind!r}")
 

--- a/src/renforge/editor_bar_resize_runner.py
+++ b/src/renforge/editor_bar_resize_runner.py
@@ -1,0 +1,358 @@
+from __future__ import annotations
+
+import hashlib
+import re
+import time
+from pathlib import Path
+from typing import Any
+
+from renforge.editor_bar_runner import (
+    FIXTURE_SCREEN,
+    TARGET_ID,
+    inject_editor_bar_resources,
+    _center,
+    _find_element,
+    _list_info,
+    _observe_selected,
+    _sha256_file,
+    _wait_bounds,
+)
+from renforge.editor_task0_runner import _require_ok, _source_generation, _wait_for_status
+
+
+def _select_resize_lock(client: Any, widget_id: str, expected_code: str) -> dict[str, Any]:
+    """Select a move-unlocked bar and require a specific resize lock code."""
+    bounds = _wait_bounds(client, widget_id)
+    selection = client.request(
+        "editor_task0_select",
+        {"x": _center(bounds)[0], "y": _center(bounds)[1]},
+    )
+    if not isinstance(selection, dict):
+        raise AssertionError(f"select returned non-dict for {widget_id!r}: {selection!r}")
+
+    def _matched(status: dict[str, Any]) -> bool:
+        if status.get("selected_widget_id") != widget_id:
+            return False
+        if status.get("selected_lock_reason") not in (None, ""):
+            return False
+        if not status.get("current_analysis_id"):
+            return False
+        caps = status.get("current_capabilities") or {}
+        if caps.get("move") is not True or caps.get("resize") is not False:
+            return False
+        source_key = status.get("current_source_key") or {}
+        reason = source_key.get("resize_lock_reason") or {}
+        return isinstance(reason, dict) and reason.get("code") == expected_code
+
+    status = _wait_for_status(
+        client,
+        _matched,
+        timeout=10.0,
+        poll_name=f"{widget_id} resize lock",
+    )
+    source_key = status.get("current_source_key") or {}
+    reason = source_key.get("resize_lock_reason") or {}
+    if not isinstance(reason, dict) or reason.get("code") != expected_code:
+        raise AssertionError(
+            f"unexpected resize lock for {widget_id!r}: status={status!r} selection={selection!r}"
+        )
+    return {
+        "code": expected_code,
+        "move": (status.get("current_capabilities") or {}).get("move"),
+        "resize": (status.get("current_capabilities") or {}).get("resize"),
+        "size_mode": source_key.get("size_mode"),
+        "resize_lock_reason": reason,
+    }
+
+
+def _target_line_with_offset(source_text: str) -> tuple[str, int]:
+    offset = 0
+    for line in source_text.splitlines(keepends=True):
+        if f'id "{TARGET_ID}"' in line and line.lstrip().startswith("bar "):
+            return line, offset
+        offset += len(line)
+    raise AssertionError(f"source missing target line for {TARGET_ID!r}")
+
+
+def _parse_size_from_target_line(source_text: str) -> dict[str, int]:
+    line, _ = _target_line_with_offset(source_text)
+    xsize = re.search(r"\bxsize\s+(-?\d+)", line)
+    ysize = re.search(r"\bysize\s+(-?\d+)", line)
+    if not xsize or not ysize:
+        raise AssertionError(f"target line missing xsize/ysize: {line!r}")
+    return {"w": int(xsize.group(1)), "h": int(ysize.group(1))}
+
+
+def _independent_expected_after_size_patch(before_text: str, *, w: int, h: int) -> str:
+    line, offset = _target_line_with_offset(before_text)
+    patched_line = re.sub(r"(\bxsize\s+)-?\d+", rf"\g<1>{int(w)}", line, count=1)
+    patched_line = re.sub(r"(\bysize\s+)-?\d+", rf"\g<1>{int(h)}", patched_line, count=1)
+    if patched_line == line:
+        raise AssertionError("independent size patch constructor did not change target line")
+    return f"{before_text[:offset]}{patched_line}{before_text[offset + len(line) :]}"
+
+
+def _outside_size_spans_identical(before_text: str, after_text: str) -> bool:
+    before_line, _ = _target_line_with_offset(before_text)
+    after_line, _ = _target_line_with_offset(after_text)
+    before_norm = re.sub(r"(\bxsize\s+)-?\d+", r"\1__W__", before_line, count=1)
+    before_norm = re.sub(r"(\bysize\s+)-?\d+", r"\1__H__", before_norm, count=1)
+    after_norm = re.sub(r"(\bxsize\s+)-?\d+", r"\1__W__", after_line, count=1)
+    after_norm = re.sub(r"(\bysize\s+)-?\d+", r"\1__H__", after_norm, count=1)
+    if before_norm != after_norm:
+        return False
+    before_rest = before_text.replace(before_line, "", 1)
+    after_rest = after_text.replace(after_line, "", 1)
+    return before_rest == after_rest
+
+
+def run_editor_bar_resize_live_scenario(client: Any, *, fixture_path: Path) -> dict[str, Any]:
+    """Seven-step live proof for bar xsize/ysize resize (issue #47)."""
+    report: dict[str, Any] = {"locks": {}}
+    baseline_bytes = fixture_path.read_bytes()
+    baseline_sha = hashlib.sha256(baseline_bytes).hexdigest()
+
+    _require_ok(client.request("editor_task0_start", {"screen": FIXTURE_SCREEN}), "start editor")
+    _wait_for_status(client, lambda status: bool(status.get("active")), timeout=10.0, poll_name="editor active")
+
+    # Resize lock matrix first: move stays unlocked, resize must stay locked with
+    # the exact host-visible code (source_key.resize_lock_reason + capabilities).
+    report["locks"] = {
+        "xysize": _select_resize_lock(client, "bar_xysize", "BAR_XYSIZE_UNSUPPORTED"),
+        "constraint": _select_resize_lock(
+            client, "bar_size_constraint", "BAR_SIZE_CONSTRAINT_UNSUPPORTED"
+        ),
+    }
+
+    target_bounds = _wait_bounds(client, TARGET_ID)
+    baseline_position = {
+        "x": int(target_bounds["x"]),
+        "y": int(target_bounds["y"]),
+        "width": int(target_bounds["width"]),
+        "height": int(target_bounds["height"]),
+    }
+    target_center = _center(target_bounds)
+
+    select = _require_ok(
+        client.request("editor_task0_select", {"x": target_center[0], "y": target_center[1]}),
+        "target select",
+    )
+    observation = select.get("observation") or {}
+    if observation.get("measurement_method") != "focus_list":
+        raise AssertionError(f"select observation not focus_list: {observation!r}")
+
+    analysis_status = _wait_for_status(
+        client,
+        lambda status: bool(status.get("current_analysis_id"))
+        and status.get("selected_widget_id") == TARGET_ID
+        and status.get("selected_lock_reason") in (None, ""),
+        timeout=10.0,
+        poll_name="bar resize analysis",
+    )
+    source_key = analysis_status.get("current_source_key") or {}
+    capabilities = analysis_status.get("current_capabilities") or {}
+    host_resize = capabilities.get("resize")
+    report["resolve"] = {
+        "statement_kind": source_key.get("statement_kind"),
+        "size_mode": source_key.get("size_mode"),
+        "lock_reason": analysis_status.get("selected_lock_reason"),
+        "resize": host_resize,
+        "move": capabilities.get("move"),
+        "analysis_id": analysis_status.get("current_analysis_id"),
+        "measurement_method": observation.get("measurement_method"),
+        "frame_id": observation.get("frame_id"),
+        "source_key": source_key,
+        "original_size": analysis_status.get("selected_original_size")
+        or analysis_status.get("selected_source_size"),
+    }
+    if source_key.get("statement_kind") != "bar":
+        raise AssertionError(f"expected bar statement_kind: {source_key!r}")
+    if source_key.get("size_mode") != "xsize_ysize":
+        raise AssertionError(f"expected size_mode xsize_ysize: {source_key!r}")
+    if host_resize is not True:
+        raise AssertionError(f"host did not unlock resize for bar: {analysis_status!r}")
+
+    original_size = analysis_status.get("selected_original_size") or analysis_status.get(
+        "selected_source_size"
+    )
+    if not (isinstance(original_size, (list, tuple)) and len(original_size) == 2):
+        original_size = [int(baseline_position["width"]), int(baseline_position["height"])]
+    requested_before = [int(original_size[0]), int(original_size[1])]
+
+    before_obs = _observe_selected(client)
+    before_rect = before_obs.get("rect") or []
+    if len(before_rect) < 4:
+        raise AssertionError(f"pre-preview observation missing size: {before_obs!r}")
+    bounds_before = [int(before_rect[2]), int(before_rect[3])]
+    frame_before = before_obs.get("frame_id")
+
+    # Step 2: preview resize via dedicated size handler (+40w, +8h).
+    _require_ok(client.request("editor_task0_size", {"dw": 40, "dh": 8}), "resize wider/taller")
+    preview_status = _wait_for_status(
+        client,
+        lambda status: isinstance(status.get("preview_size"), (list, tuple))
+        and len(status.get("preview_size") or []) == 2
+        and list(status.get("preview_size") or []) != requested_before,
+        timeout=8.0,
+        poll_name="bar resize preview",
+    )
+    requested_after = [
+        int(preview_status["preview_size"][0]),
+        int(preview_status["preview_size"][1]),
+    ]
+    after_obs = _observe_selected(client)
+    after_rect = after_obs.get("rect") or []
+    if len(after_rect) < 4:
+        raise AssertionError(f"post-preview observation missing size: {after_obs!r}")
+    bounds_after = [int(after_rect[2]), int(after_rect[3])]
+    frame_after = after_obs.get("frame_id")
+    if not frame_before or not frame_after or frame_before == frame_after:
+        raise AssertionError(
+            "preview observations must have distinct real frame_ids: "
+            f"before={frame_before!r}, after={frame_after!r}"
+        )
+    if before_obs.get("measurement_method") != "focus_list" or after_obs.get("measurement_method") != "focus_list":
+        raise AssertionError(
+            "preview observations must report measurement_method from bridge: "
+            f"before={before_obs.get('measurement_method')!r}, after={after_obs.get('measurement_method')!r}"
+        )
+    requested_delta = [requested_after[axis] - requested_before[axis] for axis in (0, 1)]
+    observed_delta = [bounds_after[axis] - bounds_before[axis] for axis in (0, 1)]
+    if any(abs(observed_delta[axis] - requested_delta[axis]) > 1 for axis in (0, 1)):
+        raise AssertionError(
+            "focus_list preview size disagrees with requested resize: "
+            f"requested={requested_delta!r}, observed={observed_delta!r}"
+        )
+    report["preview"] = {
+        "bounds_before": bounds_before,
+        "bounds_after": bounds_after,
+        "requested_before": requested_before,
+        "requested_after": requested_after,
+        "requested_delta": requested_delta,
+        "observed_delta": observed_delta,
+        "measurement_method_before": before_obs.get("measurement_method"),
+        "measurement_method_after": after_obs.get("measurement_method"),
+        "measurement_method": after_obs.get("measurement_method"),
+        "frame_id_before": frame_before,
+        "frame_id_after": frame_after,
+    }
+
+    # Step 3: patch via real Save overlay control.
+    pre_save_bytes = fixture_path.read_bytes()
+    pre_save_sha = hashlib.sha256(pre_save_bytes).hexdigest()
+    pre_save_text = pre_save_bytes.decode("utf-8")
+    generation_before = _source_generation(analysis_status)
+    save_request = _require_ok(
+        client.click_element(id="rf_save", screen="_renforge_editor_overlay"),
+        "bar resize save",
+    )
+    save_status = _wait_for_status(
+        client,
+        lambda status: not bool(status.get("save_in_progress"))
+        and status.get("status_text") == "Reload committed"
+        and _source_generation(status) == generation_before + 1,
+        timeout=60.0,
+        poll_name="bar resize save complete",
+    )
+    post_save_bytes = fixture_path.read_bytes()
+    post_save_sha = hashlib.sha256(post_save_bytes).hexdigest()
+    post_save_text = post_save_bytes.decode("utf-8")
+    source_size_after = _parse_size_from_target_line(post_save_text)
+    expected_source_size = {"w": requested_after[0], "h": requested_after[1]}
+    if source_size_after != expected_source_size:
+        raise AssertionError(
+            "source patch disagrees with requested preview size: "
+            f"expected={expected_source_size!r}, observed={source_size_after!r}"
+        )
+    expected_text = _independent_expected_after_size_patch(
+        pre_save_text,
+        w=requested_after[0],
+        h=requested_after[1],
+    )
+    if post_save_text != expected_text:
+        raise AssertionError("patched fixture bytes disagree with independent expected content")
+    outside_size_spans_identical = _outside_size_spans_identical(pre_save_text, post_save_text)
+    if not outside_size_spans_identical:
+        raise AssertionError("source patch changed bytes outside xsize/ysize spans")
+    report["patch"] = {
+        "before_sha256": pre_save_sha,
+        "after_sha256": post_save_sha,
+        "source_size_after": source_size_after,
+        "outside_size_spans_identical": outside_size_spans_identical,
+        "matches_independent_expected": True,
+        "save_request": save_request,
+    }
+
+    report["reload"] = {
+        "ok": True,
+        "script_generation": _source_generation(save_status),
+        "status_text": save_status.get("status_text"),
+        "generation_delta": _source_generation(save_status) - generation_before,
+        "pending_handshake_sent": save_status.get("pending_handshake_sent"),
+        "frame_id": None,
+    }
+
+    successor = _wait_for_status(
+        client,
+        lambda status: bool(status.get("current_analysis_id"))
+        and status.get("selected_widget_id") == TARGET_ID
+        and status.get("selected_lock_reason") in (None, ""),
+        timeout=10.0,
+        poll_name="bar resize post-save rebind analysis",
+    )
+    reload_obs = _observe_selected(client)
+    reload_rect = reload_obs.get("rect") or []
+    if len(reload_rect) < 4:
+        raise AssertionError(f"post-reload observation missing size: {reload_obs!r}")
+    reload_bounds = [int(reload_rect[2]), int(reload_rect[3])]
+    pixel_delta = [
+        reload_bounds[0] - bounds_after[0],
+        reload_bounds[1] - bounds_after[1],
+    ]
+    if any(abs(value) > 1 for value in pixel_delta):
+        raise AssertionError(
+            "post-reload focus size disagrees with post-preview focus size: "
+            f"preview={bounds_after!r}, reload={reload_bounds!r}, delta={pixel_delta!r}"
+        )
+    report["pixel_agreement"] = {
+        "preview_after": bounds_after,
+        "reload_after": reload_bounds,
+        "delta": pixel_delta,
+        "measurement_method": reload_obs.get("measurement_method"),
+        "measurement_method_preview": after_obs.get("measurement_method"),
+        "measurement_method_reload": reload_obs.get("measurement_method"),
+        "frame_id_preview": frame_after,
+        "frame_id_reload": reload_obs.get("frame_id"),
+    }
+    report["reload"]["frame_id"] = reload_obs.get("frame_id")
+
+    report["rebinding"] = {
+        "ok": successor.get("selected_widget_id") == TARGET_ID
+        and successor.get("current_analysis_id")
+        not in (None, analysis_status.get("current_analysis_id"))
+        and (successor.get("current_source_key") or {}).get("statement_kind") == "bar"
+        and (successor.get("current_source_key") or {}).get("size_mode") == "xsize_ysize"
+        and successor.get("selected_lock_reason") in (None, "")
+        and (successor.get("current_capabilities") or {}).get("resize") is True,
+        "widget_id": successor.get("selected_widget_id"),
+        "analysis_id": successor.get("current_analysis_id"),
+        "previous_analysis_id": analysis_status.get("current_analysis_id"),
+        "source_key": successor.get("current_source_key"),
+        "lock_reason": successor.get("selected_lock_reason"),
+        "capabilities": successor.get("current_capabilities"),
+    }
+    if report["rebinding"]["ok"] is not True:
+        raise AssertionError(f"rebinding failed: {report['rebinding']!r}")
+
+    fixture_path.write_bytes(baseline_bytes)
+    restored_bytes = fixture_path.read_bytes()
+    restored_sha = _sha256_file(fixture_path)
+    report["byte_identical_undo"] = {
+        "baseline_sha256": baseline_sha,
+        "restored_sha256": restored_sha,
+        "matches_baseline": restored_sha == baseline_sha and restored_bytes == baseline_bytes,
+        "patched_differed": post_save_sha != baseline_sha and post_save_bytes != baseline_bytes,
+    }
+    if restored_bytes != baseline_bytes:
+        raise AssertionError("bar resize byte-identical undo did not restore the baseline")
+    return report

--- a/tests/live_fixtures/renforge_editor_bar_fixture.rpy
+++ b/tests/live_fixtures/renforge_editor_bar_fixture.rpy
@@ -5,6 +5,8 @@ default renforge_editor_bar_style_val = 40
 default renforge_editor_bar_container_val = 40
 default renforge_editor_bar_dupe_val = 40
 default renforge_editor_bar_side_val = 40
+default renforge_editor_bar_xysize_val = 40
+default renforge_editor_bar_constraint_val = 40
 
 
 style renforge_bar_style_pos is bar:
@@ -28,6 +30,11 @@ screen renforge_editor_bar_fixture():
         yfill True
 
         bar value VariableValue("renforge_editor_bar_value", range=100) id "bar_target" xpos 200 ypos 180 xsize 240 ysize 24
+
+        # Issue #47: move-unlocked, resize-locked forms (pure fixed parent).
+        bar value VariableValue("renforge_editor_bar_xysize_val", range=100) id "bar_xysize" xpos 200 ypos 260 xysize (180, 24)
+
+        bar value VariableValue("renforge_editor_bar_constraint_val", range=100) id "bar_size_constraint" xpos 420 ypos 260 xsize 160 ysize 24 yfill True
 
         bar value VariableValue("renforge_editor_bar_computed_val", range=100) id "bar_computed" xpos renforge_editor_bar_computed_x ypos 300 xsize 200 ysize 24
 

--- a/tests/test_bridge_runtime.py
+++ b/tests/test_bridge_runtime.py
@@ -1015,7 +1015,7 @@ def test_editor_mouse_up_applies_final_drag_position_without_motion(
         state.targets[target_key] = {
             "analysis_id": "analysis-drag-target",
             "source_key": {"relative_path": "screens.rpy", "line": 12},
-            "capabilities": {"move": True},
+            "capabilities": {"move": True, "resize": False},
             "screen": screen_name,
             "widget_id": "drag_target",
             "runtime_baseline": list(baseline),
@@ -1028,7 +1028,7 @@ def test_editor_mouse_up_applies_final_drag_position_without_motion(
         )
         assert analyzed["ok"] is True
         assert state.preview_position == baseline
-        assert state.current_capabilities == {"move": True}
+        assert state.current_capabilities == {"move": True, "resize": False}
 
         down = pygame.event.Event(
             pygame.MOUSEBUTTONDOWN,
@@ -2451,10 +2451,10 @@ def test_editor_status_exposes_current_host_capabilities(
     try:
         state = globs["_renforge_editor_state"]()
         state.current_analysis_id = "analysis-vbar"
-        state.current_capabilities = {"move": True}
+        state.current_capabilities = {"move": True, "resize": False}
 
         status = globs["_renforge_editor_h_status"]({})
-        assert status["current_capabilities"] == {"move": True}
+        assert status["current_capabilities"] == {"move": True, "resize": False}
 
         state.current_analysis_id = None
         assert globs["_renforge_editor_h_status"]({})["current_capabilities"] == {}
@@ -2483,7 +2483,7 @@ def test_editor_locked_selection_clears_current_host_capabilities(
         state = globs["_renforge_editor_state"]()
         state.current_analysis_id = "analysis-editable"
         state.current_source_key = {"relative_path": "screens.rpy", "line": 12}
-        state.current_capabilities = {"move": True}
+        state.current_capabilities = {"move": True, "resize": False}
         globs["_renforge_editor_focus_candidates"] = lambda: [
             {
                 "rect": [0, 0, 20, 20],

--- a/tests/test_bridge_runtime.py
+++ b/tests/test_bridge_runtime.py
@@ -2431,6 +2431,71 @@ def test_editor_allowed_ancestry_accepts_bar_and_rejects_unknown_and_side(
         globs["_renforge_editor_stop_coordinator"]()
 
 
+def test_editor_reselect_resize_and_reset_use_the_selected_target_size(running_bridge):
+    renpy = running_bridge.renpy
+    globs = running_bridge.globs
+    renpy.config.after_load_callbacks = []
+    renpy.Displayable = object
+    renpy.Render = lambda width, height: types.SimpleNamespace(width=width, height=height)
+    renpy.IgnoreEvent = type("IgnoreEvent", (Exception,), {})
+    renpy.show_screen = lambda *args, **kwargs: None
+    exec(compile(_load_editor_body(), "editor.rpy", "exec"), globs)
+    state = globs["_renforge_editor_state"]()
+    state.active = True
+    state.preview_size = [300, 40]  # stale size from a previously selected target
+    runtime_key = {"screen": "size_screen", "widget_id": "first_bar"}
+    candidate = {"rect": [10, 20, 100, 20], "runtime_key": runtime_key}
+    target_key = "first-bar-target"
+    globs["_renforge_editor_target_key"] = lambda _runtime_key: target_key
+    state.targets[target_key] = {
+        "analysis_id": "analysis-first-bar",
+        "source_key": {
+            "relative_path": "screens.rpy",
+            "line": 12,
+            "size_mode": globs["_BAR_SIZE_MODE_XSIZE_YSIZE"],
+        },
+        "capabilities": {"move": True, "resize": True},
+        "screen": "size_screen",
+        "widget_id": "first_bar",
+        "runtime_baseline": [10, 20],
+        "source_position": [10, 20],
+        "position": [10, 20],
+        "runtime_size": [100, 20],
+        "source_size": [100, 20],
+        "size": [100, 20],
+        "dirty": False,
+    }
+    globs["_renforge_editor_focus_candidates"] = lambda: [candidate]
+    globs["_renforge_editor_validate_runtime_key"] = lambda _key: None
+    globs["_renforge_editor_observation_for_candidate"] = lambda _candidate: (
+        {"runtime_key": runtime_key},
+        None,
+    )
+    globs["_renforge_editor_show_target_overrides"] = lambda _screen: None
+    globs["_renforge_editor_set_label"] = lambda _x, _y: None
+    running_bridge.renpy.restart_interaction = lambda: None
+
+    selected = globs["_renforge_editor_select"](15, 25)
+    assert selected["ok"] is True
+    assert state.preview_size == [100, 20]
+    assert state.selected_original_size == [100, 20]
+    assert state.selected_rect == [10, 20, 100, 20]
+
+    resized = globs["_renforge_editor_resize"](10, 2)
+    assert resized == {"ok": True, "w": 110, "h": 22}
+    assert state.targets[target_key]["size"] == [110, 22]
+
+    reset = globs["_renforge_editor_reset_selected"]()
+    assert reset["ok"] is True
+    assert state.targets[target_key]["size"] == [100, 20]
+    assert state.targets[target_key]["dirty"] is False
+    assert state.history_entries[-1]["kind"] == "reset"
+
+    undone = globs["_renforge_editor_undo"]()
+    assert undone["ok"] is True
+    assert state.targets[target_key]["size"] == [110, 22]
+
+
 def test_editor_status_exposes_current_host_capabilities(
     running_bridge,
     monkeypatch,

--- a/tests/test_editor_bar_resize_live.py
+++ b/tests/test_editor_bar_resize_live.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import os
+import shutil
+import time
+from pathlib import Path
+
+import pytest
+
+from renforge.editor_bar_resize_runner import run_editor_bar_resize_live_scenario
+from renforge.editor_bar_runner import FIXTURE_SCREEN, inject_editor_bar_resources
+
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("RENFORGE_BAR_RESIZE_LIVE"),
+    reason="set RENFORGE_BAR_RESIZE_LIVE=1 to run bar resize seven-step live proof",
+)
+
+_DEMO = Path(__file__).resolve().parents[1] / "examples" / "demo_game"
+
+
+@pytest.fixture
+def demo_copy(tmp_path: Path) -> Path:
+    destination = tmp_path / "demo"
+    shutil.copytree(_DEMO, destination, ignore=shutil.ignore_patterns("*.rpyc", "cache"))
+    inject_editor_bar_resources(destination)
+    return destination
+
+
+def test_bar_resize_seven_step_live_proof(demo_copy: Path) -> None:
+    from renforge.bridge.launcher import launch_with_bridge
+    from renforge.project import RenpyProject
+    from renforge.sdk import get_or_install_sdk
+
+    sdk = get_or_install_sdk("8.5.3", project_root=demo_copy)
+    project = RenpyProject(demo_copy)
+    fixture_path = demo_copy / "game" / "zz_renforge_editor_bar_fixture.rpy"
+
+    with launch_with_bridge(
+        sdk,
+        project,
+        startup_timeout=120,
+        editor=True,
+    ) as session:
+        for _ in range(40):
+            launcher = session.client.inspect_screen("_renforge_editor_launcher")
+            if launcher.get("active") is True:
+                break
+            time.sleep(0.25)
+        else:
+            pytest.fail("editor launcher never became active")
+
+        launcher_click = session.client.click_element(
+            text="RF",
+            exact=True,
+            screen="_renforge_editor_launcher",
+        )
+        assert launcher_click.get("ok") is True, launcher_click
+        for _ in range(40):
+            overlay = session.client.inspect_screen("_renforge_editor_overlay")
+            if overlay.get("active") is True:
+                break
+            time.sleep(0.05)
+        else:
+            pytest.fail("editor overlay never became active")
+
+        for _ in range(20):
+            available = session.client.eval_expr(f'renpy.has_screen("{FIXTURE_SCREEN}")')
+            if available is True:
+                break
+            time.sleep(0.1)
+        else:
+            pytest.fail("bar fixture screen never became available")
+
+        report = run_editor_bar_resize_live_scenario(
+            session.client,
+            fixture_path=fixture_path,
+        )
+
+    locks = report["locks"]
+    assert locks["xysize"]["code"] == "BAR_XYSIZE_UNSUPPORTED"
+    assert locks["xysize"]["move"] is True
+    assert locks["xysize"]["resize"] is False
+    assert locks["constraint"]["code"] == "BAR_SIZE_CONSTRAINT_UNSUPPORTED"
+    assert locks["constraint"]["move"] is True
+    assert locks["constraint"]["resize"] is False
+
+    assert report["resolve"]["statement_kind"] == "bar"
+    assert report["resolve"]["size_mode"] == "xsize_ysize"
+    assert report["resolve"]["lock_reason"] in (None, "")
+    assert report["resolve"]["resize"] is True
+    assert report["resolve"]["move"] is True
+    assert report["resolve"]["measurement_method"] == "focus_list"
+    assert report["resolve"]["frame_id"]
+
+    preview = report["preview"]
+    assert preview["bounds_before"] != preview["bounds_after"]
+    assert all(
+        abs(int(preview["observed_delta"][i]) - int(preview["requested_delta"][i])) <= 1
+        for i in (0, 1)
+    )
+    assert preview["measurement_method"] == "focus_list"
+    assert preview["frame_id_before"] != preview["frame_id_after"]
+
+    patch = report["patch"]
+    assert patch["outside_size_spans_identical"] is True
+    assert patch["matches_independent_expected"] is True
+    assert patch["after_sha256"] != patch["before_sha256"]
+    assert patch["source_size_after"] == {
+        "w": preview["requested_after"][0],
+        "h": preview["requested_after"][1],
+    }
+
+    assert report["reload"]["ok"] is True
+    assert report["reload"]["status_text"] == "Reload committed"
+    assert report["reload"]["generation_delta"] == 1
+    assert report["reload"]["frame_id"]
+
+    assert all(abs(int(value)) <= 1 for value in report["pixel_agreement"]["delta"])
+    assert report["pixel_agreement"]["measurement_method"] == "focus_list"
+
+    assert report["rebinding"]["ok"] is True
+    assert report["rebinding"]["widget_id"] == "bar_target"
+    assert (report["rebinding"]["source_key"] or {}).get("size_mode") == "xsize_ysize"
+
+    undo = report["byte_identical_undo"]
+    assert undo["matches_baseline"] is True
+    assert undo["patched_differed"] is True

--- a/tests/test_editor_coordinator.py
+++ b/tests/test_editor_coordinator.py
@@ -1551,6 +1551,47 @@ def test_analyze_and_commit_bar_resize(tmp_path: Path) -> None:
         coordinator.close()
 
 
+def test_bar_resize_commit_rejects_unmeasured_runtime_size(tmp_path: Path) -> None:
+    project, source = _make_bar_project(tmp_path)
+    baseline = source.read_bytes()
+    observation = _base_observation(script_generation=12)
+    observation["runtime_key"]["ancestry"][1]["type"] = "Bar"
+    observation["rect"] = [12, 10, 0, 0]
+    probe = _Probe(
+        observe_reply={
+            **json.loads(json.dumps(observation)),
+            "frame_id": "independent-frame-bar-unmeasured-size",
+            "object_id": "obj-independent-bar-unmeasured-size",
+            "rect": [12, 10, 0, 0],
+        }
+    )
+    coordinator = EditorCoordinator(project, _make_sdk(tmp_path), attestation_timeout=2.0)
+    coordinator.attach_runtime_probe(probe)
+    endpoint = coordinator.start()
+    try:
+        with socket.create_connection((endpoint.host, endpoint.port), timeout=2.0) as sock:
+            auth = _auth(sock, endpoint)
+            analyzed = _analyze(sock, auth, observation, request_id="an-bar-unmeasured")
+            assert analyzed["ok"] is True
+            assert analyzed["result"]["capabilities"] == {"move": True, "resize": False}
+
+            committed = _commit(
+                sock,
+                auth,
+                analyzed,
+                x=12,
+                y=10,
+                w=80,
+                h=18,
+                request_id="co-bar-unmeasured",
+            )
+            assert committed["ok"] is False
+            assert committed["error"]["code"] == "ANALYSIS_RESIZE_UNSUPPORTED"
+            assert source.read_bytes() == baseline
+    finally:
+        coordinator.close()
+
+
 def test_bar_resize_locked_without_authored_size(tmp_path: Path) -> None:
     root = tmp_path / "project_bar_no_size"
     game_dir = root / "game"

--- a/tests/test_editor_coordinator.py
+++ b/tests/test_editor_coordinator.py
@@ -225,6 +225,8 @@ def _commit(
     *,
     x: int,
     y: int,
+    w: int | None = None,
+    h: int | None = None,
     request_id: str = "co-1",
 ) -> dict[str, Any]:
     # Temporarily raise the socket timeout so slow Windows CI hosts can finish
@@ -248,6 +250,7 @@ def _commit(
                             "source_key": analysis["result"]["source_key"],
                             "x": x,
                             "y": y,
+                            **({"w": w, "h": h} if w is not None and h is not None else {}),
                         }
                     ],
                 },
@@ -375,7 +378,7 @@ def test_analyze_target_returns_lock_reasons_for_runtime_denials(tmp_path: Path)
                 mutate(sample)
                 reply = _analyze(sock, auth, sample, request_id=f"an-{index}")
                 assert reply["ok"] is True
-                assert reply["result"]["capabilities"] == {"move": False}
+                assert reply["result"]["capabilities"] == {"move": False, "resize": False}
                 assert reply["result"]["lock_reason"]["code"] == expected_code
     finally:
         coordinator.close()
@@ -776,7 +779,7 @@ def test_analyze_target_denies_unproven_crop_states(tmp_path: Path, crop_state: 
             reply = _analyze(sock, auth, observation, request_id="an-crop")
             assert reply["ok"] is True
             assert reply["result"]["lock_reason"]["code"] == expected_code
-            assert reply["result"]["capabilities"] == {"move": False}
+            assert reply["result"]["capabilities"] == {"move": False, "resize": False}
     finally:
         coordinator.close()
 
@@ -817,7 +820,7 @@ def test_repetition_lock_outranks_a_source_form_lock(tmp_path: Path) -> None:
             analysis = _analyze(sock, auth, observation, request_id="an-repeat-precedence")
             assert analysis["ok"] is True
             assert analysis["result"]["lock_reason"]["code"] == "REPEATED_USE_UNSUPPORTED"
-            assert analysis["result"]["capabilities"] == {"move": False}
+            assert analysis["result"]["capabilities"] == {"move": False, "resize": False}
     finally:
         coordinator.close()
 
@@ -851,7 +854,7 @@ def test_single_viewport_ancestor_no_longer_locks(tmp_path: Path) -> None:
             analysis = _analyze(sock, auth, observation, request_id="an-viewport")
             assert analysis["ok"] is True
             assert analysis["result"]["lock_reason"] is None
-            assert analysis["result"]["capabilities"] == {"move": True}
+            assert analysis["result"]["capabilities"] == {"move": True, "resize": False}
     finally:
         coordinator.close()
 
@@ -885,7 +888,7 @@ def test_pure_transform_crop_ancestor_no_longer_locks(tmp_path: Path) -> None:
             analysis = _analyze(sock, auth, observation, request_id="an-crop")
             assert analysis["ok"] is True
             assert analysis["result"]["lock_reason"] is None
-            assert analysis["result"]["capabilities"] == {"move": True}
+            assert analysis["result"]["capabilities"] == {"move": True, "resize": False}
     finally:
         coordinator.close()
 
@@ -918,7 +921,7 @@ def test_transform_crop_composite_stays_locked(tmp_path: Path) -> None:
             auth = _auth(sock, endpoint)
             analysis = _analyze(sock, auth, observation, request_id="an-crop-composite")
             assert analysis["ok"] is True
-            assert analysis["result"]["capabilities"] == {"move": False}
+            assert analysis["result"]["capabilities"] == {"move": False, "resize": False}
             assert analysis["result"]["lock_reason"]["code"] == "TRANSFORM_CROP_COMPOSITE_UNSUPPORTED"
     finally:
         coordinator.close()
@@ -952,7 +955,7 @@ def test_transform_crop_partial_stays_locked(tmp_path: Path) -> None:
             auth = _auth(sock, endpoint)
             analysis = _analyze(sock, auth, observation, request_id="an-crop-partial")
             assert analysis["ok"] is True
-            assert analysis["result"]["capabilities"] == {"move": False}
+            assert analysis["result"]["capabilities"] == {"move": False, "resize": False}
             assert analysis["result"]["lock_reason"]["code"] == "TRANSFORM_CROP_PARTIAL_UNSUPPORTED"
     finally:
         coordinator.close()
@@ -986,7 +989,7 @@ def test_transform_crop_unproven_stays_locked(tmp_path: Path) -> None:
             auth = _auth(sock, endpoint)
             analysis = _analyze(sock, auth, observation, request_id="an-crop-unproven")
             assert analysis["ok"] is True
-            assert analysis["result"]["capabilities"] == {"move": False}
+            assert analysis["result"]["capabilities"] == {"move": False, "resize": False}
             assert analysis["result"]["lock_reason"]["code"] == "TRANSFORM_CROP_UNPROVEN"
     finally:
         coordinator.close()
@@ -1022,7 +1025,7 @@ def test_nested_transform_crop_stays_locked(tmp_path: Path) -> None:
             auth = _auth(sock, endpoint)
             analysis = _analyze(sock, auth, observation, request_id="an-crop-nested")
             assert analysis["ok"] is True
-            assert analysis["result"]["capabilities"] == {"move": False}
+            assert analysis["result"]["capabilities"] == {"move": False, "resize": False}
             assert analysis["result"]["lock_reason"]["code"] == "NESTED_TRANSFORM_CROP_UNSUPPORTED"
     finally:
         coordinator.close()
@@ -1055,7 +1058,7 @@ def test_runtime_key_ordinal_drift_is_ignored_for_single_static_instance(tmp_pat
             analysis = _analyze(sock, auth, observation, request_id="an-ordinal-drift")
             assert analysis["ok"] is True
             assert analysis["result"]["lock_reason"] is None
-            assert analysis["result"]["capabilities"] == {"move": True}
+            assert analysis["result"]["capabilities"] == {"move": True, "resize": False}
 
             probe.observe_reply["runtime_key"]["widget_id"] = "changed_btn"
             commit = _commit(sock, auth, analysis, x=30, y=40, request_id="co-stable-mismatch")
@@ -1348,7 +1351,7 @@ def test_analyze_and_commit_imagebutton_statement(tmp_path: Path) -> None:
             assert analyzed["ok"] is True
             result = analyzed["result"]
             assert result["lock_reason"] is None
-            assert result["capabilities"] == {"move": True}
+            assert result["capabilities"] == {"move": True, "resize": False}
             assert result["source_key"]["statement_kind"] == "imagebutton"
             assert result["original_position"] == [12, 10]
 
@@ -1441,7 +1444,7 @@ def test_analyze_rejects_unsupported_statement_kind(tmp_path: Path) -> None:
             auth = _auth(sock, endpoint)
             reply = _analyze(sock, auth, observation, request_id="an-frame")
             assert reply["ok"] is True
-            assert reply["result"]["capabilities"] == {"move": False}
+            assert reply["result"]["capabilities"] == {"move": False, "resize": False}
             assert reply["result"]["lock_reason"]["code"] == "STATEMENT_KIND_MISMATCH"
     finally:
         coordinator.close()
@@ -1483,9 +1486,11 @@ def test_analyze_and_commit_bar_statement(tmp_path: Path) -> None:
             assert analyzed["ok"] is True
             result = analyzed["result"]
             assert result["lock_reason"] is None
-            assert result["capabilities"] == {"move": True}
+            assert result["capabilities"] == {"move": True, "resize": True}
             assert result["source_key"]["statement_kind"] == "bar"
+            assert result["source_key"]["size_mode"] == "xsize_ysize"
             assert result["original_position"] == [12, 10]
+            assert result["original_size"] == [40, 10]
 
             committed = _commit(sock, auth, analyzed, x=40, y=50, request_id="co-bar")
             assert committed["ok"] is True
@@ -1496,6 +1501,145 @@ def test_analyze_and_commit_bar_statement(tmp_path: Path) -> None:
             assert "xsize 40 ysize 10" in text
     finally:
         coordinator.close()
+
+
+
+
+def test_analyze_and_commit_bar_resize(tmp_path: Path) -> None:
+    project, source = _make_bar_project(tmp_path)
+    observation = _base_observation(script_generation=12)
+    observation["runtime_key"]["ancestry"][1]["type"] = "Bar"
+    # Independent focus rect must carry positive width/height for resize unlock.
+    observation["rect"] = [12, 10, 40, 10]
+    probe = _Probe(
+        observe_reply={
+            **json.loads(json.dumps(observation)),
+            "frame_id": "independent-frame-bar-resize",
+            "object_id": "obj-independent-bar-resize",
+            "rect": [12, 10, 40, 10],
+        },
+        attest_reply={"ok": True, "state": "all_targets_attested"},
+    )
+    coordinator = EditorCoordinator(project, _make_sdk(tmp_path), attestation_timeout=2.0)
+    coordinator.attach_runtime_probe(probe)
+    endpoint = coordinator.start()
+    try:
+        with socket.create_connection((endpoint.host, endpoint.port), timeout=2.0) as sock:
+            auth = _auth(sock, endpoint)
+            analyzed = _analyze(sock, auth, observation, request_id="an-bar-resize")
+            assert analyzed["ok"] is True
+            result = analyzed["result"]
+            assert result["capabilities"] == {"move": True, "resize": True}
+            assert result["original_size"] == [40, 10]
+
+            committed = _commit(
+                sock,
+                auth,
+                analyzed,
+                x=12,
+                y=10,
+                w=80,
+                h=18,
+                request_id="co-bar-resize",
+            )
+            assert committed["ok"] is True
+            assert committed["result"]["state"] == "published"
+            text = source.read_text(encoding="utf-8")
+            assert "xpos 12 ypos 10" in text
+            assert "xsize 80 ysize 18" in text
+    finally:
+        coordinator.close()
+
+
+def test_bar_resize_locked_without_authored_size(tmp_path: Path) -> None:
+    root = tmp_path / "project_bar_no_size"
+    game_dir = root / "game"
+    game_dir.mkdir(parents=True)
+    source = game_dir / "script.rpy"
+    source.write_text(
+        "screen test_screen:\n"
+        '    bar value StaticValue(50) range 100 id "start_btn" '
+        "xpos 12 ypos 10\n",
+        encoding="utf-8",
+    )
+    project = RenpyProject(root)
+    observation = _base_observation(script_generation=12)
+    observation["runtime_key"]["ancestry"][1]["type"] = "Bar"
+    observation["rect"] = [12, 10, 40, 10]
+    probe = _Probe(
+        observe_reply={
+            **json.loads(json.dumps(observation)),
+            "frame_id": "independent-frame-bar-nosize",
+            "object_id": "obj-independent-bar-nosize",
+            "rect": [12, 10, 40, 10],
+        }
+    )
+    coordinator = EditorCoordinator(project, _make_sdk(tmp_path), attestation_timeout=2.0)
+    coordinator.attach_runtime_probe(probe)
+    endpoint = coordinator.start()
+    try:
+        with socket.create_connection((endpoint.host, endpoint.port), timeout=2.0) as sock:
+            auth = _auth(sock, endpoint)
+            analyzed = _analyze(sock, auth, observation, request_id="an-bar-nosize")
+            assert analyzed["ok"] is True
+            result = analyzed["result"]
+            assert result["lock_reason"] is None
+            assert result["capabilities"] == {"move": True, "resize": False}
+            assert result["source_key"].get("resize_lock_reason", {}).get("code") == "BAR_SIZE_NOT_DIRECTLY_AUTHORED"
+    finally:
+        coordinator.close()
+
+
+
+
+def test_bar_resize_locked_xysize_and_constraint_forms(tmp_path: Path) -> None:
+    cases = [
+        (
+            '    bar value StaticValue(50) range 100 id "start_btn" '
+            "xpos 12 ypos 10 xysize (40, 10)\n",
+            "BAR_XYSIZE_UNSUPPORTED",
+        ),
+        (
+            '    bar value StaticValue(50) range 100 id "start_btn" '
+            "xpos 12 ypos 10 xsize 40 ysize 10 xmaximum 100\n",
+            "BAR_SIZE_CONSTRAINT_UNSUPPORTED",
+        ),
+    ]
+    for index, (line, code) in enumerate(cases):
+        root = tmp_path / f"project_bar_resize_lock_{index}"
+        game_dir = root / "game"
+        game_dir.mkdir(parents=True)
+        source = game_dir / "script.rpy"
+        source.write_text("screen test_screen:\n" + line, encoding="utf-8")
+        project = RenpyProject(root)
+        observation = _base_observation(script_generation=12)
+        observation["runtime_key"]["ancestry"][1]["type"] = "Bar"
+        observation["rect"] = [12, 10, 40, 10]
+        probe = _Probe(
+            observe_reply={
+                **json.loads(json.dumps(observation)),
+                "frame_id": f"independent-frame-bar-lock-{index}",
+                "object_id": f"obj-independent-bar-lock-{index}",
+                "rect": [12, 10, 40, 10],
+            }
+        )
+        case_tmp = tmp_path / f"sdk_case_{index}"
+        case_tmp.mkdir()
+        coordinator = EditorCoordinator(project, _make_sdk(case_tmp), attestation_timeout=2.0)
+        coordinator.attach_runtime_probe(probe)
+        endpoint = coordinator.start()
+        try:
+            with socket.create_connection((endpoint.host, endpoint.port), timeout=2.0) as sock:
+                auth = _auth(sock, endpoint)
+                analyzed = _analyze(sock, auth, observation, request_id=f"an-bar-lock-{index}")
+                assert analyzed["ok"] is True
+                result = analyzed["result"]
+                assert result["lock_reason"] is None
+                assert result["capabilities"] == {"move": True, "resize": False}
+                assert result["source_key"].get("size_mode") is None
+                assert result["source_key"].get("resize_lock_reason", {}).get("code") == code
+        finally:
+            coordinator.close()
 
 
 def _make_vbar_project(tmp_path: Path) -> tuple[RenpyProject, Path]:
@@ -1535,7 +1679,7 @@ def test_analyze_and_commit_vbar_statement_uses_source_kind(tmp_path: Path) -> N
             assert analyzed["ok"] is True
             result = analyzed["result"]
             assert result["lock_reason"] is None
-            assert result["capabilities"] == {"move": True}
+            assert result["capabilities"] == {"move": True, "resize": False}
             assert result["source_key"]["statement_kind"] == "vbar"
             assert result["original_position"] == [12, 10]
 
@@ -1579,7 +1723,7 @@ def test_analyze_vbar_block_header_stays_locked(tmp_path: Path) -> None:
             auth = _auth(sock, endpoint)
             analyzed = _analyze(sock, auth, observation, request_id="an-vbar-block")
             assert analyzed["ok"] is True
-            assert analyzed["result"]["capabilities"] == {"move": False}
+            assert analyzed["result"]["capabilities"] == {"move": False, "resize": False}
             assert analyzed["result"]["lock_reason"]["code"] == "MULTILINE_STATEMENT_REJECTED"
     finally:
         coordinator.close()
@@ -1622,7 +1766,7 @@ def test_analyze_and_commit_slider_statement_uses_source_kind(tmp_path: Path) ->
             assert analyzed["ok"] is True
             result = analyzed["result"]
             assert result["lock_reason"] is None
-            assert result["capabilities"] == {"move": True}
+            assert result["capabilities"] == {"move": True, "resize": False}
             # Adapter identity is style-based; source keyword remains "bar".
             assert result["source_key"]["statement_kind"] == "slider"
             assert result["original_position"] == [12, 10]
@@ -1667,7 +1811,7 @@ def test_analyze_slider_block_header_stays_locked(tmp_path: Path) -> None:
             auth = _auth(sock, endpoint)
             analyzed = _analyze(sock, auth, observation, request_id="an-slider-block")
             assert analyzed["ok"] is True
-            assert analyzed["result"]["capabilities"] == {"move": False}
+            assert analyzed["result"]["capabilities"] == {"move": False, "resize": False}
             assert analyzed["result"]["lock_reason"]["code"] == "MULTILINE_STATEMENT_REJECTED"
     finally:
         coordinator.close()
@@ -1787,7 +1931,7 @@ def test_analyze_slider_locks_computed_style_container_without_runtime_type_infe
                 auth = _auth(sock, endpoint)
                 reply = _analyze(sock, auth, observation, request_id=f"an-slider-lock-{index}")
                 assert reply["ok"] is True
-                assert reply["result"]["capabilities"] == {"move": False}
+                assert reply["result"]["capabilities"] == {"move": False, "resize": False}
                 assert reply["result"]["lock_reason"]["code"] == expected_code
                 source_key = reply["result"].get("source_key")
                 if source_key_present:
@@ -1881,7 +2025,7 @@ def test_analyze_bar_locks_computed_style_container_without_runtime_type_inferen
                 auth = _auth(sock, endpoint)
                 reply = _analyze(sock, auth, observation, request_id=f"an-bar-lock-{index}")
                 assert reply["ok"] is True
-                assert reply["result"]["capabilities"] == {"move": False}
+                assert reply["result"]["capabilities"] == {"move": False, "resize": False}
                 assert reply["result"]["lock_reason"]["code"] == expected_code
                 source_key = reply["result"].get("source_key")
                 if source_key_present:
@@ -1934,7 +2078,7 @@ def test_analyze_and_commit_textbutton_block_preserves_action_bytes(tmp_path: Pa
             assert analyzed["ok"] is True
             result = analyzed["result"]
             assert result["lock_reason"] is None
-            assert result["capabilities"] == {"move": True}
+            assert result["capabilities"] == {"move": True, "resize": False}
             assert result["source_key"]["statement_kind"] == "textbutton"
             assert result["original_position"] == [12, 10]
 
@@ -1981,7 +2125,7 @@ def test_analyze_textbutton_block_computed_position_stays_locked(tmp_path: Path)
             auth = _auth(sock, endpoint)
             analyzed = _analyze(sock, auth, observation, request_id="an-tb-block-computed")
             assert analyzed["ok"] is True
-            assert analyzed["result"]["capabilities"] == {"move": False}
+            assert analyzed["result"]["capabilities"] == {"move": False, "resize": False}
             assert analyzed["result"]["lock_reason"]["code"] == "XPOS_LITERAL_REQUIRED"
     finally:
         coordinator.close()
@@ -2017,7 +2161,7 @@ def test_analyze_and_commit_textbutton_pos_preserves_form(tmp_path: Path) -> Non
             assert analyzed["ok"] is True
             result = analyzed["result"]
             assert result["lock_reason"] is None
-            assert result["capabilities"] == {"move": True}
+            assert result["capabilities"] == {"move": True, "resize": False}
             assert result["source_key"]["statement_kind"] == "textbutton"
             assert result["original_position"] == [12, 10]
 
@@ -2061,7 +2205,7 @@ def test_analyze_textbutton_pos_non_literal_stays_locked(tmp_path: Path) -> None
             auth = _auth(sock, endpoint)
             analyzed = _analyze(sock, auth, observation, request_id="an-pos-lock")
             assert analyzed["ok"] is True
-            assert analyzed["result"]["capabilities"] == {"move": False}
+            assert analyzed["result"]["capabilities"] == {"move": False, "resize": False}
             assert analyzed["result"]["lock_reason"]["code"] == "POS_LITERAL_REQUIRED"
     finally:
         coordinator.close()
@@ -2100,7 +2244,7 @@ def test_analyze_and_commit_textbutton_align_preserves_form(tmp_path: Path) -> N
             assert analyzed["ok"] is True
             result = analyzed["result"]
             assert result["lock_reason"] is None
-            assert result["capabilities"] == {"move": True}
+            assert result["capabilities"] == {"move": True, "resize": False}
             # original_position is runtime pixels for align delta formula
             assert result["original_position"] == [600, 340]
             assert result["source_key"]["position_mode"] == "align"
@@ -2147,7 +2291,7 @@ def test_analyze_textbutton_align_locks_unproven_parent_geometry(tmp_path: Path)
             analyzed = _analyze(sock, auth, observation, request_id="an-align-parent")
             assert analyzed["ok"] is True
             result = analyzed["result"]
-            assert result["capabilities"] == {"move": False}
+            assert result["capabilities"] == {"move": False, "resize": False}
             assert result["lock_reason"]["code"] == "ALIGN_PARENT_UNPROVEN"
     finally:
         coordinator.close()
@@ -2186,7 +2330,7 @@ def test_analyze_and_commit_textbutton_offset_preserves_form(tmp_path: Path) -> 
             assert analyzed["ok"] is True
             result = analyzed["result"]
             assert result["lock_reason"] is None
-            assert result["capabilities"] == {"move": True}
+            assert result["capabilities"] == {"move": True, "resize": False}
             assert result["original_position"] == [12, 10]
             assert result["source_key"]["position_mode"] == "offset"
             assert result["source_key"]["offset_authored"] == [12, 10]

--- a/tests/test_editor_source.py
+++ b/tests/test_editor_source.py
@@ -1432,3 +1432,56 @@ def test_analyze_textbutton_anchor_rejects_non_literal() -> None:
             expected_widget_id="start",
         )
     assert excinfo.value.code == "ANCHOR_LITERAL_REQUIRED"
+
+
+
+def test_analyze_bar_statement_size_model_and_patch() -> None:
+    line = (
+        '    bar value StaticValue(50) range 100 id "bar_target" '
+        "xpos 200 ypos 180 xsize 240 ysize 24\n"
+    )
+    parsed = analyze_bar_statement(line, expected_widget_id="bar_target")
+    assert parsed.size_mode == "xsize_ysize"
+    assert parsed.xsize == 240
+    assert parsed.ysize == 24
+    assert parsed.resize_lock_code is None
+    patched = apply_bar_patch(line.encode("utf-8"), parsed, x=200, y=180, width=300, height=32).decode("utf-8")
+    assert patched == (
+        '    bar value StaticValue(50) range 100 id "bar_target" '
+        "xpos 200 ypos 180 xsize 300 ysize 32\n"
+    )
+
+
+@pytest.mark.parametrize(
+    ("line", "code"),
+    [
+        (
+            '    bar value StaticValue(1) range 10 id "b" xpos 1 ypos 2\n',
+            "BAR_SIZE_NOT_DIRECTLY_AUTHORED",
+        ),
+        (
+            '    bar value StaticValue(1) range 10 id "b" xpos 1 ypos 2 xsize 10\n',
+            "BAR_SIZE_NOT_DIRECTLY_AUTHORED",
+        ),
+        (
+            '    bar value StaticValue(1) range 10 id "b" xpos 1 ypos 2 xysize (10, 20)\n',
+            "BAR_XYSIZE_UNSUPPORTED",
+        ),
+        (
+            '    bar value StaticValue(1) range 10 id "b" xpos 1 ypos 2 xsize 10 ysize 20 xmaximum 100\n',
+            "BAR_SIZE_CONSTRAINT_UNSUPPORTED",
+        ),
+        (
+            '    bar value StaticValue(1) range 10 id "b" xpos 1 ypos 2 xsize 0 ysize 20\n',
+            "BAR_SIZE_NON_POSITIVE",
+        ),
+        (
+            '    bar value StaticValue(1) range 10 id "b" xpos 1 ypos 2 xsize 10 if flag else 20 ysize 20\n',
+            "XSIZE_LITERAL_REQUIRED",
+        ),
+    ],
+)
+def test_analyze_bar_statement_resize_lock_matrix(line: str, code: str) -> None:
+    parsed = analyze_bar_statement(line, expected_widget_id="b")
+    assert parsed.size_mode is None
+    assert parsed.resize_lock_code == code


### PR DESCRIPTION
## Summary

- add an explicit `xsize` / `ysize` source model for the proven single-line `bar` adapter
- support resize preview, transactional save, reload attestation, rebinding, and byte-identical undo
- keep unsupported size forms and conflicting bar constraints locked with precise reasons
- add unit coverage and an opt-in Ren'Py 8.5.3 seven-step live proof

## Scope

This deliberately unlocks one authored size form for one adapter. It does not infer a generic resize contract for `vbar`, sliders, text buttons, implicit sizes, or `xysize`.

## Verification

- `PYTHONPATH="$PWD/src" /Users/alexjordan/Documents/Developer/renforge-mcp/.venv/bin/python -m pytest -q` — 631 passed, 42 skipped
- `RENFORGE_BAR_RESIZE_LIVE=1 PYTHONPATH="$PWD/src" /Users/alexjordan/Documents/Developer/renforge-mcp/.venv/bin/python -m pytest -q tests/test_editor_bar_resize_live.py -vv` — 1 passed
- `npm ci && npm run build` in `ui/` — i18n, TypeScript, and production build passed
- `git diff --check` — passed

Closes #47
