### PR TITLE
test(editor): add rotation evidence spike

### DIFF
--- a/docs/superpowers/spikes/2026-08-02-rotation-criteria.md
+++ b/docs/superpowers/spikes/2026-08-02-rotation-criteria.md
@@ -24,6 +24,7 @@ Can RenForge:
 ## Required fixtures and controls
 
 - one focusable **rotated** control using `Transform(..., rotate=15)` with integer rotate literal
+- transformed child centered in its focusable parent (`xalign=0.5`, `yalign=0.5`), so runtime seam output can be translated through the measured parent center
 - one same-shape unrotated control (same declared size)
 - one additional focusable candidate for non-rotated control-path sanity
 - one dark background (no crop/layout/repetition ambiguity)
@@ -38,6 +39,7 @@ A run is PASS only if **all** are true:
 1. Transform seam extraction succeeds and returns a non-degenerate rotated quad for the rotated control.
 2. Candidate mask probes run on isolated screenshots and report:
    - rotated center painted,
+   - painted edge derived from the runtime screen quad and classified against the independent mask,
    - at least one AABB corner for rotated target outside paint.
 3. The seam-derived rotated quad and mask are stored as the live evidence plane; focus AABB is recorded separately and not used as the sole geometry gate.
 4. Rotated target is not lock- or seam-blocked, preview delta can be written, `editor_task0_save` commit/reload succeeds, rebinding succeeds, and generation delta is coherent with a committed edit.

--- a/docs/superpowers/spikes/2026-08-02-rotation-criteria.md
+++ b/docs/superpowers/spikes/2026-08-02-rotation-criteria.md
@@ -1,0 +1,81 @@
+# Spike criteria — `Transform(rotate=...)` support for selection/write safety (issue #48)
+
+**Status:** criteria locked before measurement.
+**SDK:** Ren'Py **8.5.3** only.
+**Surface:** in-game bridge + opt-in resources (no production editor logic changes).
+
+## Question
+
+Can RenForge:
+
+1. derive a runtime-transformed painted quad from Ren'Py `Transform` forward/reverse seams for a rotated, focusable control;
+2. validate screen-space selection against an independently captured candidate paint mask instead of accepting AABB alone;
+3. safely write, reload, rebind and genuinely product-undo a rotated target in this live spike contract;
+4. prove any fallback path is a direct fixture byte restore and not product undo?
+
+## Evidence planes (must be measured independently)
+
+| Plane | What must be measured | How it must be measured |
+|---|---|---|
+| **Transform seam** | Rotated quad from runtime Transform seam | compute via `_matrix_transform.forward`/`_matrix_transform.reverse` (or equivalent) from a temporary `rotation_spike.rpy`; **do not** derive from authored rotate degrees or AABB math |
+| **Paint-mask** | Candidate-isolated mask with probes | isolate one candidate at a time, sample at center, painted edge, and AABB corner; mask comes from full screenshot classification (`rgb > bg_luma`) |
+| **AABB/focus behavior** | Focus-based rect and whether probe points hit via AABB | read focus/list_ui bounds separately from seam+mask evidence; do not treat focus AABB as ground-truth geometry |
+
+## Required fixtures and controls
+
+- one focusable **rotated** control using `Transform(..., rotate=15)` with integer rotate literal
+- one same-shape unrotated control (same declared size)
+- one additional focusable candidate for non-rotated control-path sanity
+- one dark background (no crop/layout/repetition ambiguity)
+- deterministic integer initial `xpos`/`ypos` in fixture source
+
+## Pass / blocked / inconclusive (frozen before implementation)
+
+### Pass
+
+A run is PASS only if **all** are true:
+
+1. Transform seam extraction succeeds and returns a non-degenerate rotated quad for the rotated control.
+2. Candidate mask probes run on isolated screenshots and report:
+   - rotated center painted,
+   - at least one AABB corner for rotated target outside paint.
+3. The seam-derived rotated quad and mask are stored as the live evidence plane; focus AABB is recorded separately and not used as the sole geometry gate.
+4. Rotated target is not lock- or seam-blocked, preview delta can be written, `editor_task0_save` commit/reload succeeds, rebinding succeeds, and generation delta is coherent with a committed edit.
+5. Undo evidence is **product undo** (not byte restore): a full lockable write + reload + rebind trail is observed.
+
+### Blocked
+
+BLOCKED if any one occurs:
+
+- seam missing (`forward` and `reverse` unavailable, non-degenerate quad not produced);
+- mask probes cannot be produced on isolated paint (or cannot recover three required points);
+- rotated target is genuinely locked (`selected_lock_reason` not empty), **or** any required plane fails (lock + seam/paint mismatch);
+- an unpainted point inside the focus AABB selects the rotated target through the real editor selection path;
+- write path reaches preview but fails at save/reload/rebind or generation, even with valid edit intent;
+- manual restoration path is only byte-level restore of rotate span (explicitly not product undo).
+
+### Inconclusive
+
+- identical-run reproducibility for the same scene is unstable;
+- required points are ambiguous for >10% of repeated probes (anti-alias/viewport noise not resolvable);
+- fixture/control cannot be resolved (missing ids/spans) and independent evidence cannot be reconstructed.
+
+## Stop conditions
+
+- If required IDs or spans are unresolved, stop as `inconclusive`.
+- If seam and mask disagree on rotated center/edge, stop and mark `blocked`.
+- If the same scene measured twice gives different verdict classification, stop as `inconclusive`.
+- If fixture line span patching touches non-target bytes, stop as `inconclusive`.
+
+## Controlled write proof (must be included in report)
+
+- patch only the rotated `rotate=<int>` literal in the temporary fixture,
+- prove bytes outside that span are unchanged,
+- restore the fixture from baseline bytes and prove byte-identical restoration.
+
+`restore` in this proof is documentation-only evidence and must not be presented as product undo.
+
+## Deliverable
+
+One report dictionary from `run_editor_rotation_live_scenario` with `verdict` in
+`{pass, blocked, inconclusive}` and explicit evidence fields for seam, mask, focus, lock, write/reload/rebind, and manual rotate-literal restore.

--- a/docs/superpowers/spikes/2026-08-02-rotation-result.md
+++ b/docs/superpowers/spikes/2026-08-02-rotation-result.md
@@ -12,19 +12,20 @@ This spike evaluates moving an already-rotated, focusable target. It does not ad
 
 ### Runtime Transform seam
 
-The injected opt-in resource discovered the target's runtime Transform and mapped its child quad through Ren'Py's `forward` seam. No authored-angle trigonometry was used.
+The injected opt-in resource discovered the target's runtime Transform, mapped its child quad through Ren'Py's `forward` seam, then translated that quad through the measured center of the fixture's centered focus parent. No authored-angle trigonometry was used.
 
 - seam: `forward`
-- local transformed quad: `[[0.0, 0.0], [77.27406311035156, -20.705524444580078], [86.591552734375, 14.0678071975708], [9.317485809326172, 34.77333068847656]]`
+- runtime screen quad: `[[256.7042245864868, 252.96609663963318], [333.9782876968384, 232.2605721950531], [343.2957773208618, 267.033903837204], [266.021710395813, 287.73942732810974]]`
 - forward/reverse round-trip error: `8.878860171535052e-07`
 
-This plane proves a non-degenerate runtime rotation seam. It is recorded separately from screen-space paint and selection evidence.
+This plane proves a non-degenerate runtime rotation seam in screen coordinates. It is recorded separately from screen-space paint classification and editor selection evidence.
 
 ### Candidate-isolated paint mask
 
 For the rotated target's focus AABB `[220, 220, 160, 80]`:
 
 - painted center: `[300, 260]`
+- painted edge derived from the runtime screen quad: `[304, 275]`
 - unpainted AABB corner: `[220, 220]`
 
 ### Real editor selection probe

--- a/docs/superpowers/spikes/2026-08-02-rotation-result.md
+++ b/docs/superpowers/spikes/2026-08-02-rotation-result.md
@@ -75,7 +75,7 @@ Full suite:
 PYTHONPATH=src python -m pytest -q
 ```
 
-Result: `631 passed, 43 skipped`.
+Result: `632 passed, 43 skipped`.
 
 ## Decision
 

--- a/docs/superpowers/spikes/2026-08-02-rotation-result.md
+++ b/docs/superpowers/spikes/2026-08-02-rotation-result.md
@@ -1,0 +1,82 @@
+# Rotation evidence spike — result (issue #48)
+
+**Date:** 2026-08-02
+**SDK:** Ren'Py 8.5.3
+**Verdict:** **BLOCKED** — `aabb_false_positive`
+
+## Scope
+
+This spike evaluates moving an already-rotated, focusable target. It does not add rotation controls or modify production editor logic. The frozen criteria are in `2026-08-02-rotation-criteria.md`.
+
+## Independent evidence
+
+### Runtime Transform seam
+
+The injected opt-in resource discovered the target's runtime Transform and mapped its child quad through Ren'Py's `forward` seam. No authored-angle trigonometry was used.
+
+- seam: `forward`
+- local transformed quad: `[[0.0, 0.0], [77.27406311035156, -20.705524444580078], [86.591552734375, 14.0678071975708], [9.317485809326172, 34.77333068847656]]`
+- forward/reverse round-trip error: `8.878860171535052e-07`
+
+This plane proves a non-degenerate runtime rotation seam. It is recorded separately from screen-space paint and selection evidence.
+
+### Candidate-isolated paint mask
+
+For the rotated target's focus AABB `[220, 220, 160, 80]`:
+
+- painted center: `[300, 260]`
+- unpainted AABB corner: `[220, 220]`
+
+### Real editor selection probe
+
+The editor was asked to select at the unpainted corner `[220, 220]`. It selected `rotation_target` despite the candidate-isolated paint mask reporting that point as unpainted.
+
+This is a deterministic AABB false positive, so transformed selection safety is not proved and production rotation controls must remain disabled.
+
+## Write, reload, rebind, and undo evidence
+
+The supported single-line `button` source form remained editable while containing a rotated child:
+
+- preview move: `[220, 220] -> [221, 220]`
+- product undo: `[221, 220] -> [220, 220]`
+- product redo: `[220, 220] -> [221, 220]`
+- save status: `Reload committed`
+- script generation: `0 -> 1`
+- post-reload position: `[221, 220]`
+- rebinding lock reason: `null`
+- source bytes matched an independently constructed xpos/ypos patch exactly
+
+A separate temporary rotate-literal round trip changed `rotate=15` to `rotate=16`, preserved every byte outside that literal, and restored the temporary fixture. That direct byte restoration is documentation evidence only, not product undo. The original fixture baseline was restored after the scenario.
+
+## Reproducibility
+
+The final scenario produced the same `BLOCKED / aabb_false_positive` classification on consecutive Ren'Py 8.5.3 runs.
+
+```bash
+RENFORGE_ROTATION_LIVE=1 PYTHONPATH=src python -m pytest -q tests/test_editor_rotation_live.py -vv
+```
+
+Result: `1 passed`.
+
+Focused editor regression set:
+
+```bash
+PYTHONPATH=src python -m pytest -q \
+  tests/test_editor_source.py \
+  tests/test_editor_runtime.py \
+  tests/test_editor_coordinator.py
+```
+
+Result: `143 passed`.
+
+Full suite:
+
+```bash
+PYTHONPATH=src python -m pytest -q
+```
+
+Result: `631 passed, 43 skipped`.
+
+## Decision
+
+**Do not unlock rotation editing.** The next prerequisite is a production selection path that gates rotated targets with exact transformed hit evidence rather than the focus AABB alone.

--- a/src/renforge/bridge/rotation_spike.rpy
+++ b/src/renforge/bridge/rotation_spike.rpy
@@ -205,11 +205,10 @@ init 1600 python hide:
             current = parent
         return None
 
-    def _screen_quad_from_local(local_quad, transform_displayable):
-        # Most transforms map local child coordinates to screen coordinates through
-        # one of seams (forward/reverse). Use only seam output; never authored
-        # rotation math.
-        forward = getattr(transform_displayable, "forward", None)
+    def _screen_quad_from_local(local_quad, transform_displayable, parent_aabb):
+        # The fixture centers the transformed child in its focusable parent.
+        # Map through the runtime seam, then translate the resulting quad center
+        # to the measured parent center. Never derive geometry from rotate degrees.
         for seam in ("forward", "reverse"):
             seam_fn = getattr(transform_displayable, seam, None)
             if seam_fn is None:
@@ -220,7 +219,22 @@ init 1600 python hide:
                 if mapped is None:
                     return None, seam, None, "transform_map_failed"
                 projected.append(mapped)
-            return projected, seam, None, None
+            projected_center = [
+                sum(float(point[0]) for point in projected) / len(projected),
+                sum(float(point[1]) for point in projected) / len(projected),
+            ]
+            parent_center = [
+                float(parent_aabb[0]) + float(parent_aabb[2]) / 2.0,
+                float(parent_aabb[1]) + float(parent_aabb[3]) / 2.0,
+            ]
+            screen_quad = [
+                [
+                    float(point[0]) + parent_center[0] - projected_center[0],
+                    float(point[1]) + parent_center[1] - projected_center[1],
+                ]
+                for point in projected
+            ]
+            return screen_quad, seam, projected, None
         # Transform exists but no seam callable.
         return None, "transform", None, "transform_seam_unavailable"
 
@@ -255,6 +269,7 @@ init 1600 python hide:
             "roundtrip_error": None,
             "notes": "widget_missing",
             "quad_source": None,
+            "quad_coordinate_space": None,
             "aabb": None,
             "render_size": None,
             "style_pos": None,
@@ -330,15 +345,20 @@ init 1600 python hide:
             [float(w), float(h)],
             [0.0, float(h)],
         )
-        projected, seam_name, _, seam_error = _screen_quad_from_local(local_quad, transform_d)
-        if projected is None:
+        screen_quad, seam_name, seam_quad, seam_error = _screen_quad_from_local(
+            local_quad,
+            transform_d,
+            record["aabb"],
+        )
+        if screen_quad is None:
             record["notes"] = seam_error or "transform_matrix_unavailable"
             return record
 
-        record["quad"] = projected
+        record["quad"] = screen_quad
         record["quad_source"] = seam_name
+        record["quad_coordinate_space"] = "screen"
         record["notes"] = "transform_rotation"
-        record["roundtrip_error"] = _roundtrip_error(transform_d, local_quad, projected)
+        record["roundtrip_error"] = _roundtrip_error(transform_d, local_quad, seam_quad)
         if record["roundtrip_error"] is not None:
             try:
                 if float(record["roundtrip_error"]) > 0.5:

--- a/src/renforge/bridge/rotation_spike.rpy
+++ b/src/renforge/bridge/rotation_spike.rpy
@@ -1,0 +1,488 @@
+# Opt-in spike resource for issue #48 — rotate-aware transform seam measurement.
+# Injected only into temporary demo copies.
+
+init 1600 python hide:
+    import math
+    import sys
+    import types
+
+    if "_renforge_runtime" not in sys.modules:
+        sys.modules["_renforge_runtime"] = types.ModuleType("_renforge_runtime")
+    _rt = sys.modules["_renforge_runtime"]
+    if not hasattr(_rt, "rotation_spike"):
+        _rt.rotation_spike = types.SimpleNamespace()
+    _state = _rt.rotation_spike
+
+    SCREEN = "renforge_editor_rotation_fixture"
+    TARGET_IDS = ("rotation_target", "rotation_reference", "rotation_other")
+    BACKUP_STYLE = {}
+
+
+    def _walk_find_id(displayable, widget_id, seen=None):
+        if displayable is None:
+            return None
+        if seen is None:
+            seen = set()
+        did = id(displayable)
+        if did in seen:
+            return None
+        seen.add(did)
+
+        if getattr(displayable, "id", None) == widget_id:
+            return displayable
+
+        children = []
+        raw_children = getattr(displayable, "children", None)
+        if raw_children is not None and not isinstance(raw_children, (str, bytes)):
+            try:
+                children.extend(list(raw_children))
+            except Exception:
+                pass
+        for attr in ("child", "raw_child", "original_child"):
+            child = getattr(displayable, attr, None)
+            if child is not None:
+                children.append(child)
+
+        visit = getattr(displayable, "visit", None)
+        if callable(visit):
+            try:
+                visited = visit()
+                if isinstance(visited, (list, tuple)):
+                    children.extend(list(visited))
+            except Exception:
+                pass
+
+        for child in children:
+            found = _walk_find_id(child, widget_id, seen)
+            if found is not None:
+                return found
+        return None
+
+    def _get_widget(widget_id):
+        try:
+            widget = renpy.get_widget(SCREEN, widget_id)
+        except Exception:
+            widget = None
+
+        # Prefer authoritative tree walk; get_widget can return an inner text node.
+        try:
+            screen_root = renpy.display.screen.get_screen(SCREEN)
+            walked = _walk_find_id(screen_root, widget_id)
+            if walked is not None:
+                widget = walked
+        except Exception:
+            pass
+
+        # If we landed on nested text, move up to the button container.
+        if widget is None:
+            return None
+        name = type(widget).__name__
+        if name in ("Text", "TextBase"):
+            parent = getattr(widget, "parent", None)
+            for _ in range(8):
+                if parent is None:
+                    break
+                parent_name = type(parent).__name__
+                if parent_name in ("Button", "TextButton", "ImageButton", "Window"):
+                    return parent
+                parent = getattr(parent, "parent", None)
+        return widget
+
+    def _style_xy(displayable):
+        style = getattr(displayable, "style", None)
+        if style is None:
+            return None, None
+        try:
+            xpos = getattr(style, "xpos", None)
+            ypos = getattr(style, "ypos", None)
+        except Exception:
+            return None, None
+        if isinstance(xpos, (int, float)) and isinstance(ypos, (int, float)):
+            return float(xpos), float(ypos)
+        return None, None
+
+    def _render_size(displayable):
+        if displayable is None:
+            return None
+        try:
+            rendered = renpy.display.render.render(
+                displayable,
+                renpy.config.screen_width,
+                renpy.config.screen_height,
+                0,
+                0,
+            )
+            if rendered is None:
+                return None
+            width, height = rendered.get_size()
+            return [int(width), int(height)]
+        except Exception:
+            pass
+        try:
+            child_size = getattr(displayable, "child_size", None)
+            if isinstance(child_size, (list, tuple)) and len(child_size) >= 2:
+                return [int(child_size[0]), int(child_size[1])]
+        except Exception:
+            pass
+        return None
+
+    def _matrix_map(transform_fn, point):
+        if transform_fn is None:
+            return None
+        x, y = float(point[0]), float(point[1])
+        try:
+            if hasattr(transform_fn, "transform"):
+                mapped = transform_fn.transform(x, y)
+            elif callable(transform_fn):
+                mapped = transform_fn(x, y)
+            else:
+                return None
+        except Exception:
+            return None
+        if mapped is None:
+            return None
+        try:
+            return [float(mapped[0]), float(mapped[1])]
+        except Exception:
+            return None
+
+    def _find_transform(displayable):
+        def _as_candidates(node):
+            values = []
+            for attr in ("at", "transform", "_transform", "child_transform", "transformation", "transforms"):
+                value = getattr(node, attr, None)
+                if value is None:
+                    continue
+                if isinstance(value, (list, tuple)):
+                    values.extend(value)
+                else:
+                    values.append(value)
+            return values
+
+        # Try child chain first (Transform may sit between wrapper nodes).
+        current = displayable
+        seen = set()
+        for _ in range(16):
+            if current is None or id(current) in seen:
+                break
+            seen.add(id(current))
+            for candidate in _as_candidates(current):
+                if candidate is None:
+                    continue
+                if getattr(candidate, "forward", None) is not None or getattr(candidate, "reverse", None) is not None:
+                    return candidate
+            if getattr(current, "forward", None) is not None or getattr(current, "reverse", None) is not None:
+                return current
+            name = type(current).__name__
+            if name in ("Transform", "ATLTransform", "Motion", "TransformBase"):
+                return current
+            next_child = getattr(current, "child", None)
+            if next_child is None:
+                next_child = getattr(current, "raw_child", None)
+            if next_child is None:
+                next_child = getattr(current, "original_child", None)
+            current = next_child
+
+        # Fallback to parent walk.
+        current = displayable
+        seen = set()
+        for _ in range(8):
+            if current is None or id(current) in seen:
+                break
+            seen.add(id(current))
+            parent = getattr(current, "parent", None)
+            if parent is None:
+                break
+            for candidate in _as_candidates(parent):
+                if candidate is None:
+                    continue
+                if getattr(candidate, "forward", None) is not None or getattr(candidate, "reverse", None) is not None:
+                    return candidate
+            if getattr(parent, "forward", None) is not None or getattr(parent, "reverse", None) is not None:
+                return parent
+            if type(parent).__name__ in ("Transform", "ATLTransform", "Motion", "TransformBase"):
+                return parent
+            current = parent
+        return None
+
+    def _screen_quad_from_local(local_quad, transform_displayable):
+        # Most transforms map local child coordinates to screen coordinates through
+        # one of seams (forward/reverse). Use only seam output; never authored
+        # rotation math.
+        forward = getattr(transform_displayable, "forward", None)
+        for seam in ("forward", "reverse"):
+            seam_fn = getattr(transform_displayable, seam, None)
+            if seam_fn is None:
+                continue
+            projected = []
+            for point in local_quad:
+                mapped = _matrix_map(seam_fn, point)
+                if mapped is None:
+                    return None, seam, None, "transform_map_failed"
+                projected.append(mapped)
+            return projected, seam, None, None
+        # Transform exists but no seam callable.
+        return None, "transform", None, "transform_seam_unavailable"
+
+    def _roundtrip_error(transform_displayable, local_quad, projected_quad):
+        reverse_fn = getattr(transform_displayable, "reverse", None)
+        if reverse_fn is None:
+            return None
+        recovered = []
+        for point in projected_quad:
+            mapped = _matrix_map(reverse_fn, point)
+            if mapped is None:
+                return None
+            recovered.append(mapped)
+        if len(recovered) != len(local_quad):
+            return None
+
+        errors = []
+        for recovered_point, source_point in zip(recovered, local_quad):
+            dx = float(recovered_point[0]) - float(source_point[0])
+            dy = float(recovered_point[1]) - float(source_point[1])
+            errors.append(math.hypot(dx, dy))
+        return float(max(errors)) if errors else None
+
+    def _measure_widget(widget_id):
+        widget = _get_widget(widget_id)
+        record = {
+            "widget_id": widget_id,
+            "found": widget is not None,
+            "found_by": None,
+            "quad": None,
+            "transform_present": False,
+            "roundtrip_error": None,
+            "notes": "widget_missing",
+            "quad_source": None,
+            "aabb": None,
+            "render_size": None,
+            "style_pos": None,
+            "type_name": None,
+            "has_forward": False,
+            "has_reverse": False,
+        }
+        if widget is None:
+            return record
+
+        record["type_name"] = type(widget).__name__
+        xpos, ypos = _style_xy(widget)
+        size = _render_size(widget)
+        if size is None:
+            size = [0, 0]
+
+        if xpos is not None and ypos is not None and size[0] > 0 and size[1] > 0:
+            record["style_pos"] = [int(round(xpos)), int(round(ypos))]
+            record["aabb"] = [
+                int(round(xpos)),
+                int(round(ypos)),
+                int(size[0]),
+                int(size[1]),
+            ]
+        else:
+            record["notes"] = "geometry_unavailable"
+            return record
+
+        # Force a render first, so ATL/Transform seams are available.
+        try:
+            screen_root = renpy.display.screen.get_screen(SCREEN)
+            if screen_root is not None:
+                renpy.display.render.invalidate(screen_root)
+                renpy.display.render.render(
+                    screen_root,
+                    renpy.config.screen_width,
+                    renpy.config.screen_height,
+                    0,
+                    0,
+                )
+        except Exception:
+            pass
+
+        render_size = _render_size(widget)
+        if render_size and render_size[0] > 0 and render_size[1] > 0:
+            size = [int(render_size[0]), int(render_size[1])]
+
+        transform_d = _find_transform(widget)
+        if transform_d is not None:
+            record["transform_present"] = True
+            record["type_name"] = type(transform_d).__name__
+            record["has_forward"] = getattr(transform_d, "forward", None) is not None
+            record["has_reverse"] = getattr(transform_d, "reverse", None) is not None
+
+        if not record["transform_present"]:
+            record["notes"] = "transform_missing"
+            return record
+
+        # Use runtime matrix seams only.
+        child_size = getattr(transform_d, "child_size", None)
+        if isinstance(child_size, (list, tuple)) and len(child_size) >= 2:
+            w = int(child_size[0])
+            h = int(child_size[1])
+        else:
+            w, h = int(size[0]), int(size[1])
+        if w <= 0 or h <= 0:
+            record["notes"] = "transform_child_size_unavailable"
+            return record
+
+        local_quad = (
+            [0.0, 0.0],
+            [float(w), 0.0],
+            [float(w), float(h)],
+            [0.0, float(h)],
+        )
+        projected, seam_name, _, seam_error = _screen_quad_from_local(local_quad, transform_d)
+        if projected is None:
+            record["notes"] = seam_error or "transform_matrix_unavailable"
+            return record
+
+        record["quad"] = projected
+        record["quad_source"] = seam_name
+        record["notes"] = "transform_rotation"
+        record["roundtrip_error"] = _roundtrip_error(transform_d, local_quad, projected)
+        if record["roundtrip_error"] is not None:
+            try:
+                if float(record["roundtrip_error"]) > 0.5:
+                    record["notes"] = "transform_rotation_roundtrip_imperfect"
+            except Exception:
+                pass
+        return record
+
+    def _backup_style(widget):
+        style = getattr(widget, "style", None)
+        if style is None:
+            return None
+        try:
+            return {
+                "xpos": getattr(style, "xpos", 0),
+                "ypos": getattr(style, "ypos", 0),
+                "alpha": getattr(style, "alpha", 1.0),
+                "visible": getattr(style, "visible", True),
+            }
+        except Exception:
+            return None
+
+    def _apply_hidden(widget):
+        style = getattr(widget, "style", None)
+        if style is None:
+            return False
+        try:
+            style.xpos = -4000
+            style.ypos = -4000
+            try:
+                style.alpha = 0.0
+            except Exception:
+                pass
+            try:
+                style.visible = False
+            except Exception:
+                pass
+            return True
+        except Exception:
+            return False
+
+    def _apply_backup(widget, backup):
+        style = getattr(widget, "style", None)
+        if style is None or not isinstance(backup, dict):
+            return False
+        try:
+            if "xpos" in backup:
+                style.xpos = backup["xpos"]
+            if "ypos" in backup:
+                style.ypos = backup["ypos"]
+            if "alpha" in backup:
+                try:
+                    style.alpha = backup["alpha"]
+                except Exception:
+                    pass
+            if "visible" in backup:
+                try:
+                    style.visible = backup["visible"]
+                except Exception:
+                    pass
+            return True
+        except Exception:
+            return False
+
+    def _handle_measure(payload):
+        request_ids = payload.get("target_ids") if isinstance(payload, dict) else None
+        if not isinstance(request_ids, list) or not request_ids:
+            request_ids = list(TARGET_IDS)
+        geometry = {}
+        for item in request_ids:
+            geometry[str(item)] = _measure_widget(str(item))
+        return {"ok": True, "geometry": geometry}
+
+    def _handle_set_isolation(payload):
+        target_id = None
+        if isinstance(payload, dict):
+            target_id = payload.get("target_id", payload.get("widget_id"))
+        elif isinstance(payload, str):
+            target_id = payload
+        if target_id is None:
+            target_id = "all"
+        if target_id == "all":
+            _state.selected = "all"
+            for wid in TARGET_IDS:
+                widget = _get_widget(wid)
+                if widget is None:
+                    continue
+                _apply_backup(widget, BACKUP_STYLE.get(wid) or {})
+                try:
+                    renpy.display.render.invalidate(widget)
+                except Exception:
+                    pass
+            renpy.restart_interaction()
+            return {"ok": True, "target_id": "all"}
+
+        if target_id not in TARGET_IDS:
+            return {"ok": False, "error": "unknown_target_id", "target_id": target_id}
+        _state.selected = str(target_id)
+        if not BACKUP_STYLE:
+            for wid in TARGET_IDS:
+                candidate = _get_widget(wid)
+                BACKUP_STYLE[wid] = _backup_style(candidate)
+
+        failed = []
+        for wid in TARGET_IDS:
+            candidate = _get_widget(wid)
+            if candidate is None:
+                failed.append(wid)
+                continue
+            if wid == target_id:
+                if not _apply_backup(candidate, BACKUP_STYLE.get(wid) or {}):
+                    failed.append(wid)
+            else:
+                if not _apply_hidden(candidate):
+                    failed.append(wid)
+            try:
+                renpy.display.render.invalidate(candidate)
+            except Exception:
+                pass
+
+        renpy.restart_interaction()
+        return {"ok": len(failed) == 0, "target_id": target_id, "failed": failed}
+
+    def _handle_restore(payload):
+        if not BACKUP_STYLE:
+            for wid in TARGET_IDS:
+                widget = _get_widget(wid)
+                BACKUP_STYLE[wid] = _backup_style(widget)
+        restored = []
+        for wid in TARGET_IDS:
+            widget = _get_widget(wid)
+            if widget is None:
+                continue
+            if _apply_backup(widget, BACKUP_STYLE.get(wid) or {}):
+                restored.append(wid)
+                try:
+                    renpy.display.render.invalidate(widget)
+                except Exception:
+                    pass
+        renpy.restart_interaction()
+        return {"ok": True, "restored": restored}
+
+    handlers = globals().get("_RENFORGE_HANDLERS")
+    if isinstance(handlers, dict):
+        handlers["rotation_spike_measure"] = _handle_measure
+        handlers["rotation_spike_set_isolation"] = _handle_set_isolation
+        handlers["rotation_spike_restore"] = _handle_restore

--- a/src/renforge/editor_rotation_runner.py
+++ b/src/renforge/editor_rotation_runner.py
@@ -1,0 +1,598 @@
+"""Live spike for issue #48 — rotated Transform geometry + write proof."""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import re
+from pathlib import Path
+from typing import Any
+import shutil
+
+from PIL import Image
+
+from renforge.editor_live_common import (
+    center as _center,
+    observe_selected as _observe_selected,
+    sha256_file as _sha256_file,
+    wait_bounds,
+)
+from renforge.editor_task0_runner import (
+    _require_ok,
+    _source_generation,
+    _wait_for_status,
+)
+
+FIXTURE_SCREEN = "renforge_editor_rotation_fixture"
+TARGET_ID = "rotation_target"
+REFERENCE_ID = "rotation_reference"
+EXTRA_ID = "rotation_other"
+ROTATION_IDS = (TARGET_ID, REFERENCE_ID, EXTRA_ID)
+
+SPIKE_RESOURCE = Path(__file__).resolve().parent / "bridge" / "rotation_spike.rpy"
+FIXTURE_RESOURCE = (
+    Path(__file__).resolve().parents[2]
+    / "tests"
+    / "live_fixtures"
+    / "renforge_editor_rotation_fixture.rpy"
+)
+
+BG_LUMA_MAX = 28
+
+
+def inject_editor_rotation_resources(project_root: Path) -> dict[str, str]:
+    game_dir = project_root / "game"
+    game_dir.mkdir(parents=True, exist_ok=True)
+    editor_target = game_dir / "zz_renforge_editor_rotation.rpy"
+    fixture_target = game_dir / "zz_renforge_editor_rotation_fixture.rpy"
+    shutil.copyfile(SPIKE_RESOURCE, editor_target)
+    shutil.copyfile(FIXTURE_RESOURCE, fixture_target)
+    return {"editor": str(editor_target), "fixture": str(fixture_target)}
+
+
+def _parse_xy(source_text: str, *, widget_id: str) -> dict[str, int]:
+    def resolve_literal(token: str | None, fallback: str) -> int:
+        if token is None:
+            raise AssertionError(f"{widget_id} source missing positional token {fallback}: {source_text!r}")
+        stripped = token.strip()
+        numeric = re.fullmatch(r"-?\d+", stripped)
+        if numeric is not None:
+            return int(stripped)
+        default_match = re.search(
+            rf"^\s*default\s+{re.escape(stripped)}\s*=\s*(-?\d+)\s*$",
+            source_text,
+            flags=re.MULTILINE,
+        )
+        if default_match is None:
+            raise AssertionError(f"{widget_id} unresolved positional token {token!r} for {fallback}")
+        return int(default_match.group(1))
+
+    pattern = rf"(?:textbutton|button)[\s\S]{{0,280}}id \"{re.escape(widget_id)}\"[\s\S]{{0,280}}"
+    match = re.search(pattern, source_text, flags=re.DOTALL)
+    if match is None:
+        raise AssertionError(f"source missing widget block for {widget_id!r}: {widget_id!r}")
+    block = match.group(0)
+    xpos = re.search(r"\bxpos\s+([A-Za-z_][A-Za-z0-9_]*|-?\d+)\b", block)
+    ypos = re.search(r"\bypos\s+([A-Za-z_][A-Za-z0-9_]*|-?\d+)\b", block)
+    if xpos is None or ypos is None:
+        raise AssertionError(f"{widget_id} source block missing xpos/ypos: {block!r}")
+    return {
+        "x": resolve_literal(xpos.group(1), "xpos"),
+        "y": resolve_literal(ypos.group(1), "ypos"),
+    }
+
+
+def _extract_rotate_span(source_text: str) -> tuple[int, int, int]:
+    block_pattern = rf'(?:textbutton|button)[\s\S]*?id "{re.escape(TARGET_ID)}"[\s\S]*?(?=\n\s*#|\n\s*$|$)'
+    match = re.search(block_pattern, source_text, flags=re.DOTALL)
+    if match is None:
+        raise AssertionError(f"rotated target block missing rotate literal")
+    block = match.group(0)
+    block_start = match.start(0)
+    rotate_match = re.search(r"rotate\s*=\s*(-?\d+)", block)
+    if rotate_match is None:
+        raise AssertionError(f"rotated target block missing rotate literal")
+    value = int(rotate_match.group(1))
+    return value, block_start + rotate_match.start(1), block_start + rotate_match.end(1)
+
+
+def _patch_rotate_literal(source_text: str, new_value: int) -> tuple[str, int, int]:
+    _, start_char, end_char = _extract_rotate_span(source_text)
+    start = len(source_text[:start_char].encode("utf-8"))
+    end = len(source_text[:end_char].encode("utf-8"))
+    before_bytes = source_text.encode("utf-8")
+    patched = before_bytes[:start] + str(int(new_value)).encode("utf-8") + before_bytes[end:]
+    return patched.decode("utf-8"), start, end
+
+
+def _independent_expected_position_patch(
+    source_text: str,
+    *,
+    x: int,
+    y: int,
+) -> str:
+    pattern = re.compile(
+        rf'(^\s*button\b[^\n]*\bid "{re.escape(TARGET_ID)}"[^\n]*\bxpos\s+)-?\d+'
+        r'([^\n]*\bypos\s+)-?\d+',
+        flags=re.MULTILINE,
+    )
+    patched, count = pattern.subn(
+        rf'\g<1>{int(x)}\g<2>{int(y)}',
+        source_text,
+        count=1,
+    )
+    if count != 1 or patched == source_text:
+        raise AssertionError("independent target position patch did not change the fixture")
+    return patched
+
+
+def _sample_rgb(image: Image.Image, x: int, y: int) -> tuple[int, int, int]:
+    width, height = image.size
+    if not (0 <= x < width and 0 <= y < height):
+        return (0, 0, 0)
+    pixel = image.getpixel((x, y))
+    if isinstance(pixel, int):
+        return (int(pixel), int(pixel), int(pixel))
+    if len(pixel) >= 3:
+        return (int(pixel[0]), int(pixel[1]), int(pixel[2]))
+    return (0, 0, 0)
+
+
+def _is_paint_pixel(rgb: tuple[int, int, int]) -> bool:
+    return max(rgb) > BG_LUMA_MAX
+
+
+def _build_isolation_mask(image: Image.Image, roi: list[int] | None = None) -> set[tuple[int, int]]:
+    width, height = image.size
+    if roi and len(roi) == 4:
+        x0 = max(0, int(roi[0]))
+        y0 = max(0, int(roi[1]))
+        x1 = min(width, int(roi[0] + roi[2]))
+        y1 = min(height, int(roi[1] + roi[3]))
+    else:
+        x0, y0, x1, y1 = 0, 0, width, height
+
+    painted: set[tuple[int, int]] = set()
+    for y in range(y0, y1):
+        for x in range(x0, x1):
+            if _is_paint_pixel(_sample_rgb(image, x, y)):
+                painted.add((x, y))
+    return painted
+
+
+def _mask_contains(mask: set[tuple[int, int]], x: int, y: int, *, radius: int = 1) -> bool:
+    if radius <= 0:
+        return (x, y) in mask
+    for dy in range(-radius, radius + 1):
+        for dx in range(-radius, radius + 1):
+            if (x + dx, y + dy) in mask:
+                return True
+    return False
+
+
+def _sample_mask_points(mask: set[tuple[int, int]], aabb: list[int]) -> dict[str, Any]:
+    if not aabb or len(aabb) != 4:
+        return {"center": {}, "aabb_corner": {}}
+
+    x, y, w, h = [int(v) for v in aabb]
+    if w <= 0 or h <= 0:
+        return {"center": {}, "aabb_corner": {}}
+
+    cx = x + w // 2
+    cy = y + h // 2
+    center = {
+        "point": [cx, cy],
+        "painted": _mask_contains(mask, cx, cy, radius=1),
+    }
+
+    corner = (x, y)
+    return {
+        "center": center,
+        "aabb_corner": {
+            "point": [corner[0], corner[1]],
+            "painted": _mask_contains(mask, corner[0], corner[1], radius=1),
+        },
+    }
+
+
+def _measure_geometry(client: Any, *, target_ids: list[str] | None = None) -> dict[str, Any]:
+    reply = client.request("rotation_spike_measure", {"target_ids": target_ids or []})
+    if not isinstance(reply, dict) or reply.get("ok") is not True:
+        raise AssertionError(f"rotation_spike_measure failed: {reply!r}")
+    geometry = reply.get("geometry")
+    if not isinstance(geometry, dict):
+        raise AssertionError(f"rotation_spike_measure malformed: {reply!r}")
+    return geometry
+
+
+def _run_isolation(client: Any, target_id: str, *, aabb: list[int]) -> dict[str, Any]:
+    reply = client.request("rotation_spike_set_isolation", {"target_id": target_id})
+    if not isinstance(reply, dict) or reply.get("ok") is not True:
+        raise AssertionError(f"rotation_spike_set_isolation failed: {reply!r}")
+
+    png = client.screenshot()
+    image = Image.open(io.BytesIO(png)).convert("RGB")
+    mask = _build_isolation_mask(image, roi=aabb if aabb else None)
+    return {
+        "target_id": target_id,
+        "painted_pixels": len(mask),
+        "point_samples": _sample_mask_points(mask, aabb),
+    }
+
+
+def _attempt_save_and_rebind(
+    client: Any,
+    *,
+    fixture_path: Path,
+    expected_move: list[int],
+) -> dict[str, Any]:
+    report: dict[str, Any] = {
+        "ok": False,
+        "reason": None,
+        "status_text": None,
+    }
+
+    pre_analysis = _require_ok(
+        client.request("editor_task0_status"),
+        "rotation status before save",
+    )
+    generation_before = _source_generation(pre_analysis)
+
+    pre_text = fixture_path.read_text(encoding="utf-8")
+    pre_pos = _parse_xy(pre_text, widget_id=TARGET_ID)
+    expected_pos = {
+        "x": pre_pos["x"] + int(expected_move[0]),
+        "y": pre_pos["y"] + int(expected_move[1]),
+    }
+    expected_text = _independent_expected_position_patch(
+        pre_text,
+        x=expected_pos["x"],
+        y=expected_pos["y"],
+    )
+
+    save_request = client.click_element(id="rf_save", screen="_renforge_editor_overlay")
+    if not isinstance(save_request, dict) or save_request.get("ok") is not True:
+        return {
+            "ok": False,
+            "reason": "write_chain_failed",
+            "save_request": save_request,
+        }
+
+    save_status = _wait_for_status(
+        client,
+        lambda status: (not bool(status.get("save_in_progress")))
+        and str(status.get("status_text")) in {"Reload committed", "Reload failed"},
+        timeout=60.0,
+        poll_name="rotation save settle",
+    )
+    report["status_text"] = str(save_status.get("status_text"))
+    if report["status_text"] != "Reload committed":
+        return {
+            "ok": False,
+            "reason": "write_chain_failed",
+            "status_text": report["status_text"],
+            "save_error": save_status.get("save_error"),
+        }
+
+    generation_after = _source_generation(save_status)
+    if isinstance(generation_before, int) and generation_after != generation_before + 1:
+        return {
+            "ok": False,
+            "reason": "write_chain_failed",
+            "status_text": report["status_text"],
+            "generation_before": generation_before,
+            "generation_after": generation_after,
+        }
+
+    post_status = _wait_for_status(
+        client,
+        lambda status: status.get("selected_widget_id") == TARGET_ID
+        and status.get("selected_lock_reason") != "ANALYZING"
+        and status.get("selected_analysis_pending") is not True,
+        timeout=10.0,
+        poll_name="rotation post-save rebind",
+    )
+    selected_reason = post_status.get("selected_lock_reason")
+    if selected_reason not in (None, ""):
+        return {
+            "ok": False,
+            "reason": "write_chain_failed",
+            "status_text": report["status_text"],
+            "post_save_rebind_lock_reason": selected_reason,
+        }
+
+    post_text = fixture_path.read_text(encoding="utf-8")
+    post_pos = _parse_xy(post_text, widget_id=TARGET_ID)
+    source_preserved = post_text == expected_text
+    if not source_preserved or post_pos != expected_pos:
+        return {
+            "ok": False,
+            "reason": "source_preservation_failed",
+            "expected_position": expected_pos,
+            "post_position": post_pos,
+            "matches_independent_expected": source_preserved,
+        }
+
+    report.update(
+        {
+            "ok": True,
+            "generation_before": generation_before,
+            "generation_after": generation_after,
+            "generation_delta": generation_after - generation_before if isinstance(generation_before, int) else None,
+            "save_request": save_request,
+            "expected_position": expected_pos,
+            "post_position": post_pos,
+            "outside_bytes_equal": source_preserved,
+            "matches_independent_expected": source_preserved,
+            "post_save_rebind_lock_reason": selected_reason,
+            "selected_widget": post_status.get("selected_widget_id"),
+            "status_text": report["status_text"],
+            "preview_to_source_delta": [expected_pos["x"] - pre_pos["x"], expected_pos["y"] - pre_pos["y"]],
+        }
+    )
+    return report
+
+
+def _run_manual_rotate_roundtrip(fixture_path: Path) -> dict[str, Any]:
+    before = fixture_path.read_bytes()
+    before_text = before.decode("utf-8")
+    original_value, start, end = _extract_rotate_span(before_text)
+    patched_value = original_value + 1
+
+    patched_text, patch_start, patch_end = _patch_rotate_literal(before_text, patched_value)
+    patched_bytes = patched_text.encode("utf-8")
+    outside_equal = before[:patch_start] == patched_bytes[:patch_start] and before[patch_end:] == patched_bytes[patch_end:]
+    patch_sha = hashlib.sha256(patched_bytes).hexdigest()
+
+    fixture_path.write_bytes(patched_bytes)
+    fixture_path.write_bytes(before)
+    restored = fixture_path.read_bytes()
+
+    return {
+        "rotate": {
+            "before": original_value,
+            "patched": patched_value,
+        },
+        "outside_bytes_equal": outside_equal,
+        "patch": {
+            "start": patch_start,
+            "end": patch_end,
+        },
+        "patched_sha256": patch_sha,
+        "restored_sha256": hashlib.sha256(restored).hexdigest(),
+        "matches_baseline": restored == before,
+    }
+
+
+def run_editor_rotation_live_scenario(
+    client: Any,
+    *,
+    fixture_path: Path,
+) -> dict[str, Any]:
+    """TDD live spike for issue #48."""
+    report: dict[str, Any] = {}
+    baseline_bytes = fixture_path.read_bytes()
+    baseline_text = baseline_bytes.decode("utf-8")
+    baseline_sha = _sha256_file(fixture_path)
+    baseline_position = _parse_xy(baseline_text, widget_id=TARGET_ID)
+    report["fixture_before"] = {
+        "sha256": baseline_sha,
+        "position": baseline_position,
+    }
+
+    start_reply = _require_ok(
+        client.request("editor_task0_start", {"screen": FIXTURE_SCREEN}),
+        "editor_task0_start",
+    )
+    report["start"] = {
+        "ok": True,
+        "status_text": start_reply.get("status_text"),
+    }
+
+    # Separate focus plane evidence (AABB from list_ui / runtime focus list).
+    focus_aabb: dict[str, Any] = {}
+    for wid in ROTATION_IDS:
+        bounds = wait_bounds(client, wid, fixture_screen=FIXTURE_SCREEN)
+        focus_aabb[wid] = {"aabb": [bounds["x"], bounds["y"], bounds["width"], bounds["height"]]}
+    report["focus_aabb"] = focus_aabb
+
+    # Runtime seams evidence from temporary bridge handler.
+    geometry = _measure_geometry(client, target_ids=list(ROTATION_IDS))
+    transform_plane: dict[str, Any] = {}
+    alias = {
+        TARGET_ID: "rotated",
+        REFERENCE_ID: "reference",
+        EXTRA_ID: "other",
+    }
+    for widget_id, payload in geometry.items():
+        key = alias.get(widget_id, widget_id)
+        transform_plane[key] = {
+            "found": bool(payload.get("found")),
+            "transform_present": bool(payload.get("transform_present")),
+            "quad_available": bool(payload.get("quad")),
+            "quad": payload.get("quad"),
+            "notes": str(payload.get("notes", "")),
+            "roundtrip_error": payload.get("roundtrip_error"),
+            "quad_source": payload.get("quad_source"),
+        }
+        # Keep raw ids available for easier debugging.
+        transform_plane[widget_id] = transform_plane[key]
+    report["transform_plane"] = transform_plane
+
+    # Candidate-isolated paint mask evidence.
+    report["isolation"] = {}
+    for wid in ROTATION_IDS:
+        _require_ok(client.request("rotation_spike_set_isolation", {"target_id": "all"}), "rotation_spike_set_isolation all")
+        result = _run_isolation(
+            client,
+            wid,
+            aabb=focus_aabb[wid]["aabb"],
+        )
+        alias_key = alias.get(wid, wid)
+        report["isolation"][alias_key] = {
+            **result,
+            "aabb_corner_painted": result["point_samples"]["aabb_corner"]["painted"],
+        }
+        report["isolation"][wid] = report["isolation"][alias_key]
+    _require_ok(client.request("rotation_spike_set_isolation", {"target_id": "all"}), "rotation_spike_set_isolation all")
+
+    # Probe the unpainted AABB corner through the real editor selection path.
+    corner_sample = report["isolation"]["rotated"]["point_samples"]["aabb_corner"]
+    corner_point = corner_sample.get("point")
+    if not (isinstance(corner_point, list) and len(corner_point) == 2):
+        raise AssertionError(f"rotated AABB corner probe is unavailable: {corner_sample!r}")
+    corner_select = _require_ok(
+        client.request("editor_task0_select", {"x": corner_point[0], "y": corner_point[1]}),
+        "rotation AABB corner select",
+    )
+    corner_selected = (corner_select.get("selected") or {}).get("widget_id")
+    report["aabb_corner_probe"] = {
+        "point": corner_point,
+        "painted": bool(corner_sample.get("painted")),
+        "selected_widget_id": corner_selected,
+        "selected_rotated": corner_selected == TARGET_ID,
+    }
+
+    # Resolve and move the rotated control from a painted center point.
+    target_bounds = focus_aabb[TARGET_ID]["aabb"]
+    target_center = _center({"x": target_bounds[0], "y": target_bounds[1], "width": target_bounds[2], "height": target_bounds[3]})
+
+    select = _require_ok(
+        client.request("editor_task0_select", {"x": target_center[0], "y": target_center[1]}),
+        "rotation target select",
+    )
+    lock_reason = select.get("lock_reason")
+    verdict: str
+    if isinstance(lock_reason, str) and lock_reason and lock_reason != "ANALYZING":
+        report["write_chain"] = {
+            "ok": False,
+            "reason": "selection_locked",
+            "selection_lock_reason": lock_reason,
+        }
+        verdict = "blocked"
+        report["verdict_reason"] = "selection_locked"
+    else:
+        analysis_status = _wait_for_status(
+            client,
+            lambda status: status.get("selected_widget_id") == TARGET_ID
+            and status.get("selected_lock_reason") != "ANALYZING"
+            and status.get("selected_analysis_pending") is not True,
+            timeout=10.0,
+            poll_name="rotation analysis",
+        )
+        analysis_lock = analysis_status.get("selected_lock_reason")
+        if isinstance(analysis_lock, str) and analysis_lock:
+            report["write_chain"] = {
+                "ok": False,
+                "reason": "selection_locked",
+                "selection_lock_reason": analysis_lock,
+            }
+            verdict = "blocked"
+            report["verdict_reason"] = "selection_locked"
+            report["write_chain"].update(
+                {
+                "selected_widget_id": analysis_status.get("selected_widget_id"),
+                "selected_lock_reason": analysis_lock,
+                }
+            )
+        else:
+            original = analysis_status.get("selected_original_position")
+            if not (isinstance(original, (list, tuple)) and len(original) == 2):
+                original = [baseline_position["x"], baseline_position["y"]]
+            requested_before = [int(original[0]), int(original[1])]
+
+            pre_obs = _observe_selected(client)
+            pre_rect = pre_obs.get("rect") or []
+
+            _require_ok(
+                client.request("editor_task0_key", {"key": "right", "repeat": 1}),
+                "rotation nudge right",
+            )
+            preview_status = _wait_for_status(
+                client,
+                lambda status: isinstance(status.get("preview_position"), (list, tuple))
+                and len(status.get("preview_position") or []) == 2
+                and list(status.get("preview_position") or []) != requested_before,
+                timeout=8.0,
+                poll_name="rotation preview",
+            )
+
+            preview_after = [int(preview_status["preview_position"][0]), int(preview_status["preview_position"][1])]
+            requested_after = preview_after
+            requested_move = [
+                requested_after[0] - requested_before[0],
+                requested_after[1] - requested_before[1],
+            ]
+            undo = _require_ok(client.request("editor_task0_undo", {}), "rotation product undo")
+            undo_status = _wait_for_status(
+                client,
+                lambda status: list(status.get("preview_position") or []) == requested_before,
+                timeout=8.0,
+                poll_name="rotation product undo",
+            )
+            redo = _require_ok(client.request("editor_task0_redo", {}), "rotation product redo")
+            redo_status = _wait_for_status(
+                client,
+                lambda status: list(status.get("preview_position") or []) == requested_after,
+                timeout=8.0,
+                poll_name="rotation product redo",
+            )
+            report["product_undo"] = {
+                "ok": list(undo_status.get("preview_position") or []) == requested_before
+                and list(redo_status.get("preview_position") or []) == requested_after,
+                "undo": undo,
+                "redo": redo,
+            }
+            write = _attempt_save_and_rebind(
+                client,
+                fixture_path=fixture_path,
+                expected_move=requested_move,
+            )
+            report["write_chain"] = write
+
+            if write.get("ok") is not True:
+                verdict = "blocked"
+                report["verdict_reason"] = "write_chain_failed"
+            else:
+                verdict = "pass" if report["product_undo"]["ok"] else "blocked"
+                report["verdict_reason"] = None if verdict == "pass" else "manual_undo_only"
+
+            post_obs = _observe_selected(client)
+            post_rect = post_obs.get("rect") or []
+            report["write_chain"].update(
+                {
+                    "requested_before": requested_before,
+                    "requested_after": requested_after,
+                    "requested_move": requested_move,
+                    "pre_observation_rect": pre_rect,
+                    "post_observation_rect": post_rect,
+                }
+            )
+
+    report["manual_rotate_roundtrip"] = _run_manual_rotate_roundtrip(fixture_path)
+
+    rotated = report["transform_plane"].get(TARGET_ID) or {}
+    paint = report["isolation"][TARGET_ID]["point_samples"]
+    manual = report["manual_rotate_roundtrip"]
+    if not manual.get("outside_bytes_equal") or not manual.get("matches_baseline"):
+        report["verdict"] = "inconclusive"
+        report["verdict_reason"] = "manual_roundtrip_failed"
+    elif not rotated.get("quad_available"):
+        report["verdict"] = "blocked"
+        report["verdict_reason"] = "missing_transform_seam"
+    elif not paint["center"]["painted"]:
+        report["verdict"] = "blocked"
+        report["verdict_reason"] = "paint_mask_incomplete"
+    elif report["aabb_corner_probe"]["selected_rotated"] and not report["aabb_corner_probe"]["painted"]:
+        report["verdict"] = "blocked"
+        report["verdict_reason"] = "aabb_false_positive"
+    else:
+        report["verdict"] = verdict
+
+    fixture_path.write_bytes(baseline_bytes)
+    report["fixture_restore"] = {
+        "matches_baseline": fixture_path.read_bytes() == baseline_bytes,
+        "sha256": _sha256_file(fixture_path),
+    }
+
+    return report

--- a/src/renforge/editor_rotation_runner.py
+++ b/src/renforge/editor_rotation_runner.py
@@ -341,7 +341,11 @@ def _run_manual_rotate_roundtrip(fixture_path: Path) -> dict[str, Any]:
 
     patched_text, patch_start, patch_end = _patch_rotate_literal(before_text, patched_value)
     patched_bytes = patched_text.encode("utf-8")
-    outside_equal = before[:patch_start] == patched_bytes[:patch_start] and before[patch_end:] == patched_bytes[patch_end:]
+    patched_end = patch_start + len(str(patched_value).encode("utf-8"))
+    outside_equal = (
+        before[:patch_start] == patched_bytes[:patch_start]
+        and before[patch_end:] == patched_bytes[patched_end:]
+    )
     patch_sha = hashlib.sha256(patched_bytes).hexdigest()
 
     fixture_path.write_bytes(patched_bytes)
@@ -356,7 +360,8 @@ def _run_manual_rotate_roundtrip(fixture_path: Path) -> dict[str, Any]:
         "outside_bytes_equal": outside_equal,
         "patch": {
             "start": patch_start,
-            "end": patch_end,
+            "original_end": patch_end,
+            "patched_end": patched_end,
         },
         "patched_sha256": patch_sha,
         "restored_sha256": hashlib.sha256(restored).hexdigest(),

--- a/src/renforge/editor_rotation_runner.py
+++ b/src/renforge/editor_rotation_runner.py
@@ -4,10 +4,11 @@ from __future__ import annotations
 
 import hashlib
 import io
+import math
 import re
+import shutil
 from pathlib import Path
 from typing import Any
-import shutil
 
 from PIL import Image
 
@@ -170,13 +171,45 @@ def _mask_contains(mask: set[tuple[int, int]], x: int, y: int, *, radius: int = 
     return False
 
 
-def _sample_mask_points(mask: set[tuple[int, int]], aabb: list[int]) -> dict[str, Any]:
+def _edge_probe_from_quad(quad: Any) -> list[int] | None:
+    if not isinstance(quad, list) or len(quad) != 4:
+        return None
+    try:
+        points = [(float(point[0]), float(point[1])) for point in quad]
+    except (TypeError, ValueError, IndexError):
+        return None
+    center = (
+        sum(point[0] for point in points) / len(points),
+        sum(point[1] for point in points) / len(points),
+    )
+    p1, p2 = max(
+        zip(points, points[1:] + points[:1]),
+        key=lambda edge: (edge[1][0] - edge[0][0]) ** 2 + (edge[1][1] - edge[0][1]) ** 2,
+    )
+    midpoint = ((p1[0] + p2[0]) / 2.0, (p1[1] + p2[1]) / 2.0)
+    toward_center = (center[0] - midpoint[0], center[1] - midpoint[1])
+    distance = math.hypot(*toward_center)
+    if distance <= 0.0:
+        return None
+    inset = 2.0
+    return [
+        int(round(midpoint[0] + toward_center[0] * inset / distance)),
+        int(round(midpoint[1] + toward_center[1] * inset / distance)),
+    ]
+
+
+def _sample_mask_points(
+    mask: set[tuple[int, int]],
+    aabb: list[int],
+    *,
+    edge_probe: list[int] | None = None,
+) -> dict[str, Any]:
     if not aabb or len(aabb) != 4:
-        return {"center": {}, "aabb_corner": {}}
+        return {"center": {}, "edge": {}, "aabb_corner": {}}
 
     x, y, w, h = [int(v) for v in aabb]
     if w <= 0 or h <= 0:
-        return {"center": {}, "aabb_corner": {}}
+        return {"center": {}, "edge": {}, "aabb_corner": {}}
 
     cx = x + w // 2
     cy = y + h // 2
@@ -188,6 +221,14 @@ def _sample_mask_points(mask: set[tuple[int, int]], aabb: list[int]) -> dict[str
     corner = (x, y)
     return {
         "center": center,
+        "edge": {
+            "point": edge_probe,
+            "painted": bool(
+                edge_probe is not None
+                and _mask_contains(mask, edge_probe[0], edge_probe[1], radius=1)
+            ),
+            "source": "runtime_transform_quad_inset",
+        },
         "aabb_corner": {
             "point": [corner[0], corner[1]],
             "painted": _mask_contains(mask, corner[0], corner[1], radius=1),
@@ -205,7 +246,13 @@ def _measure_geometry(client: Any, *, target_ids: list[str] | None = None) -> di
     return geometry
 
 
-def _run_isolation(client: Any, target_id: str, *, aabb: list[int]) -> dict[str, Any]:
+def _run_isolation(
+    client: Any,
+    target_id: str,
+    *,
+    aabb: list[int],
+    edge_probe: list[int] | None = None,
+) -> dict[str, Any]:
     reply = client.request("rotation_spike_set_isolation", {"target_id": target_id})
     if not isinstance(reply, dict) or reply.get("ok") is not True:
         raise AssertionError(f"rotation_spike_set_isolation failed: {reply!r}")
@@ -216,7 +263,7 @@ def _run_isolation(client: Any, target_id: str, *, aabb: list[int]) -> dict[str,
     return {
         "target_id": target_id,
         "painted_pixels": len(mask),
-        "point_samples": _sample_mask_points(mask, aabb),
+        "point_samples": _sample_mask_points(mask, aabb, edge_probe=edge_probe),
     }
 
 
@@ -419,6 +466,7 @@ def run_editor_rotation_live_scenario(
             "notes": str(payload.get("notes", "")),
             "roundtrip_error": payload.get("roundtrip_error"),
             "quad_source": payload.get("quad_source"),
+            "quad_coordinate_space": payload.get("quad_coordinate_space"),
         }
         # Keep raw ids available for easier debugging.
         transform_plane[widget_id] = transform_plane[key]
@@ -432,6 +480,11 @@ def run_editor_rotation_live_scenario(
             client,
             wid,
             aabb=focus_aabb[wid]["aabb"],
+            edge_probe=(
+                _edge_probe_from_quad(transform_plane[wid].get("quad"))
+                if wid == TARGET_ID
+                else None
+            ),
         )
         alias_key = alias.get(wid, wid)
         report["isolation"][alias_key] = {
@@ -585,7 +638,7 @@ def run_editor_rotation_live_scenario(
     elif not rotated.get("quad_available"):
         report["verdict"] = "blocked"
         report["verdict_reason"] = "missing_transform_seam"
-    elif not paint["center"]["painted"]:
+    elif not paint["center"]["painted"] or not paint["edge"]["painted"]:
         report["verdict"] = "blocked"
         report["verdict_reason"] = "paint_mask_incomplete"
     elif report["aabb_corner_probe"]["selected_rotated"] and not report["aabb_corner_probe"]["painted"]:

--- a/tests/live_fixtures/renforge_editor_rotation_fixture.rpy
+++ b/tests/live_fixtures/renforge_editor_rotation_fixture.rpy
@@ -1,0 +1,71 @@
+# Spike fixture for issue #48 — rotate-aware geometry and paint-separability proof.
+# Intent: one focusable rotated control, one same-shape unrotated control,
+# and one additional focusable control for ambiguity sanity.
+default renforge_rotation_isolation = "all"
+
+default renforge_rotation_target_fill = "#e5c82e"
+default renforge_rotation_reference_fill = "#2e6be5"
+default renforge_rotation_other_fill = "#2ee5a0"
+
+default renforge_rotation_font_color = "#f4f4f5"
+
+default renforge_rotation_target_text = "ROTATED"
+default renforge_rotation_reference_text = "REFERENCE"
+default renforge_rotation_other_text = "OTHER"
+
+default renforge_rotation_target_size = 140
+default renforge_rotation_target_depth = 80
+
+default renforge_rotation_target_x = 220
+default renforge_rotation_target_y = 220
+
+default renforge_rotation_reference_x = 420
+
+default renforge_rotation_reference_y = 220
+
+default renforge_rotation_other_x = 220
+
+default renforge_rotation_other_y = 430
+
+screen renforge_editor_rotation_fixture():
+    layer "screens"
+    zorder 640
+
+    fixed:
+        id "rotation_root"
+        xfill True
+        yfill True
+
+        # Dark stage to make painted-mask checks stable.
+        add Solid("#0a0a0a", xysize=(1280, 720)):
+            xpos 0
+            ypos 0
+
+        # Focusable rotated target (same declared shape as reference).
+        if renforge_rotation_isolation in ("all", "rotation_target"):
+            button id "rotation_target" xpos 220 ypos 220 xsize 160 ysize renforge_rotation_target_depth:
+                action NullAction()
+                add Transform(
+                    Solid(renforge_rotation_target_fill, xysize=(80, 36)),
+                    rotate=15,
+                    xalign=0.5,
+                    yalign=0.5,
+                )
+
+        # Same-shape unrotated control (same button shape).
+        if renforge_rotation_isolation in ("all", "rotation_reference"):
+            button id "rotation_reference" xpos 420 ypos 220 xsize 160 ysize renforge_rotation_target_depth:
+                action NullAction()
+                background Solid(renforge_rotation_reference_fill)
+                text str(renforge_rotation_reference_text):
+                    color renforge_rotation_font_color
+                    size 18
+
+        # Additional same-depth focusable control for control-plane sanity.
+        if renforge_rotation_isolation in ("all", "rotation_other"):
+            button id "rotation_other" xpos 220 ypos 430 xsize 160 ysize renforge_rotation_target_depth:
+                action NullAction()
+                background Solid(renforge_rotation_other_fill)
+                text str(renforge_rotation_other_text):
+                    color renforge_rotation_font_color
+                    size 18

--- a/tests/test_editor_rotation_live.py
+++ b/tests/test_editor_rotation_live.py
@@ -85,6 +85,7 @@ def test_rotation_spike_evidence_leads_to_blocked(demo_copy: Path) -> None:
     rotated = report["transform_plane"]["rotated"]
     assert rotated["quad_available"] is True
     assert rotated["quad_source"] in {"forward", "reverse"}
+    assert rotated["quad_coordinate_space"] == "screen"
     assert rotated["roundtrip_error"] is not None
     assert rotated["roundtrip_error"] <= 0.5
     quad = rotated["quad"]
@@ -105,6 +106,8 @@ def test_rotation_spike_evidence_leads_to_blocked(demo_copy: Path) -> None:
 
     paint = report["isolation"]["rotated"]["point_samples"]
     assert paint["center"]["painted"] is True
+    assert paint["edge"]["painted"] is True
+    assert paint["edge"]["source"] == "runtime_transform_quad_inset"
     assert paint["aabb_corner"]["painted"] is False
 
     corner = report["aabb_corner_probe"]

--- a/tests/test_editor_rotation_live.py
+++ b/tests/test_editor_rotation_live.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import math
+import os
+import shutil
+import time
+from pathlib import Path
+
+import pytest
+
+from renforge.editor_rotation_runner import (
+    FIXTURE_SCREEN,
+    inject_editor_rotation_resources,
+    run_editor_rotation_live_scenario,
+)
+
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("RENFORGE_ROTATION_LIVE"),
+    reason="set RENFORGE_ROTATION_LIVE=1 to run issue #48 rotation spike",
+)
+
+_DEMO = Path(__file__).resolve().parents[1] / "examples" / "demo_game"
+
+
+@pytest.fixture
+def demo_copy(tmp_path: Path) -> Path:
+    destination = tmp_path / "demo"
+    shutil.copytree(_DEMO, destination, ignore=shutil.ignore_patterns("*.rpyc", "cache"))
+    inject_editor_rotation_resources(destination)
+    return destination
+
+
+def _open_editor(session) -> None:
+    for _ in range(40):
+        if session.client.inspect_screen("_renforge_editor_launcher").get("active") is True:
+            break
+        time.sleep(0.2)
+    else:
+        pytest.fail("editor launcher never became active")
+
+    assert session.client.click_element(
+        text="RF", exact=True, screen="_renforge_editor_launcher"
+    ).get("ok") is True
+    for _ in range(40):
+        if session.client.inspect_screen("_renforge_editor_overlay").get("active") is True:
+            break
+        time.sleep(0.05)
+    else:
+        pytest.fail("editor overlay never became active")
+
+    for _ in range(20):
+        if session.client.eval_expr(f'renpy.has_screen("{FIXTURE_SCREEN}")') is True:
+            break
+        time.sleep(0.1)
+    else:
+        pytest.fail("rotation fixture screen never became active")
+
+
+def test_rotation_spike_evidence_leads_to_blocked(demo_copy: Path) -> None:
+    """Issue #48 stays blocked when an unpainted AABB corner selects the rotated target."""
+    from renforge.bridge.launcher import launch_with_bridge
+    from renforge.project import RenpyProject
+    from renforge.sdk import get_or_install_sdk
+
+    sdk = get_or_install_sdk("8.5.3", project_root=demo_copy)
+    project = RenpyProject(demo_copy)
+    fixture_path = demo_copy / "game" / "zz_renforge_editor_rotation_fixture.rpy"
+
+    reports = []
+    for _ in range(2):
+        with launch_with_bridge(sdk, project, startup_timeout=120, editor=True) as session:
+            _open_editor(session)
+            reports.append(
+                run_editor_rotation_live_scenario(
+                    session.client,
+                    fixture_path=fixture_path,
+                )
+            )
+
+    assert [(item["verdict"], item["verdict_reason"]) for item in reports] == [
+        ("blocked", "aabb_false_positive"),
+        ("blocked", "aabb_false_positive"),
+    ]
+    report = reports[-1]
+    rotated = report["transform_plane"]["rotated"]
+    assert rotated["quad_available"] is True
+    assert rotated["quad_source"] in {"forward", "reverse"}
+    assert rotated["roundtrip_error"] is not None
+    assert rotated["roundtrip_error"] <= 0.5
+    quad = rotated["quad"]
+    assert isinstance(quad, list) and len(quad) == 4
+    points = [(float(point[0]), float(point[1])) for point in quad]
+    assert all(math.isfinite(value) for point in points for value in point)
+    area = abs(
+        sum(
+            x1 * y2 - x2 * y1
+            for (x1, y1), (x2, y2) in zip(points, points[1:] + points[:1])
+        )
+    ) / 2.0
+    assert area > 1.0
+    assert any(
+        abs(x2 - x1) > 0.5 and abs(y2 - y1) > 0.5
+        for (x1, y1), (x2, y2) in zip(points, points[1:] + points[:1])
+    )
+
+    paint = report["isolation"]["rotated"]["point_samples"]
+    assert paint["center"]["painted"] is True
+    assert paint["aabb_corner"]["painted"] is False
+
+    corner = report["aabb_corner_probe"]
+    assert corner["painted"] is False
+    assert corner["selected_rotated"] is True
+    assert corner["selected_widget_id"] == "rotation_target"
+
+    assert report["product_undo"]["ok"] is True
+    assert report["write_chain"]["ok"] is True
+    assert report["write_chain"]["status_text"] == "Reload committed"
+    assert report["write_chain"]["generation_delta"] == 1
+    assert report["write_chain"]["matches_independent_expected"] is True
+    assert report["write_chain"]["post_save_rebind_lock_reason"] is None
+
+    manual = report["manual_rotate_roundtrip"]
+    assert manual["outside_bytes_equal"] is True
+    assert manual["matches_baseline"] is True
+    assert report["fixture_restore"]["matches_baseline"] is True

--- a/tests/test_editor_rotation_runner.py
+++ b/tests/test_editor_rotation_runner.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from renforge.editor_rotation_runner import _run_manual_rotate_roundtrip
+
+
+def test_manual_rotate_roundtrip_handles_replacement_length_change(tmp_path: Path) -> None:
+    fixture = tmp_path / "fixture.rpy"
+    baseline = (
+        b'screen example():\n'
+        b'    button id "rotation_target":\n'
+        b'        add Transform(Solid("#fff"), rotate=9)\n'
+    )
+    fixture.write_bytes(baseline)
+
+    report = _run_manual_rotate_roundtrip(fixture)
+
+    assert report["rotate"] == {"before": 9, "patched": 10}
+    assert report["outside_bytes_equal"] is True
+    assert report["patch"]["patched_end"] == report["patch"]["original_end"] + 1
+    assert report["matches_baseline"] is True
+    assert fixture.read_bytes() == baseline


### PR DESCRIPTION
## Summary

- adds frozen `PASS / BLOCKED / INCONCLUSIVE` criteria for the rotation evidence spike
- measures the runtime Transform seam independently from candidate-isolated screen paint
- probes the real editor selection path at an unpainted AABB corner
- proves product nudge, undo/redo, source-preserving save, reload, and rebinding
- documents the observed `BLOCKED / aabb_false_positive` verdict

## Result

Ren'Py 8.5.3 consistently selected `rotation_target` at `[220, 220]`, although the candidate-isolated paint mask proved that point was unpainted. Rotation editing therefore remains disabled until selection uses exact transformed hit evidence rather than focus AABB alone.

No production editor logic or UI controls are changed.

## Test plan

- [x] `RENFORGE_ROTATION_LIVE=1 PYTHONPATH=src python -m pytest -q tests/test_editor_rotation_live.py -vv` — `1 passed` with two independent live runs
- [x] focused editor regression set — `143 passed`
- [x] full suite — `632 passed, 43 skipped`
- [x] `git diff --check`
- [x] Python compile check

Closes #48