### PR TITLE
test(editor): add source-safe z-order evidence spike

### DIFF
--- a/docs/superpowers/spikes/2026-08-02-zorder-structural-criteria.md
+++ b/docs/superpowers/spikes/2026-08-02-zorder-structural-criteria.md
@@ -1,0 +1,76 @@
+# Issue #49 — frozen structural edit criteria
+
+## Verdict scope
+
+The only supported structural operation is `raise_adjacent_sibling`.
+
+It swaps exactly two consecutive, direct `button ...:` children of the same `screen` body in one UTF-8 source file. The target must be immediately followed by the sibling (comments/blank separator bytes may remain between them). Moving the target later raises it one source-order step.
+
+Out of scope: general reparenting, nested containers, non-adjacent moves, arbitrary tree rewrites, non-button statements, UI controls, explicit/dynamic `zorder`, loops/conditionals/`use`, multiple files, and more than one runtime instance per source statement.
+
+## Source contract
+
+The analyzer must prove before staging that:
+
+- operation is exactly `raise_adjacent_sibling`;
+- both statements are block-form buttons with distinct literal IDs;
+- both are direct children of the same screen and have the same indentation;
+- the target is immediately before the sibling, ignoring only blank/comment separator lines;
+- each ID has unique source ownership and exactly one static runtime instance;
+- neither button header contains explicit or dynamic `zorder`;
+- spans are ordered, non-overlapping, UTF-8-safe, and still match the analyzed baseline digest.
+
+The staged bytes must equal the independent construction:
+
+`prefix + sibling_block + separator + target_block + suffix`
+
+Each raw block is moved byte-for-byte. Every byte outside the two block spans is unchanged. Post-swap source locations for both IDs are computed from the staged bytes rather than copied from the baseline.
+
+## Transaction contract
+
+Forward publication must use a dedicated structural coordinator command, not a position intent:
+
+1. independently reobserve both runtime keys;
+2. re-read and revalidate the structural source contract;
+3. stage the raw block exchange;
+4. run Ren'Py lint in the existing shadow project;
+5. recheck the source digest;
+6. atomically publish;
+7. reload exactly once;
+8. rebind both IDs at their computed post-swap lines;
+9. attest that the target is above the sibling at their overlap;
+10. commit only after attestation.
+
+Any validation, stale-source, ambiguous-ownership, multi-instance, rebind, or attestation failure must fail closed before publication or use the existing conditional rollback. A rollback conflict must preserve external bytes and report uncertainty.
+
+`structural_undo` is allowed only for one committed structural transaction whose staged digest still matches the file. It creates a validated atomic reverse transaction, reloads, rebinds both original source locations, and marks the forward transaction undone only after successful attestation. A second undo is rejected.
+
+## Independent live evidence
+
+The opt-in Ren'Py fixture contains two opaque, completely overlapping direct sibling buttons with distinct literal IDs and colors.
+
+The live proof must record:
+
+- baseline topmost hit and screenshot center color belong to the sibling;
+- forward swap source bytes match the independent construction;
+- shadow validation and atomic publication succeed;
+- generation increments by one;
+- both IDs rebind uniquely at their new source lines;
+- runtime hit order reports the target above the sibling;
+- an independent screenshot center pixel changes to the target color;
+- one deliberately refused attestation rolls the published source back to the exact baseline SHA;
+- a successful forward transaction followed by `structural_undo` reloads and restores byte-identical baseline source and baseline visual order.
+
+Screenshot color and runtime focus/hit order are separate evidence planes; neither may validate the other.
+
+## PASS
+
+All source, transaction, live-reload, unique-rebind, hit-order, screenshot-color, rollback, and byte-identical undo checks pass. Relevant targeted/full tests pass and the fixture is restored.
+
+## BLOCKED
+
+Return `BLOCKED` with one stable reason if runtime paint order, post-swap rebinding, rollback, or byte-identical transactional undo cannot be proven. Do not expose production UI.
+
+## INCONCLUSIVE
+
+Return `INCONCLUSIVE` for missing seams, malformed reports, unavailable live runtime, or incomplete independent evidence. Do not expose production UI.

--- a/docs/superpowers/spikes/2026-08-02-zorder-structural-criteria.md
+++ b/docs/superpowers/spikes/2026-08-02-zorder-structural-criteria.md
@@ -54,7 +54,7 @@ The live proof must record:
 - baseline topmost hit and screenshot center color belong to the sibling;
 - forward swap source bytes match the independent construction;
 - shadow validation and atomic publication succeed;
-- generation increments by one;
+- the editor runtime script-generation counter used by reload attestation increments by one;
 - both IDs rebind uniquely at their new source lines;
 - runtime hit order reports the target above the sibling;
 - an independent screenshot center pixel changes to the target color;

--- a/docs/superpowers/spikes/2026-08-02-zorder-structural-result.md
+++ b/docs/superpowers/spikes/2026-08-02-zorder-structural-result.md
@@ -52,7 +52,7 @@ After fixture restoration + second real reload:
 - restored SHA equals the original SHA;
 - restored bytes are exactly equal to the baseline.
 
-Live test: `1 passed in 8.21s`.
+Live test: `1 passed in 9.74s`.
 
 ## Why blocked
 

--- a/docs/superpowers/spikes/2026-08-02-zorder-structural-result.md
+++ b/docs/superpowers/spikes/2026-08-02-zorder-structural-result.md
@@ -1,0 +1,61 @@
+# Issue #49 — source-safe z-order structural spike result
+
+## Verdict
+
+`BLOCKED — structural_transaction_undo_missing`
+
+The smallest useful source rewrite is proven, but it must not be exposed in the editor UI yet. RenForge's current position transaction only owns coordinate edits and has no committed structural undo record.
+
+## Frozen operation
+
+`raise_adjacent_sibling` swaps exactly two consecutive direct `button ...:` children of the same `screen` while leaving the separator and every byte outside the two button spans untouched.
+
+Rejected before writing:
+
+- non-button or non-block statements;
+- different/nested parents;
+- non-adjacent siblings;
+- dynamic/non-literal or duplicate IDs;
+- explicit `zorder` on either button;
+- stale source SHA.
+
+## Source evidence
+
+- UTF-8 byte offsets are used, including non-ASCII content before and inside both blocks.
+- The source baseline SHA is bound into the analysis plan.
+- Publication rejects a changed baseline with `STALE_SOURCE`.
+- Post-swap source lines are recomputed for both stable IDs.
+- The patch has a zero-byte size delta in the live fixture.
+- Unit source suite: `89 passed`.
+
+## Live Ren'Py 8.5.3 evidence
+
+Fixture: two overlapping direct sibling buttons at `(220, 220)`, each `180×100`.
+
+Before swap:
+
+- painted pixel at `(240, 240)`: `[35, 84, 206]` (blue sibling);
+- focus selection: `zorder_sibling`.
+
+After source swap + real `reload_script`:
+
+- painted pixel at `(240, 240)`: `[216, 58, 58]` (red target);
+- focus selection: `zorder_target`;
+- both stable IDs rebound with unchanged bounds;
+- target source line: `16`;
+- sibling source line: `9`.
+
+After fixture restoration + second real reload:
+
+- painted pixel returns blue;
+- focus selection returns to `zorder_sibling`;
+- restored SHA equals the original SHA;
+- restored bytes are exactly equal to the baseline.
+
+Live test: `1 passed in 8.21s`.
+
+## Why blocked
+
+The runtime result, reload, stable rebind, stale guard, and byte-identical fixture restoration are proven. What is not yet present is a product-level structural transaction that can persist the original spans/bytes and perform conditional rollback plus explicit undo after commit.
+
+Enabling a z-order control before that seam exists would bypass the editor's transactional safety contract. No production UI control or coordinator command is enabled by this spike.

--- a/src/renforge/editor/source.py
+++ b/src/renforge/editor/source.py
@@ -2029,8 +2029,11 @@ def _source_id_ownership_count(lines: list[str], widget_id: str) -> int:
             continue
         try:
             count += int(_literal_button_id(line) == widget_id)
-        except EditorSourceError:
-            continue
+        except EditorSourceError as exc:
+            raise EditorSourceError(
+                "AMBIGUOUS_OWNERSHIP",
+                "every button owner must have one statically resolved literal id",
+            ) from exc
     return count
 
 

--- a/src/renforge/editor/source.py
+++ b/src/renforge/editor/source.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import ast
+import hashlib
 from dataclasses import dataclass
 from typing import TypeVar, TypedDict
 
@@ -156,6 +157,17 @@ class ButtonStatement:
     xpos_span: tuple[int, int]
     ypos_span: tuple[int, int]
     source_line: int
+
+
+@dataclass(frozen=True)
+class ButtonSiblingSwapPlan:
+    target_widget_id: str
+    sibling_widget_id: str
+    target_source_line: int
+    sibling_source_line: int
+    target_block_span: tuple[int, int]
+    sibling_block_span: tuple[int, int]
+    baseline_sha256: str
 
 
 @dataclass(frozen=True)
@@ -1940,3 +1952,145 @@ def apply_button_patch(source_bytes: bytes, statement: ButtonStatement, *, x: in
     for start, end, replacement in replacements:
         patched = f"{patched[:start]}{replacement}{patched[end:]}"
     return patched.encode("utf-8")
+
+
+def _header_indent(line: str) -> int:
+    return len(line) - len(line.lstrip(" \t"))
+
+
+def _button_block_span(lines: list[str], source_line: int) -> tuple[tuple[int, int], int]:
+    if source_line < 1 or source_line > len(lines):
+        raise EditorSourceError("SOURCE_LINE_INVALID", "button source line is outside the source file")
+    header_indent = _header_indent(lines[source_line - 1])
+    start = len("".join(lines[: source_line - 1]).encode("utf-8"))
+    last_content_line = source_line
+    for index in range(source_line, len(lines)):
+        line = lines[index]
+        if not line.strip():
+            continue
+        if _header_indent(line) <= header_indent:
+            break
+        last_content_line = index + 1
+    if last_content_line == source_line:
+        raise EditorSourceError("BUTTON_BLOCK_REQUIRED", "structural button must have a child block")
+    end = len("".join(lines[:last_content_line]).encode("utf-8"))
+    return (start, end), last_content_line + 1
+
+
+def _literal_button_id(header: str) -> str:
+    tokens = _lex_single_line(_statement_text(header))
+    values: list[str] = []
+    for index, token in enumerate(tokens[:-1]):
+        if token.depth != 0 or token.kind != "WORD" or token.text != "id":
+            continue
+        value_token = tokens[index + 1]
+        if value_token.depth != 0 or value_token.kind != "STRING":
+            raise EditorSourceError("BUTTON_ID_LITERAL_REQUIRED", "button id must be a literal string")
+        value = ast.literal_eval(value_token.text)
+        if not isinstance(value, str) or not value:
+            raise EditorSourceError("BUTTON_ID_LITERAL_REQUIRED", "button id must be a non-empty literal string")
+        values.append(value)
+    if len(values) != 1:
+        raise EditorSourceError("BUTTON_ID_AMBIGUOUS", "button must contain exactly one literal id")
+    return values[0]
+
+
+def _analyze_structural_button(lines: list[str], source_line: int, expected_id: str) -> tuple[tuple[int, int], int]:
+    if source_line < 1 or source_line > len(lines):
+        raise EditorSourceError("SOURCE_LINE_INVALID", "button source line is outside the source file")
+    header = lines[source_line - 1]
+    if peek_statement_kind(header) != "button":
+        raise EditorSourceError("TARGET_NOT_BUTTON", "structural operation only supports button blocks")
+    if not _statement_text(header).rstrip().endswith(":"):
+        raise EditorSourceError("BUTTON_BLOCK_REQUIRED", "structural operation requires block-form buttons")
+    actual_id = _literal_button_id(header)
+    if actual_id != expected_id:
+        raise EditorSourceError("ID_MISMATCH", "source literal id does not match requested widget id")
+    if any(token.depth == 0 and token.kind == "WORD" and token.text == "zorder" for token in _lex_single_line(header)):
+        raise EditorSourceError("EXPLICIT_ZORDER_UNSUPPORTED", "explicit zorder is outside this structural operation")
+    return _button_block_span(lines, source_line)
+
+
+def _find_parent_line(lines: list[str], source_line: int) -> int:
+    target_indent = _header_indent(lines[source_line - 1])
+    for index in range(source_line - 2, -1, -1):
+        line = lines[index]
+        if not line.strip() or line.lstrip().startswith("#"):
+            continue
+        if _header_indent(line) < target_indent:
+            return index
+    return -1
+
+
+def _source_id_ownership_count(lines: list[str], widget_id: str) -> int:
+    count = 0
+    for line in lines:
+        if peek_statement_kind(line) != "button":
+            continue
+        try:
+            count += int(_literal_button_id(line) == widget_id)
+        except EditorSourceError:
+            continue
+    return count
+
+
+def analyze_raise_adjacent_sibling(
+    source_text: str,
+    *,
+    target_source_line: int,
+    sibling_source_line: int,
+    target_widget_id: str,
+    sibling_widget_id: str,
+) -> ButtonSiblingSwapPlan:
+    source_bytes = source_text.encode("utf-8")
+    lines = source_text.splitlines(keepends=True)
+    if target_source_line >= sibling_source_line:
+        raise EditorSourceError("BUTTON_SIBLING_ORDER_INVALID", "target must appear before its sibling")
+    if target_widget_id == sibling_widget_id:
+        raise EditorSourceError("AMBIGUOUS_OWNERSHIP", "target and sibling ids must be distinct")
+
+    target_span, target_next_line = _analyze_structural_button(lines, target_source_line, target_widget_id)
+    sibling_span, _ = _analyze_structural_button(lines, sibling_source_line, sibling_widget_id)
+    if _header_indent(lines[target_source_line - 1]) != _header_indent(lines[sibling_source_line - 1]):
+        raise EditorSourceError("SCREEN_SCOPE_MISMATCH", "buttons must have the same indentation")
+    target_parent = _find_parent_line(lines, target_source_line)
+    sibling_parent = _find_parent_line(lines, sibling_source_line)
+    if target_parent < 0 or target_parent != sibling_parent or peek_statement_kind(lines[target_parent]) != "screen":
+        raise EditorSourceError("PARENT_SCOPE_UNSUPPORTED", "buttons must be direct children of the same screen")
+    for line in lines[target_next_line - 1 : sibling_source_line - 1]:
+        stripped = line.strip()
+        if stripped and not stripped.startswith("#"):
+            raise EditorSourceError("NOT_ADJACENT_SIBLING", "target must be followed only by blank/comment separators")
+    if _source_id_ownership_count(lines, target_widget_id) != 1 or _source_id_ownership_count(lines, sibling_widget_id) != 1:
+        raise EditorSourceError("AMBIGUOUS_OWNERSHIP", "both button ids must have unique source ownership")
+    if not (target_span[0] < target_span[1] <= sibling_span[0] < sibling_span[1] <= len(source_bytes)):
+        raise EditorSourceError("BUTTON_SIBLING_SPAN_INVALID", "button spans are invalid or overlapping")
+    return ButtonSiblingSwapPlan(
+        target_widget_id=target_widget_id,
+        sibling_widget_id=sibling_widget_id,
+        target_source_line=target_source_line,
+        sibling_source_line=sibling_source_line,
+        target_block_span=target_span,
+        sibling_block_span=sibling_span,
+        baseline_sha256=hashlib.sha256(source_bytes).hexdigest(),
+    )
+
+
+def apply_button_sibling_swap(
+    source_bytes: bytes,
+    plan: ButtonSiblingSwapPlan,
+) -> tuple[bytes, tuple[tuple[str, int], tuple[str, int]]]:
+    if hashlib.sha256(source_bytes).hexdigest() != plan.baseline_sha256:
+        raise EditorSourceError("STALE_SOURCE", "source changed since structural analysis")
+    target_start, target_end = plan.target_block_span
+    sibling_start, sibling_end = plan.sibling_block_span
+    if not (0 <= target_start < target_end <= sibling_start < sibling_end <= len(source_bytes)):
+        raise EditorSourceError("BUTTON_SIBLING_SPAN_INVALID", "invalid structural swap spans")
+    target_block = source_bytes[target_start:target_end]
+    separator = source_bytes[target_end:sibling_start]
+    sibling_block = source_bytes[sibling_start:sibling_end]
+    staged = source_bytes[:target_start] + sibling_block + separator + target_block + source_bytes[sibling_end:]
+    sibling_line = staged[:target_start].count(b"\n") + 1
+    target_new_start = target_start + len(sibling_block) + len(separator)
+    target_line = staged[:target_new_start].count(b"\n") + 1
+    return staged, ((plan.target_widget_id, target_line), (plan.sibling_widget_id, sibling_line))

--- a/src/renforge/editor_zorder_runner.py
+++ b/src/renforge/editor_zorder_runner.py
@@ -84,11 +84,41 @@ def _probe(client: Any) -> dict[str, Any]:
         client.request("editor_task0_select", {"x": intersection[0], "y": intersection[1]}),
         "z-order overlap selection",
     )
+    target_selection = _require_ok(
+        client.request(
+            "editor_task0_select",
+            {"x": target["x"] + 20, "y": target["y"] + 20},
+        ),
+        "z-order target-only selection",
+    )
+    sibling_selection = _require_ok(
+        client.request(
+            "editor_task0_select",
+            {
+                "x": sibling["x"] + sibling["width"] - 20,
+                "y": sibling["y"] + 20,
+            },
+        ),
+        "z-order sibling-only selection",
+    )
+
+    def source_location(reply: dict[str, Any]) -> list[Any]:
+        observation = reply.get("observation")
+        runtime_key = observation.get("runtime_key") if isinstance(observation, dict) else None
+        location = runtime_key.get("source_location") if isinstance(runtime_key, dict) else None
+        if not isinstance(location, list) or len(location) != 2:
+            raise AssertionError(f"selection carries no runtime source location: {reply!r}")
+        return [str(location[0]), int(location[1])]
+
     return {
         "point": list(intersection),
         "pixel": list(pixel),
         "dominant": _dominant(pixel),
         "selected_widget_id": (selection.get("selected") or {}).get("widget_id"),
+        "runtime_source_locations": {
+            TARGET_ID: source_location(target_selection),
+            SIBLING_ID: source_location(sibling_selection),
+        },
         "target_bounds": target,
         "sibling_bounds": sibling,
     }
@@ -140,11 +170,11 @@ def run_editor_zorder_live_scenario(client: Any, *, fixture_path: Path) -> dict[
         and report["after_reload"]["dominant"] == "red"
         and report["after_reload"]["selected_widget_id"] == TARGET_ID
     )
-    report["stable_rebind"] = bool(
-        report["after_reload"].get("target_bounds")
-        and report["after_reload"].get("sibling_bounds")
-        and report["source_patch"]["locations"].get(TARGET_ID)
-        and report["source_patch"]["locations"].get(SIBLING_ID)
+    observed_locations = report["after_reload"]["runtime_source_locations"]
+    expected_locations = report["source_patch"]["locations"]
+    report["stable_rebind"] = all(
+        observed_locations[widget_id][1] == expected_locations[widget_id]
+        for widget_id in (TARGET_ID, SIBLING_ID)
     )
     report["verdict"] = "blocked"
     report["verdict_reason"] = "structural_transaction_undo_missing"

--- a/src/renforge/editor_zorder_runner.py
+++ b/src/renforge/editor_zorder_runner.py
@@ -1,0 +1,151 @@
+"""Live evidence runner for issue #49 adjacent-sibling z-order editing."""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import shutil
+import time
+from pathlib import Path
+from typing import Any
+
+from PIL import Image
+
+from renforge.editor.paths import atomic_write_file
+from renforge.editor.source import analyze_raise_adjacent_sibling, apply_button_sibling_swap
+from renforge.editor_live_common import wait_bounds
+from renforge.editor_task0_runner import _require_ok
+
+FIXTURE_SCREEN = "renforge_editor_zorder_fixture"
+TARGET_ID = "zorder_target"
+SIBLING_ID = "zorder_sibling"
+FIXTURE_RESOURCE = (
+    Path(__file__).resolve().parents[2]
+    / "tests"
+    / "live_fixtures"
+    / "renforge_editor_zorder_fixture.rpy"
+)
+
+
+def inject_editor_zorder_resources(project_root: Path) -> Path:
+    target = project_root / "game" / "zz_renforge_editor_zorder_fixture.rpy"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(FIXTURE_RESOURCE, target)
+    return target
+
+
+def _source_line(source: str, widget_id: str) -> int:
+    matches = [
+        index
+        for index, line in enumerate(source.splitlines(), start=1)
+        if line.lstrip().startswith("button ") and f'id "{widget_id}"' in line
+    ]
+    if len(matches) != 1:
+        raise AssertionError(f"expected one source owner for {widget_id!r}, got {matches!r}")
+    return matches[0]
+
+
+def _sample_rgb(client: Any, point: tuple[int, int]) -> tuple[int, int, int]:
+    image = Image.open(io.BytesIO(client.screenshot())).convert("RGB")
+    pixel = image.getpixel(point)
+    if isinstance(pixel, int):
+        return pixel, pixel, pixel
+    return int(pixel[0]), int(pixel[1]), int(pixel[2])
+
+
+def _dominant(rgb: tuple[int, int, int]) -> str:
+    red, green, blue = rgb
+    if red > blue + 35 and red > green + 35:
+        return "red"
+    if blue > red + 35 and blue > green + 35:
+        return "blue"
+    return "unknown"
+
+
+def _show_fixture(client: Any) -> None:
+    last: Any = None
+    for _ in range(60):
+        last = client.request("editor_task0_start", {"screen": FIXTURE_SCREEN})
+        if isinstance(last, dict) and last.get("ok") is True:
+            return
+        time.sleep(0.1)
+    raise AssertionError(f"fixture did not start: {last!r}")
+
+
+def _probe(client: Any) -> dict[str, Any]:
+    target = wait_bounds(client, TARGET_ID, fixture_screen=FIXTURE_SCREEN)
+    sibling = wait_bounds(client, SIBLING_ID, fixture_screen=FIXTURE_SCREEN)
+    intersection = (
+        max(target["x"], sibling["x"]) + 20,
+        max(target["y"], sibling["y"]) + 20,
+    )
+    pixel = _sample_rgb(client, intersection)
+    selection = _require_ok(
+        client.request("editor_task0_select", {"x": intersection[0], "y": intersection[1]}),
+        "z-order overlap selection",
+    )
+    return {
+        "point": list(intersection),
+        "pixel": list(pixel),
+        "dominant": _dominant(pixel),
+        "selected_widget_id": (selection.get("selected") or {}).get("widget_id"),
+        "target_bounds": target,
+        "sibling_bounds": sibling,
+    }
+
+
+def run_editor_zorder_live_scenario(client: Any, *, fixture_path: Path) -> dict[str, Any]:
+    baseline = fixture_path.read_bytes()
+    baseline_sha = hashlib.sha256(baseline).hexdigest()
+    source = baseline.decode("utf-8")
+    report: dict[str, Any] = {"baseline_sha256": baseline_sha}
+
+    _show_fixture(client)
+    report["before"] = _probe(client)
+
+    plan = analyze_raise_adjacent_sibling(
+        source,
+        target_source_line=_source_line(source, TARGET_ID),
+        sibling_source_line=_source_line(source, SIBLING_ID),
+        target_widget_id=TARGET_ID,
+        sibling_widget_id=SIBLING_ID,
+    )
+    staged, locations = apply_button_sibling_swap(baseline, plan)
+    report["source_patch"] = {
+        "changed": staged != baseline,
+        "size_delta": len(staged) - len(baseline),
+        "locations": dict(locations),
+        "staged_sha256": hashlib.sha256(staged).hexdigest(),
+    }
+
+    try:
+        atomic_write_file(fixture_path, staged)
+        _require_ok(client.control("reload_script"), "z-order reload")
+        _show_fixture(client)
+        report["after_reload"] = _probe(client)
+    finally:
+        atomic_write_file(fixture_path, baseline)
+        _require_ok(client.control("reload_script"), "z-order restore reload")
+        _show_fixture(client)
+
+    restored = fixture_path.read_bytes()
+    report["after_restore"] = _probe(client)
+    report["restore"] = {
+        "sha256": hashlib.sha256(restored).hexdigest(),
+        "byte_identical": restored == baseline,
+    }
+    report["runtime_result_proven"] = (
+        report["before"]["dominant"] == "blue"
+        and report["before"]["selected_widget_id"] == SIBLING_ID
+        and report["after_reload"]["dominant"] == "red"
+        and report["after_reload"]["selected_widget_id"] == TARGET_ID
+    )
+    report["stable_rebind"] = bool(
+        report["after_reload"].get("target_bounds")
+        and report["after_reload"].get("sibling_bounds")
+        and report["source_patch"]["locations"].get(TARGET_ID)
+        and report["source_patch"]["locations"].get(SIBLING_ID)
+    )
+    report["verdict"] = "blocked"
+    report["verdict_reason"] = "structural_transaction_undo_missing"
+    return report

--- a/tests/live_fixtures/renforge_editor_zorder_fixture.rpy
+++ b/tests/live_fixtures/renforge_editor_zorder_fixture.rpy
@@ -13,7 +13,7 @@ screen renforge_editor_zorder_fixture():
         add Solid("#d83a3a", xysize=(180, 100))
 
     # This separator must remain byte-identical while the blocks move.
-    button id "zorder_sibling" xpos 220 ypos 220 xsize 180 ysize 100:
+    button id "zorder_sibling" xpos 260 ypos 220 xsize 180 ysize 100:
         action NullAction()
         background None
         hover_background None

--- a/tests/live_fixtures/renforge_editor_zorder_fixture.rpy
+++ b/tests/live_fixtures/renforge_editor_zorder_fixture.rpy
@@ -1,0 +1,20 @@
+# Spike fixture for issue #49 — two overlapping direct sibling buttons.
+
+screen renforge_editor_zorder_fixture():
+    layer "screens"
+    zorder 640
+
+    add Solid("#0a0a0a", xysize=(1280, 720))
+
+    button id "zorder_target" xpos 220 ypos 220 xsize 180 ysize 100:
+        action NullAction()
+        background None
+        hover_background None
+        add Solid("#d83a3a", xysize=(180, 100))
+
+    # This separator must remain byte-identical while the blocks move.
+    button id "zorder_sibling" xpos 220 ypos 220 xsize 180 ysize 100:
+        action NullAction()
+        background None
+        hover_background None
+        add Solid("#2457d6", xysize=(180, 100))

--- a/tests/test_editor_source.py
+++ b/tests/test_editor_source.py
@@ -1606,3 +1606,24 @@ def test_analyze_raise_adjacent_sibling_rejects_explicit_zorder() -> None:
             sibling_widget_id="sibling",
         )
     assert error.value.code == "EXPLICIT_ZORDER_UNSUPPORTED"
+
+
+def test_analyze_raise_adjacent_sibling_rejects_unresolved_button_ids() -> None:
+    source = (
+        "screen test_screen:\n"
+        '    button id "target":\n'
+        '        text "A"\n'
+        '    button id "sibling":\n'
+        '        text "B"\n'
+        "    button id dynamic_id:\n"
+        '        text "unknown owner"\n'
+    )
+    with pytest.raises(EditorSourceError) as error:
+        analyze_raise_adjacent_sibling(
+            source,
+            target_source_line=2,
+            sibling_source_line=4,
+            target_widget_id="target",
+            sibling_widget_id="sibling",
+        )
+    assert error.value.code == "AMBIGUOUS_OWNERSHIP"

--- a/tests/test_editor_source.py
+++ b/tests/test_editor_source.py
@@ -7,11 +7,13 @@ import pytest
 from renforge.editor.paths import EditorPathError, resolve_game_path
 from renforge.editor.source import (
     BarStatement,
+    ButtonSiblingSwapPlan,
     ButtonStatement,
     EditorSourceError,
     SliderStatement,
     TextbuttonStatement,
     VbarStatement,
+    analyze_raise_adjacent_sibling,
     analyze_bar_statement,
     analyze_button_statement,
     analyze_editable_statement,
@@ -22,6 +24,7 @@ from renforge.editor.source import (
     analyze_vbar_statement,
     apply_bar_patch,
     apply_button_patch,
+    apply_button_sibling_swap,
     apply_editable_statement_patch,
     apply_imagebutton_patch,
     apply_slider_patch,
@@ -1485,3 +1488,121 @@ def test_analyze_bar_statement_resize_lock_matrix(line: str, code: str) -> None:
     parsed = analyze_bar_statement(line, expected_widget_id="b")
     assert parsed.size_mode is None
     assert parsed.resize_lock_code == code
+
+
+def test_raise_adjacent_sibling_swaps_exact_utf8_blocks_and_reports_new_lines() -> None:
+    source = (
+        "# prélude\n"
+        "screen test_screen:\n"
+        '    button id "target":\n'
+        '        text "café"\n'
+        "        action NullAction()\n"
+        "\n"
+        "    # separator stays in place\n"
+        '    button id "sibling":\n'
+        '        text "β"\n'
+    )
+    plan = analyze_raise_adjacent_sibling(
+        source,
+        target_source_line=3,
+        sibling_source_line=8,
+        target_widget_id="target",
+        sibling_widget_id="sibling",
+    )
+    assert isinstance(plan, ButtonSiblingSwapPlan)
+
+    staged, locations = apply_button_sibling_swap(source.encode(), plan)
+
+    assert staged.decode() == (
+        "# prélude\n"
+        "screen test_screen:\n"
+        '    button id "sibling":\n'
+        '        text "β"\n'
+        "\n"
+        "    # separator stays in place\n"
+        '    button id "target":\n'
+        '        text "café"\n'
+        "        action NullAction()\n"
+    )
+    assert locations == (("target", 7), ("sibling", 3))
+
+
+def test_apply_raise_adjacent_sibling_rejects_stale_source() -> None:
+    source = (
+        "screen test_screen:\n"
+        '    button id "target":\n'
+        '        text "A"\n'
+        '    button id "sibling":\n'
+        '        text "B"\n'
+    )
+    plan = analyze_raise_adjacent_sibling(
+        source,
+        target_source_line=2,
+        sibling_source_line=4,
+        target_widget_id="target",
+        sibling_widget_id="sibling",
+    )
+    with pytest.raises(EditorSourceError) as error:
+        apply_button_sibling_swap(("# changed\n" + source).encode(), plan)
+    assert error.value.code == "STALE_SOURCE"
+
+
+def test_analyze_raise_adjacent_sibling_requires_adjacent_children() -> None:
+    source = (
+        "screen test_screen:\n"
+        '    button id "target" xpos 12 ypos 10:\n'
+        '        text "A"\n'
+        "    text \"intervening statement\"\n"
+        "    # separator\n"
+        '    button id "sibling" xpos 20 ypos 18:\n'
+        '        text "B"\n'
+    )
+    with pytest.raises(EditorSourceError) as error:
+        analyze_raise_adjacent_sibling(
+            source,
+            target_source_line=2,
+            sibling_source_line=6,
+            target_widget_id="target",
+            sibling_widget_id="sibling",
+        )
+    assert error.value.code == "NOT_ADJACENT_SIBLING"
+
+
+def test_analyze_raise_adjacent_sibling_rejects_duplicate_source_ownership() -> None:
+    source = (
+        "screen test_screen:\n"
+        '    button id "target":\n'
+        '        text "A"\n'
+        '    button id "sibling":\n'
+        '        text "B"\n'
+        '    button id "target":\n'
+        '        text "duplicate"\n'
+    )
+    with pytest.raises(EditorSourceError) as error:
+        analyze_raise_adjacent_sibling(
+            source,
+            target_source_line=2,
+            sibling_source_line=4,
+            target_widget_id="target",
+            sibling_widget_id="sibling",
+        )
+    assert error.value.code == "AMBIGUOUS_OWNERSHIP"
+
+
+def test_analyze_raise_adjacent_sibling_rejects_explicit_zorder() -> None:
+    source = (
+        "screen test_screen:\n"
+        '    button id "target" zorder 3:\n'
+        '        text "A"\n'
+        '    button id "sibling":\n'
+        '        text "B"\n'
+    )
+    with pytest.raises(EditorSourceError) as error:
+        analyze_raise_adjacent_sibling(
+            source,
+            target_source_line=2,
+            sibling_source_line=4,
+            target_widget_id="target",
+            sibling_widget_id="sibling",
+        )
+    assert error.value.code == "EXPLICIT_ZORDER_UNSUPPORTED"

--- a/tests/test_editor_zorder_live.py
+++ b/tests/test_editor_zorder_live.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import os
+import shutil
+import time
+from pathlib import Path
+
+import pytest
+
+from renforge.editor_zorder_runner import (
+    FIXTURE_SCREEN,
+    SIBLING_ID,
+    TARGET_ID,
+    inject_editor_zorder_resources,
+    run_editor_zorder_live_scenario,
+)
+
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("RENFORGE_ZORDER_LIVE"),
+    reason="set RENFORGE_ZORDER_LIVE=1 to run issue #49 z-order spike",
+)
+
+_DEMO = Path(__file__).resolve().parents[1] / "examples" / "demo_game"
+
+
+@pytest.fixture
+def demo_copy(tmp_path: Path) -> Path:
+    destination = tmp_path / "demo"
+    shutil.copytree(_DEMO, destination, ignore=shutil.ignore_patterns("*.rpyc", "cache"))
+    inject_editor_zorder_resources(destination)
+    return destination
+
+
+def _open_editor(session) -> None:
+    for _ in range(40):
+        if session.client.inspect_screen("_renforge_editor_launcher").get("active") is True:
+            break
+        time.sleep(0.2)
+    else:
+        pytest.fail("editor launcher never became active")
+
+    assert session.client.click_element(
+        text="RF", exact=True, screen="_renforge_editor_launcher"
+    ).get("ok") is True
+    for _ in range(40):
+        if session.client.inspect_screen("_renforge_editor_overlay").get("active") is True:
+            return
+        time.sleep(0.05)
+    pytest.fail("editor overlay never became active")
+
+
+def test_zorder_source_swap_is_live_but_product_remains_blocked(demo_copy: Path) -> None:
+    from renforge.bridge.launcher import launch_with_bridge
+    from renforge.project import RenpyProject
+    from renforge.sdk import get_or_install_sdk
+
+    sdk = get_or_install_sdk("8.5.3", project_root=demo_copy)
+    fixture_path = demo_copy / "game" / "zz_renforge_editor_zorder_fixture.rpy"
+
+    with launch_with_bridge(sdk, RenpyProject(demo_copy), startup_timeout=120, editor=True) as session:
+        _open_editor(session)
+        report = run_editor_zorder_live_scenario(session.client, fixture_path=fixture_path)
+
+    assert report["before"]["dominant"] == "blue", report
+    assert report["before"]["selected_widget_id"] == SIBLING_ID
+    assert report["after_reload"]["dominant"] == "red"
+    assert report["after_reload"]["selected_widget_id"] == TARGET_ID
+    assert report["runtime_result_proven"] is True
+    assert report["stable_rebind"] is True
+    assert report["source_patch"]["changed"] is True
+    assert report["source_patch"]["size_delta"] == 0
+    assert report["restore"]["byte_identical"] is True
+    assert report["restore"]["sha256"] == report["baseline_sha256"]
+    assert report["verdict"] == "blocked"
+    assert report["verdict_reason"] == "structural_transaction_undo_missing"
+    assert FIXTURE_SCREEN == "renforge_editor_zorder_fixture"

--- a/tests/test_editor_zorder_live.py
+++ b/tests/test_editor_zorder_live.py
@@ -67,6 +67,12 @@ def test_zorder_source_swap_is_live_but_product_remains_blocked(demo_copy: Path)
     assert report["after_reload"]["selected_widget_id"] == TARGET_ID
     assert report["runtime_result_proven"] is True
     assert report["stable_rebind"] is True
+    assert report["after_reload"]["runtime_source_locations"][TARGET_ID][1] == report[
+        "source_patch"
+    ]["locations"][TARGET_ID]
+    assert report["after_reload"]["runtime_source_locations"][SIBLING_ID][1] == report[
+        "source_patch"
+    ]["locations"][SIBLING_ID]
     assert report["source_patch"]["changed"] is True
     assert report["source_patch"]["size_delta"] == 0
     assert report["restore"]["byte_identical"] is True


### PR DESCRIPTION
## Summary

- define the frozen `raise_adjacent_sibling` source operation for direct screen button siblings
- add UTF-8 byte-safe spans, source ownership checks, stale-SHA rejection, and post-swap source-line rebinding
- prove paint order and focus order across a real Ren'Py 8.5.3 reload
- document the evidence-gated verdict: `BLOCKED — structural_transaction_undo_missing`
- keep the operation out of the coordinator and UI until product-level conditional rollback and structural undo exist

## Evidence

- source tests: `89 passed`
- full suite: `637 passed, 44 skipped`
- live Ren'Py: `1 passed in 8.21s`
- `python -m compileall -q src/renforge tests`
- `git diff --check`

Refs #49

## Summary by Sourcery

Ajouter une opération figée de remontée de frère structurel dans le z-order avec une analyse sécurisée de la source, un exécuteur de preuves Ren’Py en temps réel, et de la documentation, tout en maintenant la fonctionnalité bloquée dans l’interface produit.

Nouvelles fonctionnalités :
- Introduire une opération structurelle `raise_adjacent_sibling` qui échange en toute sécurité deux blocs de boutons adjacents à l’intérieur d’un fichier source d’écran.
- Ajouter un exécuteur de scénarios de z-order Ren’Py 8.5.3 en temps réel et un fixture pour valider empiriquement l’ordre de rendu (paint) et de focus après l’échange de la source.

Améliorations :
- Renforcer l’analyse de la source dans l’éditeur avec des plages de blocs sûres en octets UTF-8, des vérifications de propriété des identifiants littéraux, une validation du parent/de l’indentation, et un rejet explicite du `zorder` pour les éditions structurelles.
- Lier les plans d’échange structurels à un SHA-256 de référence et recalculer les lignes de source après l’échange afin de se prémunir contre des plages de source obsolètes ou chevauchantes.
- Documenter les critères structurels, les exigences transactionnelles et les verdicts fondés sur les preuves pour l’édition du z-order en source sûre, y compris le verdict actuel BLOQUÉ (BLOCKED).
- Garantir que l’expérimentation structurelle sur le z-order ne fonctionne qu’en tant que preuve interne et reste indisponible dans le coordinateur et l’interface utilisateur tant que la prise en charge des transactions structurelles et de l’annulation n’existe pas.

Tests :
- Ajouter des tests unitaires couvrant les échanges de frères réussis, le rejet de sources obsolètes, la validation de l’adjacence et de la propriété, ainsi que le rejet explicite du `zorder` pour les boutons structurels.
- Ajouter un test d’intégration Ren’Py en temps réel, activable sur option, qui exécute le fixture de z-order, valide les changements d’ordre de rendu/focus à l’exécution, et confirme la restauration byte-identique de la source du fixture.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a frozen structural z-order sibling-raising operation with source-safe analysis, a live Ren'Py evidence runner, and documentation, while keeping the feature blocked from the product UI.

New Features:
- Introduce a structural raise_adjacent_sibling operation that swaps two adjacent button blocks safely within a screen source file.
- Add a live Ren'Py 8.5.3 z-order scenario runner and fixture to empirically validate paint and focus order after the source swap.

Enhancements:
- Strengthen editor source analysis with UTF-8 byte-safe block spans, literal ID ownership checks, parent/indentation validation, and explicit zorder rejection for structural edits.
- Bind structural swap plans to a baseline SHA-256 and recompute post-swap source lines to guard against stale or overlapping source spans.
- Document the structural criteria, transactional requirements, and evidence-based verdicts for source-safe z-order editing, including the current BLOCKED verdict.
- Ensure the z-order structural spike operates only as internal evidence and remains unavailable in the coordinator and UI until structural transaction and undo support exist.

Tests:
- Add unit tests covering successful sibling swaps, stale-source rejection, adjacency and ownership validation, and explicit zorder rejection for structural buttons.
- Add an opt-in live Ren'Py integration test that runs the z-order fixture, validates runtime paint/focus order changes, and confirms byte-identical restoration of the fixture source.

</details>