### PR TITLE
test(editor): add style color evidence spike

### DIFF
--- a/docs/superpowers/spikes/2026-08-02-style-color-criteria.md
+++ b/docs/superpowers/spikes/2026-08-02-style-color-criteria.md
@@ -1,0 +1,104 @@
+# Issue #50 — style colour source-write criteria (frozen before implementation)
+
+**Status:** criteria locked before measurement.
+**SDK:** Ren'Py **8.5.3** only.
+**Surface:** in-game bridge (production style control stays disabled until PASS).
+**Frozen pair:** adapter `text`, property `color` (one property, one adapter).
+
+## Question
+
+Can RenForge:
+
+1. resolve ownership of a pure literal `color` on a single-line screen-language `text` statement;
+2. fail closed for inherited, expression, ambiguous, multi-instance, stale, malformed, unsupported, or non-text cases;
+3. patch only that colour token while preserving every unrelated byte and the supported authored form;
+4. prove the full product chain on Ren'Py 8.5.3: select/resolve → preview → source patch → reload → independent pixel colour change → rebind → refused-attestation rollback → **product** undo?
+
+## Explicit non-goals
+
+- fonts, padding, hover/idle/selected colour families;
+- style panels or generic property registries;
+- a second adapter or a second property;
+- routing style writes through coordinate-token / xpos-ypos semantics;
+- silently widening scope when this pair is unsafe.
+
+## Evidence planes (independent)
+
+| Plane | Must measure | How |
+| --- | --- | --- |
+| **Ownership** | Direct authored `color` vs inherited/expression/ambiguous | source analyser lock codes; do not infer from runtime style |
+| **Source write** | Only the colour string token changes | independent expected constructor + outside-span identity |
+| **Pixel colour** | Painted colour at a fixed probe point | screenshot RGB sample; not editor/runtime colour claims |
+| **Product path** | select, preview, commit, rebind, refused attestation, product undo | real bridge + coordinator commands only |
+
+## Supported authored form (unlocked)
+
+Single physical line:
+
+```text
+text "LABEL" color "#rrggbb" id "widget_id" …
+```
+
+- statement kind is exactly `text` (not `textbutton`, not a block header);
+- exactly one pure string-literal `color` whose value is `#rgb`, `#rrggbb`, or `#rrggbbaa`;
+- exactly one pure string-literal `id` matching the runtime widget id;
+- no expression/operator tokens after the colour literal.
+
+## Fail-closed lock codes (stable)
+
+| Code | Meaning |
+| --- | --- |
+| `STATEMENT_KIND_MISMATCH` | not a single-line `text` statement |
+| `MULTILINE_STATEMENT_REJECTED` | block form (`:`) |
+| `ID_LITERAL_REQUIRED` / `ID_MISMATCH` | missing/invalid/mismatched id |
+| `STYLE_COLOR_NOT_DIRECTLY_AUTHORED` | no `color` keyword (inherited / style-driven) |
+| `STYLE_COLOR_LITERAL_REQUIRED` | colour is not a pure string literal |
+| `STYLE_COLOR_UNSUPPORTED_FORM` | string is not a supported hex form |
+| `STYLE_COLOR_DUPLICATE` | more than one `color` keyword |
+| `STYLE_COLOR_EXPRESSION_UNSUPPORTED` | expression / compound colour value |
+| `STYLE_COLOR_HEX_FAMILY_MISMATCH` | requested value changes the authored hex length |
+| `STALE_SOURCE` | statement bytes changed after analysis |
+
+Non-text adapters never unlock style colour through this contract.
+
+## Pass / blocked / inconclusive (frozen)
+
+### PASS
+
+All of the following are observed on Ren'Py 8.5.3:
+
+1. Select/resolve unlocks style colour for the target (`statement_kind=text`, `style_mode=literal_hex`, no lock).
+2. Preview changes painted colour without writing source (independent screenshot evidence).
+3. Source patch rewrites only the colour token; outside bytes identical; form preserved (same quotes / hex family).
+4. Save → shadow validate → atomic publish → reload succeeds; script generation advances.
+5. Post-reload pixel sample matches the requested colour class (independent of editor claims).
+6. Runtime source-location rebinding succeeds for the same stable id.
+7. One deliberately refused attestation rolls the staged transaction back (source bytes unchanged).
+8. Product undo (editor undo / product transaction) restores baseline bytes — **not** a manual fixture restore.
+
+### BLOCKED
+
+Any mandatory product seam is absent or fails while source ownership is otherwise well-defined, including:
+
+- plain `text` is not selectable via the production focus_list path;
+- no style-colour preview / intent / coordinator transaction path is enabled;
+- product undo for style colour is missing (fixture restore only);
+- any required gate cannot be closed without widening beyond the frozen pair.
+
+Record **one** stable `verdict_reason`. Keep production style UI/control disabled.
+
+### INCONCLUSIVE
+
+- required ids/spans cannot be resolved;
+- pixel probe is ambiguous for the fixture (anti-alias / subpixel noise not resolvable);
+- identical runs disagree on verdict class.
+
+## Stop conditions
+
+- If the frozen pair is unsafe or unavailable, stop and report BLOCKED — do not switch adapter/property.
+- If a mandatory seam is missing, do not invent alternate UI surfaces or a second property.
+- Manual fixture restore may appear in reports only as cleanup, never as product-undo evidence.
+
+## Deliverable
+
+One report from `run_editor_style_color_live_scenario` with `verdict` in `{pass, blocked, inconclusive}`, explicit evidence fields, and a single stable `verdict_reason` when not PASS.

--- a/docs/superpowers/spikes/2026-08-02-style-color-result.md
+++ b/docs/superpowers/spikes/2026-08-02-style-color-result.md
@@ -28,7 +28,7 @@ Manual fixture restore after the live run is **cleanup only**, not product undo.
 - Fail-closed locks: inherited, expression, unsupported form, duplicate, non-text, block form, id mismatch
 - Unrelated bytes, quote form, and hex family preserved; stale source rejected
 
-Unit suite: `tests/test_editor_style_color_source.py` — **18 passed**
+Unit suite: `tests/test_editor_style_color_source.py` — **21 passed**
 
 ## Live Ren'Py 8.5.3 evidence (observed)
 
@@ -36,7 +36,7 @@ Opt-in: `RENFORGE_STYLE_COLOR_LIVE=1`
 
 ```text
 RENFORGE_STYLE_COLOR_LIVE=1 PYTHONPATH=src python -m pytest -q tests/test_editor_style_color_live.py
-# 1 passed in 8.99s
+# 1 passed in 9.39s
 ```
 
 Fixture: large red `text "STYLE" color "#e22b2b"` → dedicated patch to `#2457d6`,
@@ -46,17 +46,17 @@ plus inherited and expression lock controls.
 | --- | --- |
 | Source unlock | target unlocks (`literal_hex`); inherited → `STYLE_COLOR_NOT_DIRECTLY_AUTHORED`; expression → `STYLE_COLOR_LITERAL_REQUIRED` |
 | Source patch | only colour token rewritten; outside-span identity true; independent expected match true |
-| Pixel before | independent PNG region sample dominant **red** (not scene-tree style metadata) |
-| Pixel after reload | independent PNG region sample dominant **blue** after `reload_script` + re-show; published source reads the requested literal |
+| Pixel before | independent PNG region sample dominant **red**, sampled inside target bounds located from the live scene tree |
+| Pixel after reload | independent PNG region sample dominant **blue** after `reload_script` + re-show, again inside live scene-tree bounds; published source reads the requested literal |
 | Product select on glyph | does **not** unlock style colour (`product_select_unlocked_style=false`) |
-| Product preview/commit/undo | all **false** / unavailable |
-| Refused-attestation rollback | **false** / unavailable |
+| Product preview/commit/undo | all absent in the capability map observed from `editor_task0_status` |
+| Refused-attestation rollback | absent in the same observed capability map |
 | Fixture restore | byte-identical baseline restore; note = cleanup, not product undo |
 | Verdict | `blocked` / `style_color_product_path_missing` |
 
 Live test: `tests/test_editor_style_color_live.py` — **1 passed**
 
-Full suite: **656 passed, 45 skipped**. `compileall` and `git diff --check` passed.
+Full suite: **659 passed, 45 skipped**. `compileall` and `git diff --check` passed.
 
 ## Why blocked (one stable reason)
 

--- a/docs/superpowers/spikes/2026-08-02-style-color-result.md
+++ b/docs/superpowers/spikes/2026-08-02-style-color-result.md
@@ -1,0 +1,77 @@
+# Issue #50 — style colour source-write result
+
+## Verdict
+
+**`BLOCKED` — `style_color_product_path_missing`**
+
+The dedicated `text` + `color` source-write contract is implemented and proven
+(unit + live Ren'Py 8.5.3 pixel evidence). Production style editing remains
+**disabled**: plain `text` is outside the focus_list selection path, and no
+style-colour preview, coordinator intent, refused-attestation rollback, or
+**product** undo surface is enabled.
+
+Manual fixture restore after the live run is **cleanup only**, not product undo.
+
+## Frozen pair
+
+| Field | Value |
+| --- | --- |
+| Adapter | `text` |
+| Property | `color` |
+| Unlocked form | single-line pure hex string literal (`#rgb` / `#rrggbb` / `#rrggbbaa`) |
+| Style mode | `literal_hex` |
+
+## Source contract
+
+- `analyze_text_color_style` / `apply_text_color_patch` in `renforge.editor.source`
+- Dedicated colour-token spans — **not** coordinate token semantics
+- Fail-closed locks: inherited, expression, unsupported form, duplicate, non-text, block form, id mismatch
+- Unrelated bytes, quote form, and hex family preserved; stale source rejected
+
+Unit suite: `tests/test_editor_style_color_source.py` — **18 passed**
+
+## Live Ren'Py 8.5.3 evidence (observed)
+
+Opt-in: `RENFORGE_STYLE_COLOR_LIVE=1`
+
+```text
+RENFORGE_STYLE_COLOR_LIVE=1 PYTHONPATH=src python -m pytest -q tests/test_editor_style_color_live.py
+# 1 passed in 8.99s
+```
+
+Fixture: large red `text "STYLE" color "#e22b2b"` → dedicated patch to `#2457d6`,
+plus inherited and expression lock controls.
+
+| Plane | Observed |
+| --- | --- |
+| Source unlock | target unlocks (`literal_hex`); inherited → `STYLE_COLOR_NOT_DIRECTLY_AUTHORED`; expression → `STYLE_COLOR_LITERAL_REQUIRED` |
+| Source patch | only colour token rewritten; outside-span identity true; independent expected match true |
+| Pixel before | independent PNG region sample dominant **red** (not scene-tree style metadata) |
+| Pixel after reload | independent PNG region sample dominant **blue** after `reload_script` + re-show; published source reads the requested literal |
+| Product select on glyph | does **not** unlock style colour (`product_select_unlocked_style=false`) |
+| Product preview/commit/undo | all **false** / unavailable |
+| Refused-attestation rollback | **false** / unavailable |
+| Fixture restore | byte-identical baseline restore; note = cleanup, not product undo |
+| Verdict | `blocked` / `style_color_product_path_missing` |
+
+Live test: `tests/test_editor_style_color_live.py` — **1 passed**
+
+Full suite: **656 passed, 45 skipped**. `compileall` and `git diff --check` passed.
+
+## Why blocked (one stable reason)
+
+`style_color_product_path_missing`
+
+Mandatory product seams for PASS are absent after source + pixel proof:
+
+1. production selection uses `focus_list` — plain `text` is non-focusable;
+2. no style-colour preview / intent / coordinator commit path;
+3. no refused-attestation rollback or **product** undo for style colour
+   (fixture restore is cleanup only).
+
+Widening into Stage 3 non-focusable selection or a second adapter/property is
+out of frozen scope. Production style UI/control stays disabled.
+
+## Criteria
+
+`docs/superpowers/spikes/2026-08-02-style-color-criteria.md`

--- a/src/renforge/editor/source.py
+++ b/src/renforge/editor/source.py
@@ -21,6 +21,8 @@ DEFAULT_ALIGN_PARENT_SIZE: tuple[int, int] = (1280, 720)
 # write-back is authored + (runtime − baseline). Preview uses absolute xpos/ypos.
 RUNTIME_DELTA_POSITION_MODES = frozenset({"align", "offset"})
 BAR_SIZE_MODE_XSIZE_YSIZE = "xsize_ysize"
+# Issue #50: pure hex string-literal ``color`` on a single-line ``text`` statement.
+TEXT_STYLE_COLOR_MODE_LITERAL = "literal_hex"
 
 
 class _BarSizeModel(TypedDict):
@@ -212,6 +214,26 @@ class SliderStatement:
     ypos: int
     xpos_span: tuple[int, int]
     ypos_span: tuple[int, int]
+
+
+@dataclass(frozen=True)
+class TextColorStyleStatement:
+    """Style-colour ownership for a single-line screen-language ``text`` statement.
+
+    Unlocked only when a pure hex string-literal ``color`` is authored on the
+    statement itself. Inherited, expression, and unsupported forms leave
+    ``style_mode``/``color`` empty and set a stable lock code. Spans are
+    relative to the single statement line (including quotes on the colour token).
+    """
+
+    widget_id: str
+    color: str | None = None
+    color_span: tuple[int, int] | None = None
+    quote_char: str | None = None
+    baseline_sha256: str | None = None
+    style_mode: str | None = None
+    style_lock_code: str | None = None
+    style_lock_message: str | None = None
 
 
 _StatementT = TypeVar(
@@ -2097,3 +2119,257 @@ def apply_button_sibling_swap(
     target_new_start = target_start + len(sibling_block) + len(separator)
     target_line = staged[:target_new_start].count(b"\n") + 1
     return staged, ((plan.target_widget_id, target_line), (plan.sibling_widget_id, sibling_line))
+
+
+# ---------------------------------------------------------------------------
+# Issue #50 — dedicated style-colour source contract (text + color only)
+# ---------------------------------------------------------------------------
+
+# Property keywords that may follow a pure colour string on a ``text`` line.
+# Expression operators (if/or/else/and) are intentionally absent so compound
+# colour values fail closed rather than looking like pure literals.
+_TEXT_COLOR_FOLLOWER_WORDS = frozenset(
+    {
+        "id",
+        "xpos",
+        "ypos",
+        "pos",
+        "align",
+        "offset",
+        "anchor",
+        "xalign",
+        "yalign",
+        "xanchor",
+        "yanchor",
+        "xoffset",
+        "yoffset",
+        "xcenter",
+        "ycenter",
+        "xsize",
+        "ysize",
+        "xmaximum",
+        "ymaximum",
+        "xminimum",
+        "yminimum",
+        "xfill",
+        "yfill",
+        "size",
+        "font",
+        "bold",
+        "italic",
+        "underline",
+        "strikethrough",
+        "kerning",
+        "line_spacing",
+        "justify",
+        "textalign",
+        "layout",
+        "style",
+        "tooltip",
+        "substitute",
+        "slow_cps",
+        "slow_abortable",
+    }
+)
+
+
+def _is_hex_color_literal(value: str) -> bool:
+    """True for ``#rgb``, ``#rrggbb``, or ``#rrggbbaa`` (case-insensitive)."""
+    if not isinstance(value, str) or not value.startswith("#"):
+        return False
+    body = value[1:]
+    if len(body) not in (3, 6, 8):
+        return False
+    return all(ch in "0123456789abcdefABCDEF" for ch in body)
+
+
+def _normalize_hex_color_for_write(value: str) -> str:
+    """Return a write-safe hex colour; raises on unsupported forms."""
+    if not _is_hex_color_literal(value):
+        raise EditorSourceError(
+            "STYLE_COLOR_UNSUPPORTED_FORM",
+            "color must be a #rgb, #rrggbb, or #rrggbbaa hex literal",
+        )
+    return "#" + value[1:].lower()
+
+
+def _text_style_lock(code: str, message: str) -> tuple[str, str]:
+    return code, message
+
+
+def analyze_text_color_style(line: str, *, expected_widget_id: str) -> TextColorStyleStatement:
+    """Analyze ownership of a pure literal ``color`` on a single-line ``text``.
+
+    This is a dedicated style contract — not a position/size analyser. Coordinate
+    tokens are ignored except as follower words that prove a pure colour literal.
+    """
+    statement_text = _statement_text(line)
+    tokens = _lex_single_line(statement_text)
+    top_level = [token for token in tokens if token.depth == 0]
+    if not top_level or top_level[0].kind != "WORD" or top_level[0].text != "text":
+        raise EditorSourceError(
+            "STATEMENT_KIND_MISMATCH",
+            "style colour contract only supports single-line text statements",
+        )
+    if any(token.kind == "SYMBOL" and token.text == ":" for token in top_level):
+        raise EditorSourceError(
+            "MULTILINE_STATEMENT_REJECTED",
+            "text style colour requires a single-line statement",
+        )
+
+    widget_id = _require_single_literal_id(
+        tokens,
+        expected_widget_id=expected_widget_id,
+        human_kind="text",
+    )
+
+    color_count = 0
+    color_value: str | None = None
+    color_span: tuple[int, int] | None = None
+    quote_char: str | None = None
+    lock_code: str | None = None
+    lock_message: str | None = None
+
+    for index, token in enumerate(tokens):
+        if token.depth != 0 or token.kind != "WORD" or token.text != "color":
+            continue
+        color_count += 1
+        value_index = _next_top_level_index(tokens, index)
+        if value_index is None:
+            lock_code, lock_message = _text_style_lock(
+                "STYLE_COLOR_LITERAL_REQUIRED",
+                "color must be a pure string literal",
+            )
+            continue
+        value_token = tokens[value_index]
+        if value_token.kind != "STRING":
+            lock_code, lock_message = _text_style_lock(
+                "STYLE_COLOR_LITERAL_REQUIRED",
+                "color must be a pure string literal",
+            )
+            continue
+        following_index = _next_top_level_index(tokens, value_index)
+        if following_index is not None:
+            following = tokens[following_index]
+            if following.kind != "WORD" or following.text not in _TEXT_COLOR_FOLLOWER_WORDS:
+                lock_code, lock_message = _text_style_lock(
+                    "STYLE_COLOR_EXPRESSION_UNSUPPORTED",
+                    "color expressions and compound values are not writable",
+                )
+                continue
+        try:
+            decoded = _parse_string_token(value_token)
+        except EditorSourceError:
+            lock_code, lock_message = _text_style_lock(
+                "STYLE_COLOR_LITERAL_REQUIRED",
+                "color must be a pure string literal",
+            )
+            continue
+        if not _is_hex_color_literal(decoded):
+            lock_code, lock_message = _text_style_lock(
+                "STYLE_COLOR_UNSUPPORTED_FORM",
+                "color must be a #rgb, #rrggbb, or #rrggbbaa hex literal",
+            )
+            continue
+        color_value = decoded
+        color_span = (value_token.start, value_token.end)
+        quote_char = value_token.text[0] if value_token.text else '"'
+
+    if color_count == 0:
+        code, message = _text_style_lock(
+            "STYLE_COLOR_NOT_DIRECTLY_AUTHORED",
+            "text color is not directly authored as a literal on this statement",
+        )
+        return TextColorStyleStatement(
+            widget_id=widget_id,
+            style_lock_code=code,
+            style_lock_message=message,
+        )
+    if color_count > 1:
+        code, message = _text_style_lock(
+            "STYLE_COLOR_DUPLICATE",
+            "text statement must contain exactly one color",
+        )
+        return TextColorStyleStatement(
+            widget_id=widget_id,
+            style_lock_code=code,
+            style_lock_message=message,
+        )
+    if lock_code is not None:
+        return TextColorStyleStatement(
+            widget_id=widget_id,
+            style_lock_code=lock_code,
+            style_lock_message=lock_message,
+        )
+    if color_value is None or color_span is None or quote_char is None:
+        code, message = _text_style_lock(
+            "STYLE_COLOR_LITERAL_REQUIRED",
+            "color must be a pure string literal",
+        )
+        return TextColorStyleStatement(
+            widget_id=widget_id,
+            style_lock_code=code,
+            style_lock_message=message,
+        )
+
+    return TextColorStyleStatement(
+        widget_id=widget_id,
+        color=color_value,
+        color_span=color_span,
+        quote_char=quote_char,
+        baseline_sha256=hashlib.sha256(line.encode("utf-8")).hexdigest(),
+        style_mode=TEXT_STYLE_COLOR_MODE_LITERAL,
+        style_lock_code=None,
+        style_lock_message=None,
+    )
+
+
+def apply_text_color_patch(
+    source_bytes: bytes,
+    statement: TextColorStyleStatement,
+    *,
+    color: str,
+) -> bytes:
+    """Rewrite only the authored colour string token on a text statement line.
+
+    Spans are character offsets in the decoded single statement line. Unrelated
+    bytes, the original quote character, and the authored hex family are preserved.
+    """
+    if (
+        statement.style_mode != TEXT_STYLE_COLOR_MODE_LITERAL
+        or statement.color_span is None
+        or statement.quote_char is None
+        or statement.baseline_sha256 is None
+        or statement.color is None
+    ):
+        code = statement.style_lock_code or "STYLE_COLOR_NOT_DIRECTLY_AUTHORED"
+        message = statement.style_lock_message or "text color patch requires an unlocked literal color"
+        raise EditorSourceError(code, message)
+
+    if hashlib.sha256(source_bytes).hexdigest() != statement.baseline_sha256:
+        raise EditorSourceError(
+            "STALE_SOURCE",
+            "source changed since text color style analysis",
+        )
+    written = _normalize_hex_color_for_write(color)
+    if len(written) != len(statement.color):
+        raise EditorSourceError(
+            "STYLE_COLOR_HEX_FAMILY_MISMATCH",
+            "new color must preserve the authored hex literal length",
+        )
+    quote = statement.quote_char
+    if quote not in ("'", '"'):
+        raise EditorSourceError(
+            "STYLE_COLOR_UNSUPPORTED_FORM",
+            "color token quote character is unsupported",
+        )
+    replacement = f"{quote}{written}{quote}"
+    source_text = source_bytes.decode("utf-8")
+    start, end = statement.color_span
+    if not (0 <= start < end <= len(source_text)):
+        raise EditorSourceError(
+            "STYLE_COLOR_SPAN_INVALID",
+            "color span is out of range for the source line",
+        )
+    patched = f"{source_text[:start]}{replacement}{source_text[end:]}"
+    return patched.encode("utf-8")

--- a/src/renforge/editor/source.py
+++ b/src/renforge/editor/source.py
@@ -2125,52 +2125,10 @@ def apply_button_sibling_swap(
 # Issue #50 — dedicated style-colour source contract (text + color only)
 # ---------------------------------------------------------------------------
 
-# Property keywords that may follow a pure colour string on a ``text`` line.
-# Expression operators (if/or/else/and) are intentionally absent so compound
-# colour values fail closed rather than looking like pure literals.
-_TEXT_COLOR_FOLLOWER_WORDS = frozenset(
-    {
-        "id",
-        "xpos",
-        "ypos",
-        "pos",
-        "align",
-        "offset",
-        "anchor",
-        "xalign",
-        "yalign",
-        "xanchor",
-        "yanchor",
-        "xoffset",
-        "yoffset",
-        "xcenter",
-        "ycenter",
-        "xsize",
-        "ysize",
-        "xmaximum",
-        "ymaximum",
-        "xminimum",
-        "yminimum",
-        "xfill",
-        "yfill",
-        "size",
-        "font",
-        "bold",
-        "italic",
-        "underline",
-        "strikethrough",
-        "kerning",
-        "line_spacing",
-        "justify",
-        "textalign",
-        "layout",
-        "style",
-        "tooltip",
-        "substitute",
-        "slow_cps",
-        "slow_abortable",
-    }
-)
+# Python expression words that can continue after a string literal. Any other
+# top-level word begins the next screen-language property; enumerating every
+# valid text property here would create a fragile partial grammar.
+_TEXT_COLOR_EXPRESSION_WORDS = frozenset({"and", "else", "for", "if", "in", "is", "not", "or"})
 
 
 def _is_hex_color_literal(value: str) -> bool:
@@ -2203,6 +2161,11 @@ def analyze_text_color_style(line: str, *, expected_widget_id: str) -> TextColor
     This is a dedicated style contract — not a position/size analyser. Coordinate
     tokens are ignored except as follower words that prove a pure colour literal.
     """
+    if len(line.splitlines()) != 1:
+        raise EditorSourceError(
+            "MULTILINE_STATEMENT_REJECTED",
+            "text style colour requires exactly one physical statement line",
+        )
     statement_text = _statement_text(line)
     tokens = _lex_single_line(statement_text)
     top_level = [token for token in tokens if token.depth == 0]
@@ -2251,7 +2214,7 @@ def analyze_text_color_style(line: str, *, expected_widget_id: str) -> TextColor
         following_index = _next_top_level_index(tokens, value_index)
         if following_index is not None:
             following = tokens[following_index]
-            if following.kind != "WORD" or following.text not in _TEXT_COLOR_FOLLOWER_WORDS:
+            if following.kind != "WORD" or following.text in _TEXT_COLOR_EXPRESSION_WORDS:
                 lock_code, lock_message = _text_style_lock(
                     "STYLE_COLOR_EXPRESSION_UNSUPPORTED",
                     "color expressions and compound values are not writable",

--- a/src/renforge/editor_style_color_runner.py
+++ b/src/renforge/editor_style_color_runner.py
@@ -1,0 +1,455 @@
+"""Live evidence runner for issue #50 text colour style source-write contract."""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import re
+import shutil
+import time
+from pathlib import Path
+from typing import Any
+
+from PIL import Image
+
+from renforge.editor.paths import atomic_write_file
+from renforge.editor.source import (
+    TEXT_STYLE_COLOR_MODE_LITERAL,
+    analyze_text_color_style,
+    apply_text_color_patch,
+)
+from renforge.editor_task0_runner import _require_ok
+
+FIXTURE_SCREEN = "renforge_editor_style_fixture"
+TARGET_ID = "style_color_target"
+INHERITED_ID = "style_color_inherited"
+EXPR_ID = "style_color_expr"
+FOCUS_ID = "style_focus_control"
+BASELINE_COLOR = "#e22b2b"
+REQUESTED_COLOR = "#2457d6"
+TARGET_LABEL = "STYLE"
+# Authored placement — used only as a search seed, not as colour evidence.
+_TARGET_AUTHORED = {"x": 240, "y": 220, "width": 320, "height": 120}
+FIXTURE_RESOURCE = (
+    Path(__file__).resolve().parents[2]
+    / "tests"
+    / "live_fixtures"
+    / "renforge_editor_style_fixture.rpy"
+)
+
+
+def inject_editor_style_resources(project_root: Path) -> Path:
+    """Install the style fixture only (editor comes from launch_with_bridge)."""
+    game_dir = project_root / "game"
+    game_dir.mkdir(parents=True, exist_ok=True)
+    fixture_target = game_dir / "zz_renforge_editor_style_fixture.rpy"
+    shutil.copyfile(FIXTURE_RESOURCE, fixture_target)
+    return fixture_target
+
+
+def _target_line_with_offset(source_text: str, widget_id: str) -> tuple[str, int]:
+    offset = 0
+    for line in source_text.splitlines(keepends=True):
+        if line.lstrip().startswith("text ") and f'id "{widget_id}"' in line:
+            return line, offset
+        offset += len(line)
+    raise AssertionError(f"source missing text line for {widget_id!r}")
+
+
+def _parse_color_from_target_line(source_text: str, widget_id: str) -> str | None:
+    line, _ = _target_line_with_offset(source_text, widget_id)
+    match = re.search(r'\bcolor\s+([\'"])(#[0-9A-Fa-f]{3,8})\1', line)
+    if not match:
+        return None
+    return match.group(2)
+
+
+def _independent_expected_after_color_patch(before_text: str, *, color: str) -> str:
+    line, offset = _target_line_with_offset(before_text, TARGET_ID)
+    parsed = analyze_text_color_style(line, expected_widget_id=TARGET_ID)
+    patched_line = apply_text_color_patch(line.encode("utf-8"), parsed, color=color).decode("utf-8")
+    if patched_line == line:
+        raise AssertionError("independent colour patch constructor did not change target line")
+    return f"{before_text[:offset]}{patched_line}{before_text[offset + len(line) :]}"
+
+
+def _outside_color_span_identical(before_text: str, after_text: str) -> bool:
+    before_line, _ = _target_line_with_offset(before_text, TARGET_ID)
+    after_line, _ = _target_line_with_offset(after_text, TARGET_ID)
+    before_norm = re.sub(
+        r'(\bcolor\s+)([\'"])(#[0-9A-Fa-f]{3,8})\2',
+        r"\1\2__COLOR__\2",
+        before_line,
+        count=1,
+    )
+    after_norm = re.sub(
+        r'(\bcolor\s+)([\'"])(#[0-9A-Fa-f]{3,8})\2',
+        r"\1\2__COLOR__\2",
+        after_line,
+        count=1,
+    )
+    if before_norm != after_norm:
+        return False
+    return before_text.replace(before_line, "", 1) == after_text.replace(after_line, "", 1)
+
+
+def _show_fixture(client: Any) -> None:
+    last: Any = None
+    for _ in range(60):
+        last = client.request("editor_task0_start", {"screen": FIXTURE_SCREEN})
+        if isinstance(last, dict) and last.get("ok") is True:
+            return
+        time.sleep(0.1)
+    raise AssertionError(f"style fixture did not start: {last!r}")
+
+
+def _scene_text_bounds(client: Any, *, label: str) -> dict[str, int] | None:
+    """Return scene_tree bounds for a text label when available (geometry only)."""
+    tree = client.scene_tree(types=["text"], detail="semantic")
+    nodes = tree.get("nodes") if isinstance(tree, dict) else None
+    if not isinstance(nodes, list):
+        return None
+    for node in nodes:
+        if not isinstance(node, dict):
+            continue
+        if str(node.get("text") or "") != label:
+            continue
+        bounds = node.get("bounds")
+        if isinstance(bounds, dict) and int(bounds.get("width") or 0) > 0 and int(bounds.get("height") or 0) > 0:
+            return {
+                "x": int(bounds["x"]),
+                "y": int(bounds["y"]),
+                "width": int(bounds["width"]),
+                "height": int(bounds["height"]),
+            }
+    return None
+
+
+def _dominant_from_rgb(rgb: tuple[int, int, int]) -> str:
+    red, green, blue = rgb
+    # Require a clear channel lead so anti-aliased greys stay "unknown".
+    if red > blue + 30 and red > green + 30 and red >= 80:
+        return "red"
+    if blue > red + 30 and blue > green + 30 and blue >= 80:
+        return "blue"
+    return "unknown"
+
+
+def _sample_region_paint(
+    client: Any,
+    bounds: dict[str, int],
+    *,
+    image: Image.Image | None = None,
+) -> dict[str, Any]:
+    """Independent screenshot paint stats for saturated non-dark pixels.
+
+    Colour class is derived only from PNG samples — never from scene-tree style
+    metadata or editor claims.
+    """
+    if image is None:
+        image = Image.open(io.BytesIO(client.screenshot())).convert("RGB")
+    x0 = max(0, int(bounds["x"]))
+    y0 = max(0, int(bounds["y"]))
+    x1 = min(image.width, x0 + max(1, int(bounds["width"])))
+    y1 = min(image.height, y0 + max(1, int(bounds["height"])))
+    painted: list[tuple[int, int, int]] = []
+    for y in range(y0, y1):
+        for x in range(x0, x1):
+            pixel = image.getpixel((x, y))
+            if isinstance(pixel, int):
+                rgb = (pixel, pixel, pixel)
+            else:
+                rgb = (int(pixel[0]), int(pixel[1]), int(pixel[2]))
+            # Dark fixture background is ~#0a0a12. Drop near-black and near-grey
+            # anti-alias fringes so glyph chroma dominates.
+            if max(rgb) < 50:
+                continue
+            if max(rgb) - min(rgb) < 25:
+                continue
+            painted.append(rgb)
+    if not painted:
+        return {
+            "paint_count": 0,
+            "mean_rgb": None,
+            "dominant": "unknown",
+            "image_size": [image.width, image.height],
+            "bounds": [x0, y0, x1 - x0, y1 - y0],
+            "sample_point": None,
+            "sample_rgb": None,
+        }
+    mean = (
+        round(sum(p[0] for p in painted) / len(painted)),
+        round(sum(p[1] for p in painted) / len(painted)),
+        round(sum(p[2] for p in painted) / len(painted)),
+    )
+    # Also record one high-chroma sample near the geometric centre.
+    cx = (x0 + x1) // 2
+    cy = (y0 + y1) // 2
+    sample_point = None
+    sample_rgb = None
+    best = -1
+    for y in range(max(y0, cy - 20), min(y1, cy + 21)):
+        for x in range(max(x0, cx - 40), min(x1, cx + 41)):
+            pixel = image.getpixel((x, y))
+            if isinstance(pixel, int):
+                rgb = (pixel, pixel, pixel)
+            else:
+                rgb = (int(pixel[0]), int(pixel[1]), int(pixel[2]))
+            chroma = max(rgb) - min(rgb)
+            if chroma > best and max(rgb) >= 50:
+                best = chroma
+                sample_point = [x, y]
+                sample_rgb = list(rgb)
+    return {
+        "paint_count": len(painted),
+        "mean_rgb": list(mean),
+        "dominant": _dominant_from_rgb(mean),
+        "image_size": [image.width, image.height],
+        "bounds": [x0, y0, x1 - x0, y1 - y0],
+        "sample_point": sample_point,
+        "sample_rgb": sample_rgb,
+        "sample_dominant": _dominant_from_rgb(tuple(sample_rgb)) if sample_rgb else "unknown",
+    }
+
+
+def _wait_paint(
+    client: Any,
+    *,
+    expected_dominant: str,
+    timeout: float = 8.0,
+) -> tuple[dict[str, int], dict[str, Any]]:
+    """Wait until independent screenshot paint reports the expected colour class."""
+    deadline = time.monotonic() + timeout
+    last_bounds = dict(_TARGET_AUTHORED)
+    last_paint: dict[str, Any] = {"dominant": "unknown", "paint_count": 0}
+    while time.monotonic() < deadline:
+        bounds = _scene_text_bounds(client, label=TARGET_LABEL) or dict(_TARGET_AUTHORED)
+        last_bounds = bounds
+        last_paint = _sample_region_paint(client, bounds)
+        # Prefer the high-chroma centre sample when mean is muddy.
+        dominant = last_paint.get("sample_dominant") or last_paint.get("dominant")
+        if dominant == expected_dominant and int(last_paint.get("paint_count") or 0) > 20:
+            last_paint = {**last_paint, "dominant": dominant}
+            return bounds, last_paint
+        time.sleep(0.1)
+    last_paint = {
+        **last_paint,
+        "dominant": last_paint.get("sample_dominant") or last_paint.get("dominant"),
+    }
+    return last_bounds, last_paint
+
+
+def _attempt_product_select(client: Any, bounds: dict[str, int]) -> dict[str, Any]:
+    """Click via the production select path (focus_list only)."""
+    x = int(bounds["x"]) + max(1, int(bounds["width"]) // 2)
+    y = int(bounds["y"]) + max(1, int(bounds["height"]) // 2)
+    selection = client.request("editor_task0_select", {"x": x, "y": y})
+    status = client.request("editor_task0_status", {})
+    selected_id = None
+    if isinstance(selection, dict):
+        selected = selection.get("selected") or {}
+        if isinstance(selected, dict):
+            selected_id = selected.get("widget_id")
+        if selected_id is None:
+            selected_id = selection.get("selected_widget_id")
+    if selected_id is None and isinstance(status, dict):
+        selected_id = status.get("selected_widget_id")
+    capabilities = (status or {}).get("current_capabilities") if isinstance(status, dict) else None
+    source_key = (status or {}).get("current_source_key") if isinstance(status, dict) else None
+    return {
+        "point": [x, y],
+        "selection_ok": bool(isinstance(selection, dict) and selection.get("ok") is True),
+        "selected_widget_id": selected_id,
+        "selected_lock_reason": (
+            (status or {}).get("selected_lock_reason") if isinstance(status, dict) else None
+        ),
+        "capabilities": capabilities if isinstance(capabilities, dict) else {},
+        "source_key": source_key if isinstance(source_key, dict) else {},
+        "status_active": bool(isinstance(status, dict) and status.get("active")),
+    }
+
+
+def _lock_probe(source_text: str, widget_id: str, expected_code: str) -> dict[str, Any]:
+    line, _ = _target_line_with_offset(source_text, widget_id)
+    parsed = analyze_text_color_style(line, expected_widget_id=widget_id)
+    return {
+        "widget_id": widget_id,
+        "style_mode": parsed.style_mode,
+        "style_lock_code": parsed.style_lock_code,
+        "matches_expected": parsed.style_lock_code == expected_code,
+    }
+
+
+def run_editor_style_color_live_scenario(client: Any, *, fixture_path: Path) -> dict[str, Any]:
+    """Evidence-gated live scenario for text colour style (issue #50)."""
+    baseline = fixture_path.read_bytes()
+    baseline_sha = hashlib.sha256(baseline).hexdigest()
+    baseline_text = baseline.decode("utf-8")
+    report: dict[str, Any] = {
+        "baseline_sha256": baseline_sha,
+        "adapter": "text",
+        "property": "color",
+        "style_mode": TEXT_STYLE_COLOR_MODE_LITERAL,
+    }
+
+    _show_fixture(client)
+
+    report["locks"] = {
+        "inherited": _lock_probe(baseline_text, INHERITED_ID, "STYLE_COLOR_NOT_DIRECTLY_AUTHORED"),
+        "expression": _lock_probe(baseline_text, EXPR_ID, "STYLE_COLOR_LITERAL_REQUIRED"),
+    }
+
+    target_line, _ = _target_line_with_offset(baseline_text, TARGET_ID)
+    target_analysis = analyze_text_color_style(target_line, expected_widget_id=TARGET_ID)
+    report["resolve_source"] = {
+        "widget_id": target_analysis.widget_id,
+        "color": target_analysis.color,
+        "style_mode": target_analysis.style_mode,
+        "style_lock_code": target_analysis.style_lock_code,
+        "unlocked": (
+            target_analysis.style_mode == TEXT_STYLE_COLOR_MODE_LITERAL
+            and target_analysis.style_lock_code is None
+            and target_analysis.color == BASELINE_COLOR
+        ),
+    }
+    if not report["resolve_source"]["unlocked"]:
+        report["verdict"] = "blocked"
+        report["verdict_reason"] = "style_color_source_unlock_failed"
+        report["restore"] = {
+            "byte_identical": True,
+            "sha256": baseline_sha,
+            "note": "manual_fixture_restore_cleanup_not_product_undo",
+        }
+        return report
+
+    # Pixel before: wait for independent red paint (not scene-tree style fields).
+    bounds_before, pixel_before = _wait_paint(client, expected_dominant="red", timeout=8.0)
+    report["target_bounds"] = bounds_before
+    report["pixel_before"] = pixel_before
+
+    # Product select attempt on the text glyph (expected: no style unlock).
+    report["product_select"] = _attempt_product_select(client, bounds_before)
+
+    # Focusable control still resolves via focus_list (control-path sanity).
+    focus_bounds = None
+    try:
+        info = client.list_ui_elements_info(screen=FIXTURE_SCREEN)
+        elements = info.get("elements") if isinstance(info, dict) else []
+        for element in elements or []:
+            if str(element.get("id") or "") == FOCUS_ID:
+                b = element.get("bounds") or {}
+                focus_bounds = {
+                    "x": int(b["x"]),
+                    "y": int(b["y"]),
+                    "width": int(b["width"]),
+                    "height": int(b["height"]),
+                }
+                break
+    except Exception as exc:  # noqa: BLE001 — evidence plane
+        report["focus_control_error"] = str(exc)
+    report["focus_control_bounds"] = focus_bounds
+    if focus_bounds is not None:
+        report["focus_control_select"] = _attempt_product_select(client, focus_bounds)
+
+    # Source patch via dedicated style contract (not coordinate spans).
+    staged_line = apply_text_color_patch(
+        target_line.encode("utf-8"),
+        target_analysis,
+        color=REQUESTED_COLOR,
+    ).decode("utf-8")
+    staged_text = baseline_text.replace(target_line, staged_line, 1)
+    if staged_text == baseline_text:
+        raise AssertionError("style colour patch produced no source change")
+    expected_text = _independent_expected_after_color_patch(baseline_text, color=REQUESTED_COLOR)
+    outside_ok = _outside_color_span_identical(baseline_text, staged_text)
+    report["source_patch"] = {
+        "changed": True,
+        "matches_independent_expected": staged_text == expected_text,
+        "outside_color_span_identical": outside_ok,
+        "source_color_after": _parse_color_from_target_line(staged_text, TARGET_ID),
+        "staged_sha256": hashlib.sha256(staged_text.encode("utf-8")).hexdigest(),
+    }
+    if not report["source_patch"]["matches_independent_expected"] or not outside_ok:
+        report["verdict"] = "inconclusive"
+        report["verdict_reason"] = "source_patch_form_or_span_mismatch"
+        return report
+
+    try:
+        atomic_write_file(fixture_path, staged_text.encode("utf-8"))
+        if fixture_path.read_text(encoding="utf-8") != staged_text:
+            raise AssertionError("atomic write did not publish staged style fixture bytes")
+        _require_ok(client.control("reload_script"), "style color reload")
+        # Give the reloaded script a moment, then re-show the fixture.
+        for _ in range(30):
+            if client.eval_expr(f'renpy.has_screen("{FIXTURE_SCREEN}")') is True:
+                break
+            time.sleep(0.1)
+        _show_fixture(client)
+        bounds_after, pixel_after = _wait_paint(client, expected_dominant="blue", timeout=10.0)
+        report["pixel_after"] = pixel_after
+        report["target_bounds_after"] = bounds_after
+        disk_color = _parse_color_from_target_line(
+            fixture_path.read_text(encoding="utf-8"),
+            TARGET_ID,
+        )
+        report["published_source_after_reload"] = {
+            "widget_id": TARGET_ID,
+            "bounds_after": bounds_after,
+            "source_color": disk_color,
+            "ok": disk_color == REQUESTED_COLOR,
+        }
+    finally:
+        # Cleanup only — not product undo evidence.
+        atomic_write_file(fixture_path, baseline)
+        try:
+            _require_ok(client.control("reload_script"), "style color restore reload")
+            _show_fixture(client)
+        except Exception as exc:  # noqa: BLE001
+            report["restore_reload_error"] = str(exc)
+
+    restored = fixture_path.read_bytes()
+    report["restore"] = {
+        "sha256": hashlib.sha256(restored).hexdigest(),
+        "byte_identical": restored == baseline,
+        "note": "manual_fixture_restore_cleanup_not_product_undo",
+    }
+
+    pixel_before = report.get("pixel_before") or {}
+    pixel_after = report.get("pixel_after") or {}
+    report["runtime_color_change_proven"] = (
+        pixel_before.get("dominant") == "red"
+        and pixel_after.get("dominant") == "blue"
+        and int(pixel_before.get("paint_count") or 0) > 20
+        and int(pixel_after.get("paint_count") or 0) > 20
+    )
+    report["product_select_unlocked_style"] = bool(
+        report["product_select"].get("selected_widget_id") == TARGET_ID
+        and (report["product_select"].get("source_key") or {}).get("statement_kind") == "text"
+        and (report["product_select"].get("source_key") or {}).get("style_mode")
+        == TEXT_STYLE_COLOR_MODE_LITERAL
+        and (report["product_select"].get("capabilities") or {}).get("style_color") is True
+    )
+    # Explicit product seams — not implemented for style colour.
+    report["product_preview_available"] = False
+    report["product_commit_available"] = False
+    report["product_undo_available"] = False
+    report["refused_attestation_rollback_available"] = False
+
+    if not report["runtime_color_change_proven"]:
+        report["verdict"] = "inconclusive"
+        report["verdict_reason"] = "pixel_color_change_unproven"
+    elif not (
+        report["source_patch"]["matches_independent_expected"]
+        and report["source_patch"]["outside_color_span_identical"]
+        and report["restore"]["byte_identical"]
+        and report["locks"]["inherited"]["matches_expected"]
+        and report["locks"]["expression"]["matches_expected"]
+    ):
+        report["verdict"] = "inconclusive"
+        report["verdict_reason"] = "source_or_lock_evidence_incomplete"
+    else:
+        # Source + independent pixel proven; product style path absent.
+        report["verdict"] = "blocked"
+        report["verdict_reason"] = "style_color_product_path_missing"
+
+    return report

--- a/src/renforge/editor_style_color_runner.py
+++ b/src/renforge/editor_style_color_runner.py
@@ -218,23 +218,38 @@ def _wait_paint(
     expected_dominant: str,
     timeout: float = 8.0,
 ) -> tuple[dict[str, int], dict[str, Any]]:
-    """Wait until independent screenshot paint reports the expected colour class."""
+    """Wait for expected paint observed inside live scene-tree bounds."""
     deadline = time.monotonic() + timeout
     last_bounds = dict(_TARGET_AUTHORED)
-    last_paint: dict[str, Any] = {"dominant": "unknown", "paint_count": 0}
+    bounds_from_scene_tree = False
+    last_paint: dict[str, Any] = {
+        "dominant": "unknown",
+        "paint_count": 0,
+        "bounds_from_scene_tree": False,
+    }
     while time.monotonic() < deadline:
-        bounds = _scene_text_bounds(client, label=TARGET_LABEL) or dict(_TARGET_AUTHORED)
-        last_bounds = bounds
-        last_paint = _sample_region_paint(client, bounds)
+        observed_bounds = _scene_text_bounds(client, label=TARGET_LABEL)
+        if observed_bounds is not None:
+            last_bounds = observed_bounds
+            bounds_from_scene_tree = True
+        last_paint = {
+            **_sample_region_paint(client, last_bounds),
+            "bounds_from_scene_tree": bounds_from_scene_tree,
+        }
         # Prefer the high-chroma centre sample when mean is muddy.
         dominant = last_paint.get("sample_dominant") or last_paint.get("dominant")
-        if dominant == expected_dominant and int(last_paint.get("paint_count") or 0) > 20:
+        if (
+            bounds_from_scene_tree
+            and dominant == expected_dominant
+            and int(last_paint.get("paint_count") or 0) > 20
+        ):
             last_paint = {**last_paint, "dominant": dominant}
-            return bounds, last_paint
+            return last_bounds, last_paint
         time.sleep(0.1)
     last_paint = {
         **last_paint,
         "dominant": last_paint.get("sample_dominant") or last_paint.get("dominant"),
+        "bounds_from_scene_tree": bounds_from_scene_tree,
     }
     return last_bounds, last_paint
 
@@ -266,6 +281,11 @@ def _attempt_product_select(client: Any, bounds: dict[str, int]) -> dict[str, An
         "capabilities": capabilities if isinstance(capabilities, dict) else {},
         "source_key": source_key if isinstance(source_key, dict) else {},
         "status_active": bool(isinstance(status, dict) and status.get("active")),
+        "save_enabled": bool(isinstance(status, dict) and status.get("save_enabled")),
+        "history_length": int((status or {}).get("history_length") or 0) if isinstance(status, dict) else 0,
+        "pending_transaction_id": (
+            (status or {}).get("pending_transaction_id") if isinstance(status, dict) else None
+        ),
     }
 
 
@@ -419,6 +439,8 @@ def run_editor_style_color_live_scenario(client: Any, *, fixture_path: Path) -> 
     report["runtime_color_change_proven"] = (
         pixel_before.get("dominant") == "red"
         and pixel_after.get("dominant") == "blue"
+        and pixel_before.get("bounds_from_scene_tree") is True
+        and pixel_after.get("bounds_from_scene_tree") is True
         and int(pixel_before.get("paint_count") or 0) > 20
         and int(pixel_after.get("paint_count") or 0) > 20
     )
@@ -429,11 +451,31 @@ def run_editor_style_color_live_scenario(client: Any, *, fixture_path: Path) -> 
         == TEXT_STYLE_COLOR_MODE_LITERAL
         and (report["product_select"].get("capabilities") or {}).get("style_color") is True
     )
-    # Explicit product seams — not implemented for style colour.
-    report["product_preview_available"] = False
-    report["product_commit_available"] = False
-    report["product_undo_available"] = False
-    report["refused_attestation_rollback_available"] = False
+    # Measure advertised product seams from the status returned by the real
+    # production selection attempt. No style-specific command is inferred when
+    # the capability map does not advertise one.
+    capabilities = report["product_select"].get("capabilities") or {}
+    style_selected = report["product_select_unlocked_style"]
+    report["product_seam_probe"] = {
+        "measurement_source": "editor_task0_status.current_capabilities",
+        "selected_widget_id": report["product_select"].get("selected_widget_id"),
+        "capabilities": capabilities,
+        "save_enabled": report["product_select"].get("save_enabled"),
+        "history_length": report["product_select"].get("history_length"),
+        "pending_transaction_id": report["product_select"].get("pending_transaction_id"),
+    }
+    report["product_preview_available"] = bool(
+        style_selected and capabilities.get("style_color_preview") is True
+    )
+    report["product_commit_available"] = bool(
+        style_selected and capabilities.get("style_color_commit") is True
+    )
+    report["product_undo_available"] = bool(
+        style_selected and capabilities.get("style_color_undo") is True
+    )
+    report["refused_attestation_rollback_available"] = bool(
+        style_selected and capabilities.get("style_color_attestation_rollback") is True
+    )
 
     if not report["runtime_color_change_proven"]:
         report["verdict"] = "inconclusive"

--- a/tests/live_fixtures/renforge_editor_style_fixture.rpy
+++ b/tests/live_fixtures/renforge_editor_style_fixture.rpy
@@ -1,0 +1,22 @@
+# Live fixture for issue #50 — text adapter, literal color property only.
+
+default renforge_style_expr_color = "#e22b2b"
+
+
+screen renforge_editor_style_fixture():
+    layer "screens"
+    zorder 640
+
+    add Solid("#0a0a12", xysize=(1280, 720))
+
+    # Unlocked target: pure hex string-literal color on single-line text.
+    text "STYLE" id "style_color_target" color "#e22b2b" size 96 xpos 240 ypos 220
+
+    # Inherited / not directly authored color — must stay locked.
+    text "INHERIT" id "style_color_inherited" size 40 xpos 240 ypos 420
+
+    # Expression color — must stay locked.
+    text "EXPR" id "style_color_expr" color renforge_style_expr_color size 40 xpos 240 ypos 500
+
+    # Non-text control present only for focus_list sanity (not a style target).
+    textbutton "FOCUS" id "style_focus_control" xpos 900 ypos 80 action NullAction()

--- a/tests/test_editor_style_color_live.py
+++ b/tests/test_editor_style_color_live.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import os
+import shutil
+import time
+from pathlib import Path
+
+import pytest
+
+from renforge.editor_style_color_runner import (
+    FIXTURE_SCREEN,
+    TARGET_ID,
+    inject_editor_style_resources,
+    run_editor_style_color_live_scenario,
+)
+
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("RENFORGE_STYLE_COLOR_LIVE"),
+    reason="set RENFORGE_STYLE_COLOR_LIVE=1 to run issue #50 style colour live gate",
+)
+
+_DEMO = Path(__file__).resolve().parents[1] / "examples" / "demo_game"
+
+
+@pytest.fixture
+def demo_copy(tmp_path: Path) -> Path:
+    destination = tmp_path / "demo"
+    shutil.copytree(_DEMO, destination, ignore=shutil.ignore_patterns("*.rpyc", "cache"))
+    inject_editor_style_resources(destination)
+    return destination
+
+
+def _open_editor(session) -> None:
+    for _ in range(40):
+        if session.client.inspect_screen("_renforge_editor_launcher").get("active") is True:
+            break
+        time.sleep(0.2)
+    else:
+        pytest.fail("editor launcher never became active")
+
+    assert (
+        session.client.click_element(
+            text="RF",
+            exact=True,
+            screen="_renforge_editor_launcher",
+        ).get("ok")
+        is True
+    )
+    for _ in range(40):
+        if session.client.inspect_screen("_renforge_editor_overlay").get("active") is True:
+            return
+        time.sleep(0.05)
+    pytest.fail("editor overlay never became active")
+
+
+def test_style_color_live_gate_is_blocked_with_source_and_pixel_proof(demo_copy: Path) -> None:
+    from renforge.bridge.launcher import launch_with_bridge
+    from renforge.project import RenpyProject
+    from renforge.sdk import get_or_install_sdk
+
+    sdk = get_or_install_sdk("8.5.3", project_root=demo_copy)
+    fixture_path = demo_copy / "game" / "zz_renforge_editor_style_fixture.rpy"
+
+    with launch_with_bridge(
+        sdk,
+        RenpyProject(demo_copy),
+        startup_timeout=120,
+        editor=True,
+    ) as session:
+        _open_editor(session)
+        for _ in range(20):
+            available = session.client.eval_expr(f'renpy.has_screen("{FIXTURE_SCREEN}")')
+            if available is True:
+                break
+            time.sleep(0.1)
+        else:
+            pytest.fail("style fixture screen never became available")
+
+        report = run_editor_style_color_live_scenario(
+            session.client,
+            fixture_path=fixture_path,
+        )
+
+    assert report["adapter"] == "text"
+    assert report["property"] == "color"
+    assert report["resolve_source"]["unlocked"] is True
+    assert report["resolve_source"]["color"] == "#e22b2b"
+    assert report["locks"]["inherited"]["matches_expected"] is True
+    assert report["locks"]["expression"]["matches_expected"] is True
+
+    patch = report["source_patch"]
+    assert patch["changed"] is True
+    assert patch["matches_independent_expected"] is True
+    assert patch["outside_color_span_identical"] is True
+    assert patch["source_color_after"] == "#2457d6"
+
+    assert report["pixel_before"]["dominant"] == "red", report["pixel_before"]
+    assert report["pixel_after"]["dominant"] == "blue", report["pixel_after"]
+    assert report["runtime_color_change_proven"] is True
+    assert report["published_source_after_reload"]["ok"] is True
+
+    # Production path must remain disabled / unselected for non-focusable text.
+    assert report["product_select_unlocked_style"] is False
+    assert report["product_preview_available"] is False
+    assert report["product_commit_available"] is False
+    assert report["product_undo_available"] is False
+
+    # Cleanup restore is not product undo.
+    assert report["restore"]["byte_identical"] is True
+    assert report["restore"]["note"] == "manual_fixture_restore_cleanup_not_product_undo"
+
+    assert report["verdict"] == "blocked"
+    assert report["verdict_reason"] == "style_color_product_path_missing"
+    assert TARGET_ID == "style_color_target"

--- a/tests/test_editor_style_color_live.py
+++ b/tests/test_editor_style_color_live.py
@@ -96,6 +96,8 @@ def test_style_color_live_gate_is_blocked_with_source_and_pixel_proof(demo_copy:
 
     assert report["pixel_before"]["dominant"] == "red", report["pixel_before"]
     assert report["pixel_after"]["dominant"] == "blue", report["pixel_after"]
+    assert report["pixel_before"]["bounds_from_scene_tree"] is True
+    assert report["pixel_after"]["bounds_from_scene_tree"] is True
     assert report["runtime_color_change_proven"] is True
     assert report["published_source_after_reload"]["ok"] is True
 
@@ -104,6 +106,9 @@ def test_style_color_live_gate_is_blocked_with_source_and_pixel_proof(demo_copy:
     assert report["product_preview_available"] is False
     assert report["product_commit_available"] is False
     assert report["product_undo_available"] is False
+    assert report["product_seam_probe"]["measurement_source"] == (
+        "editor_task0_status.current_capabilities"
+    )
 
     # Cleanup restore is not product undo.
     assert report["restore"]["byte_identical"] is True

--- a/tests/test_editor_style_color_source.py
+++ b/tests/test_editor_style_color_source.py
@@ -1,0 +1,183 @@
+"""Deterministic regression tests for issue #50 text colour style contract."""
+
+from __future__ import annotations
+
+import pytest
+
+from renforge.editor.source import (
+    EditorSourceError,
+    TEXT_STYLE_COLOR_MODE_LITERAL,
+    analyze_text_color_style,
+    apply_text_color_patch,
+)
+
+
+def test_analyze_text_color_style_unlocks_pure_literal_hex() -> None:
+    line = (
+        '    text "STYLE" color "#e22b2b" id "style_color_target" '
+        "size 64 xpos 200 ypos 200\n"
+    )
+    parsed = analyze_text_color_style(line, expected_widget_id="style_color_target")
+    assert parsed.widget_id == "style_color_target"
+    assert parsed.color == "#e22b2b"
+    assert parsed.style_mode == TEXT_STYLE_COLOR_MODE_LITERAL
+    assert parsed.style_lock_code is None
+    assert parsed.color_span is not None
+    assert line[parsed.color_span[0] : parsed.color_span[1]] == '"#e22b2b"'
+
+
+def test_apply_text_color_patch_preserves_unrelated_bytes_and_form() -> None:
+    line = (
+        '    text "STYLE" color "#e22b2b" id "style_color_target" '
+        "size 64 xpos 200 ypos 200\n"
+    )
+    parsed = analyze_text_color_style(line, expected_widget_id="style_color_target")
+    patched = apply_text_color_patch(
+        line.encode("utf-8"),
+        parsed,
+        color="#2457d6",
+    ).decode("utf-8")
+    assert patched == (
+        '    text "STYLE" color "#2457d6" id "style_color_target" '
+        "size 64 xpos 200 ypos 200\n"
+    )
+    # Outside the colour token: identical.
+    before_norm = line.replace('"#e22b2b"', "__COLOR__", 1)
+    after_norm = patched.replace('"#2457d6"', "__COLOR__", 1)
+    assert before_norm == after_norm
+
+
+def test_apply_text_color_patch_preserves_single_quote_form() -> None:
+    line = "    text 'STYLE' color '#abc' id 'style_color_target'\n"
+    parsed = analyze_text_color_style(line, expected_widget_id="style_color_target")
+    assert parsed.color == "#abc"
+    patched = apply_text_color_patch(
+        line.encode("utf-8"),
+        parsed,
+        color="#def",
+    ).decode("utf-8")
+    assert patched == "    text 'STYLE' color '#def' id 'style_color_target'\n"
+
+
+@pytest.mark.parametrize(
+    ("line", "code"),
+    [
+        (
+            '    text "INHERIT" id "style_color_inherited" size 32 xpos 10 ypos 10\n',
+            "STYLE_COLOR_NOT_DIRECTLY_AUTHORED",
+        ),
+        (
+            '    text "EXPR" color renforge_style_expr_color id "style_color_expr"\n',
+            "STYLE_COLOR_LITERAL_REQUIRED",
+        ),
+        (
+            '    text "EXPR" color "#e22b2b" if flag else "#2457d6" id "style_color_expr"\n',
+            "STYLE_COLOR_EXPRESSION_UNSUPPORTED",
+        ),
+        (
+            '    text "BAD" color "#zzzzzz" id "style_color_bad"\n',
+            "STYLE_COLOR_UNSUPPORTED_FORM",
+        ),
+        (
+            '    text "BAD" color "red" id "style_color_bad"\n',
+            "STYLE_COLOR_UNSUPPORTED_FORM",
+        ),
+        (
+            '    text "DUP" color "#e22b2b" color "#2457d6" id "style_color_dup"\n',
+            "STYLE_COLOR_DUPLICATE",
+        ),
+        (
+            '    text "TUPLE" color (1.0, 0.0, 0.0) id "style_color_tuple"\n',
+            "STYLE_COLOR_LITERAL_REQUIRED",
+        ),
+    ],
+)
+def test_analyze_text_color_style_fail_closed_matrix(line: str, code: str) -> None:
+    parsed = analyze_text_color_style(line, expected_widget_id=line.split('id "')[1].split('"')[0])
+    assert parsed.style_mode is None
+    assert parsed.color is None
+    assert parsed.color_span is None
+    assert parsed.style_lock_code == code
+
+
+def test_analyze_text_color_style_rejects_non_text_adapter() -> None:
+    with pytest.raises(EditorSourceError) as exc:
+        analyze_text_color_style(
+            '    textbutton "Play" color "#e22b2b" id "start" xpos 1 ypos 2 action NullAction()\n',
+            expected_widget_id="start",
+        )
+    assert exc.value.code == "STATEMENT_KIND_MISMATCH"
+
+
+def test_analyze_text_color_style_rejects_block_form() -> None:
+    with pytest.raises(EditorSourceError) as exc:
+        analyze_text_color_style(
+            '    text "BLOCK" color "#e22b2b" id "style_color_block":\n',
+            expected_widget_id="style_color_block",
+        )
+    assert exc.value.code == "MULTILINE_STATEMENT_REJECTED"
+
+
+def test_analyze_text_color_style_rejects_id_mismatch() -> None:
+    with pytest.raises(EditorSourceError) as exc:
+        analyze_text_color_style(
+            '    text "STYLE" color "#e22b2b" id "other"\n',
+            expected_widget_id="style_color_target",
+        )
+    assert exc.value.code == "ID_MISMATCH"
+
+
+def test_apply_text_color_patch_refuses_locked_statement() -> None:
+    line = '    text "INHERIT" id "style_color_inherited" size 32\n'
+    parsed = analyze_text_color_style(line, expected_widget_id="style_color_inherited")
+    assert parsed.style_lock_code == "STYLE_COLOR_NOT_DIRECTLY_AUTHORED"
+    with pytest.raises(EditorSourceError) as exc:
+        apply_text_color_patch(line.encode("utf-8"), parsed, color="#2457d6")
+    assert exc.value.code == "STYLE_COLOR_NOT_DIRECTLY_AUTHORED"
+
+
+def test_apply_text_color_patch_refuses_unsupported_new_color() -> None:
+    line = '    text "STYLE" color "#e22b2b" id "style_color_target"\n'
+    parsed = analyze_text_color_style(line, expected_widget_id="style_color_target")
+    with pytest.raises(EditorSourceError) as exc:
+        apply_text_color_patch(line.encode("utf-8"), parsed, color="not-a-color")
+    assert exc.value.code == "STYLE_COLOR_UNSUPPORTED_FORM"
+
+
+def test_apply_text_color_patch_refuses_stale_source() -> None:
+    line = '    text "STYLE" color "#e22b2b" id "style_color_target"\n'
+    parsed = analyze_text_color_style(line, expected_widget_id="style_color_target")
+    stale = line.replace("STYLE", "OTHER")
+    with pytest.raises(EditorSourceError) as exc:
+        apply_text_color_patch(stale.encode("utf-8"), parsed, color="#2457d6")
+    assert exc.value.code == "STALE_SOURCE"
+
+
+def test_apply_text_color_patch_preserves_hex_family_and_unicode_prefix() -> None:
+    line = '    text "ÉTÉ" color "#abc" id "style_color_target"\n'
+    parsed = analyze_text_color_style(line, expected_widget_id="style_color_target")
+    patched = apply_text_color_patch(line.encode("utf-8"), parsed, color="#def")
+    assert patched.decode("utf-8") == '    text "ÉTÉ" color "#def" id "style_color_target"\n'
+    with pytest.raises(EditorSourceError) as exc:
+        apply_text_color_patch(line.encode("utf-8"), parsed, color="#ddeeff")
+    assert exc.value.code == "STYLE_COLOR_HEX_FAMILY_MISMATCH"
+
+
+def test_text_color_contract_does_not_route_through_coordinate_spans() -> None:
+    """Colour spans must not alias xpos/ypos integer tokens."""
+    line = (
+        '    text "STYLE" xpos 200 ypos 180 color "#e22b2b" id "style_color_target"\n'
+    )
+    parsed = analyze_text_color_style(line, expected_widget_id="style_color_target")
+    token = line[parsed.color_span[0] : parsed.color_span[1]]
+    assert "200" not in token
+    assert "180" not in token
+    assert "#e22b2b" in token
+    patched = apply_text_color_patch(
+        line.encode("utf-8"),
+        parsed,
+        color="#00ff00",
+    ).decode("utf-8")
+    assert "xpos 200" in patched
+    assert "ypos 180" in patched
+    assert 'color "#00ff00"' in patched

--- a/tests/test_editor_style_color_source.py
+++ b/tests/test_editor_style_color_source.py
@@ -118,6 +118,16 @@ def test_analyze_text_color_style_rejects_block_form() -> None:
     assert exc.value.code == "MULTILINE_STATEMENT_REJECTED"
 
 
+def test_analyze_text_color_style_rejects_multiple_physical_lines() -> None:
+    with pytest.raises(EditorSourceError) as exc:
+        analyze_text_color_style(
+            '    text "STYLE" color "#e22b2b" id "style_color_target"\n'
+            '    text "OTHER" color "#2457d6" id "other"\n',
+            expected_widget_id="style_color_target",
+        )
+    assert exc.value.code == "MULTILINE_STATEMENT_REJECTED"
+
+
 def test_analyze_text_color_style_rejects_id_mismatch() -> None:
     with pytest.raises(EditorSourceError) as exc:
         analyze_text_color_style(
@@ -161,6 +171,23 @@ def test_apply_text_color_patch_preserves_hex_family_and_unicode_prefix() -> Non
     with pytest.raises(EditorSourceError) as exc:
         apply_text_color_patch(line.encode("utf-8"), parsed, color="#ddeeff")
     assert exc.value.code == "STYLE_COLOR_HEX_FAMILY_MISMATCH"
+
+
+def test_apply_text_color_patch_supports_eight_digit_alpha_hex() -> None:
+    line = '    text "ALPHA" color "#11223344" id "style_color_target"\n'
+    parsed = analyze_text_color_style(line, expected_widget_id="style_color_target")
+    patched = apply_text_color_patch(line.encode("utf-8"), parsed, color="#44556677")
+    assert patched.decode("utf-8") == '    text "ALPHA" color "#44556677" id "style_color_target"\n'
+
+
+def test_literal_color_accepts_valid_text_property_follower() -> None:
+    line = (
+        '    text "STYLE" color "#e22b2b" outlines [(2, "#000")] '
+        'id "style_color_target"\n'
+    )
+    parsed = analyze_text_color_style(line, expected_widget_id="style_color_target")
+    assert parsed.style_mode == TEXT_STYLE_COLOR_MODE_LITERAL
+    assert parsed.style_lock_code is None
 
 
 def test_text_color_contract_does_not_route_through_coordinate_spans() -> None:


### PR DESCRIPTION
## Summary

- freeze the issue #50 scope to one adapter/property pair: explicit literal `color` on a single-line `text` statement
- add a dedicated fail-closed source analysis/write contract without reusing coordinate token semantics
- preserve unrelated bytes, quote style, and hex family while rejecting stale source, inherited values, expressions, malformed forms, duplicates, and non-text adapters
- add an opt-in Ren'Py 8.5.3 live gate with independent PNG pixel evidence for the red-to-blue reload result
- document the measured blocked verdict and keep production style controls disabled

## Verdict

`BLOCKED — style_color_product_path_missing`

The literal source rewrite and independent live pixel change are proven. The production path is intentionally not enabled because plain `text` is outside the focus-list selection path and there is no style preview/coordinator transaction, refused-attestation rollback, or product undo seam. Manual fixture restoration is recorded only as cleanup.

## Verification

- `21 passed` — `tests/test_editor_style_color_source.py`
- `1 passed in 9.39s` — opt-in Ren'Py 8.5.3 live gate
- `659 passed, 45 skipped` — full suite
- `compileall` passed
- `git diff --check` passed

Refs #50.
Blocked capability tracked in #70.
