### PR TITLE
feat(editor): add safe text color editing

### DIFF
--- a/docs/superpowers/specs/2026-07-30-renforge-visual-editor-vfull-roadmap.md
+++ b/docs/superpowers/specs/2026-07-30-renforge-visual-editor-vfull-roadmap.md
@@ -284,7 +284,7 @@ Only once the above is settled:
 - **Resize** — needs a size model per adapter (`xsize`/`ysize`/`xysize`/implicit)
 - **Rotation** — `Transform(rotate=)`; interacts badly with AABB selection
 - **Z-order / reparenting** — changes the source tree structure, not just a literal
-- **Style editing** — colours, padding, fonts; a different write contract entirely
+- **Style editing** — **Implemented for the first evidence-gated pair only** (issue #50): a single-line `text` statement with one directly authored literal hex `color`. The dedicated source contract, non-focusable text selection, preview, atomic commit/reload, independent pixel attestation, refused-attestation rollback, stable-id rebinding, and product undo pass on Ren'Py 8.5.3. Inherited/expression/ambiguous forms and every other style property or adapter remain locked.
 
 **Animated elements** (`at Transform(...)`) are untested with the `_widget_properties` seam. Spike A
 found the older override approach non-deterministic on animated variants (3 of 4 runs blocked). The

--- a/docs/superpowers/spikes/2026-08-02-style-color-result.md
+++ b/docs/superpowers/spikes/2026-08-02-style-color-result.md
@@ -2,15 +2,11 @@
 
 ## Verdict
 
-**`BLOCKED` — `style_color_product_path_missing`**
+**`PASS`**
 
-The dedicated `text` + `color` source-write contract is implemented and proven
-(unit + live Ren'Py 8.5.3 pixel evidence). Production style editing remains
-**disabled**: plain `text` is outside the focus_list selection path, and no
-style-colour preview, coordinator intent, refused-attestation rollback, or
-**product** undo surface is enabled.
+RenForge now proves the frozen `text` + `color` pair through the production in-game bridge on Ren'Py 8.5.3. The product path covers selection of a non-focusable plain text displayable, source-safe analysis, preview without a source write, transactional commit, reload, independent painted-pixel attestation, stable-id rebinding, refused-attestation rollback, and product undo.
 
-Manual fixture restore after the live run is **cleanup only**, not product undo.
+This result remains deliberately narrow. It does not enable a generic style panel, additional style properties, or additional adapters.
 
 ## Frozen pair
 
@@ -20,57 +16,91 @@ Manual fixture restore after the live run is **cleanup only**, not product undo.
 | Property | `color` |
 | Unlocked form | single-line pure hex string literal (`#rgb` / `#rrggbb` / `#rrggbbaa`) |
 | Style mode | `literal_hex` |
+| Runtime measurement | `scene_tree_text` |
 
 ## Source contract
 
 - `analyze_text_color_style` / `apply_text_color_patch` in `renforge.editor.source`
-- Dedicated colour-token spans — **not** coordinate token semantics
-- Fail-closed locks: inherited, expression, unsupported form, duplicate, non-text, block form, id mismatch
-- Unrelated bytes, quote form, and hex family preserved; stale source rejected
+- Dedicated colour-token spans — never coordinate-token semantics
+- Exactly one literal `id` matching the runtime widget id
+- Only the colour token is rewritten; unrelated bytes, quote form, and hex family are preserved
+- Stale source is rejected before publication
+- Inherited, expression-based, duplicated, multiline, malformed, non-text, ambiguous, or multi-instance targets remain locked
 
-Unit suite: `tests/test_editor_style_color_source.py` — **21 passed**
+Source/coordinator suite:
 
-## Live Ren'Py 8.5.3 evidence (observed)
+```text
+PYTHONPATH=src python -m pytest -q tests/test_editor_style_color_source.py tests/test_editor_coordinator.py
+77 passed in 12.16s
+```
 
-Opt-in: `RENFORGE_STYLE_COLOR_LIVE=1`
+## Production bridge path
+
+The in-game bridge now provides the following bounded path:
+
+1. Discover an identified plain `Text` displayable independently of `focus_list`.
+2. Resolve its source location and reject unproven ownership, ancestry, or instance identity.
+3. Preview the requested colour through `_widget_properties` without touching source bytes.
+4. Submit a dedicated colour intent to the coordinator.
+5. Shadow-lint and atomically publish the one-file transaction.
+6. Reload Ren'Py and rebind the same source target by stable id.
+7. Attest the runtime colour and independently sample the painted pixels.
+8. Roll source bytes back when attestation is deliberately refused.
+9. Undo a committed colour edit through a second product transaction and re-attest the restored colour.
+
+## Live Ren'Py 8.5.3 evidence
+
+Opt-in command:
 
 ```text
 RENFORGE_STYLE_COLOR_LIVE=1 PYTHONPATH=src python -m pytest -q tests/test_editor_style_color_live.py
-# 1 passed in 9.39s
+1 passed in 28.31s
 ```
 
-Fixture: large red `text "STYLE" color "#e22b2b"` → dedicated patch to `#2457d6`,
-plus inherited and expression lock controls.
+Fixture: large red `text "STYLE" color "#e22b2b"` changed to blue `#2457d6`, with inherited and expression-based lock controls.
 
-| Plane | Observed |
+| Plane | Observed evidence |
 | --- | --- |
-| Source unlock | target unlocks (`literal_hex`); inherited → `STYLE_COLOR_NOT_DIRECTLY_AUTHORED`; expression → `STYLE_COLOR_LITERAL_REQUIRED` |
-| Source patch | only colour token rewritten; outside-span identity true; independent expected match true |
-| Pixel before | independent PNG region sample dominant **red**, sampled inside target bounds located from the live scene tree |
-| Pixel after reload | independent PNG region sample dominant **blue** after `reload_script` + re-show, again inside live scene-tree bounds; published source reads the requested literal |
-| Product select on glyph | does **not** unlock style colour (`product_select_unlocked_style=false`) |
-| Product preview/commit/undo | all absent in the capability map observed from `editor_task0_status` |
-| Refused-attestation rollback | absent in the same observed capability map |
-| Fixture restore | byte-identical baseline restore; note = cleanup, not product undo |
-| Verdict | `blocked` / `style_color_product_path_missing` |
+| Product selection | Clicking the painted glyph selects the non-focusable plain text target and unlocks only `style_color` capabilities. |
+| Ownership locks | Direct literal unlocks; inherited and expression values return their frozen lock codes. |
+| Preview | Painted pixels become blue while fixture source remains byte-identical. |
+| Preview reset | The bridge Reset control restores red painted pixels while source remains byte-identical, then the requested preview can be applied again. |
+| Source write | Independent expected-byte construction matches; bytes outside the colour token remain identical. |
+| Refused attestation | A deliberately refused runtime attestation rolls the published bytes back to the baseline. |
+| Commit/reload | Shadow validation, atomic publication, script-generation advance, reload, and committed handshake succeed. |
+| Pixel attestation | Screenshot sampling inside independently resolved text bounds changes from dominant red to dominant blue. |
+| Rebinding | The post-reload target resolves again using the stable literal id and source location. |
+| Product undo | The bridge invokes `undo_commit`; a second validated transaction restores the original bytes and red painted result. |
+| Cleanup | Final fixture restore is byte-identical but is recorded only as cleanup, never as undo evidence. |
 
-Live test: `tests/test_editor_style_color_live.py` — **1 passed**
+The live report returns `verdict="pass"` only when every mandatory evidence field above is true. Missing product seams return `blocked`; ambiguous pixel evidence returns `inconclusive`.
 
-Full suite: **659 passed, 45 skipped**. `compileall` and `git diff --check` passed.
+## Repository gates
 
-## Why blocked (one stable reason)
+```text
+PYTHONPATH=src python -m pytest -q
+663 passed, 45 skipped in 35.82s
 
-`style_color_product_path_missing`
+python -m compileall -q src tests
+# exit 0
 
-Mandatory product seams for PASS are absent after source + pixel proof:
+git diff --check
+# exit 0
 
-1. production selection uses `focus_list` — plain `text` is non-focusable;
-2. no style-colour preview / intent / coordinator commit path;
-3. no refused-attestation rollback or **product** undo for style colour
-   (fixture restore is cleanup only).
+cd ui && npm run build
+# i18n status=GREEN, TypeScript clean, Vite build successful
+```
 
-Widening into Stage 3 non-focusable selection or a second adapter/property is
-out of frozen scope. Production style UI/control stays disabled.
+The full suite requires the locked UI dependencies (`npm ci --no-audit --no-fund` in `ui/`) because the i18n contract tests invoke the TypeScript scanner.
+
+## Deliberate limits
+
+- one adapter: `text`
+- one property: `color`
+- one physical source line
+- directly authored pure hex literal only
+- one proven static instance
+- no fonts, padding, hover/idle/selected colour families, inheritance editing, expressions, or generic property registry
 
 ## Criteria
 

--- a/docs/superpowers/spikes/2026-08-02-style-color-result.md
+++ b/docs/superpowers/spikes/2026-08-02-style-color-result.md
@@ -54,7 +54,7 @@ Opt-in command:
 
 ```text
 RENFORGE_STYLE_COLOR_LIVE=1 PYTHONPATH=src python -m pytest -q tests/test_editor_style_color_live.py
-1 passed in 28.31s
+1 passed in 34.52s
 ```
 
 Fixture: large red `text "STYLE" color "#e22b2b"` changed to blue `#2457d6`, with inherited and expression-based lock controls.

--- a/docs/superpowers/spikes/2026-08-02-style-color-result.md
+++ b/docs/superpowers/spikes/2026-08-02-style-color-result.md
@@ -31,7 +31,7 @@ Source/coordinator suite:
 
 ```text
 PYTHONPATH=src python -m pytest -q tests/test_editor_style_color_source.py tests/test_editor_coordinator.py
-77 passed in 12.16s
+77 passed in 16.19s
 ```
 
 ## Production bridge path
@@ -54,10 +54,10 @@ Opt-in command:
 
 ```text
 RENFORGE_STYLE_COLOR_LIVE=1 PYTHONPATH=src python -m pytest -q tests/test_editor_style_color_live.py
-1 passed in 34.52s
+1 passed in 26.36s
 ```
 
-Fixture: large red `text "STYLE" color "#e22b2b"` changed to blue `#2457d6`, with inherited and expression-based lock controls.
+Fixture: large red `text "STYLE" color "#e22b2b"` changed to blue `#2457d6` under an offset parent, with inherited/expression locks, a non-opaque `#rrggbbaa` runtime probe, and a repeated-loop instance lock.
 
 | Plane | Observed evidence |
 | --- | --- |
@@ -79,7 +79,7 @@ The live report returns `verdict="pass"` only when every mandatory evidence fiel
 
 ```text
 PYTHONPATH=src python -m pytest -q
-663 passed, 45 skipped in 35.82s
+663 passed, 45 skipped in 34.51s
 
 python -m compileall -q src tests
 # exit 0

--- a/src/renforge/bridge/editor.rpy
+++ b/src/renforge/bridge/editor.rpy
@@ -523,6 +523,20 @@ init 1100 python:
         return literal
 
 
+    def _renforge_editor_style_color_from_channels(channels):
+        try:
+            values = [int(channel) for channel in channels]
+        except Exception:
+            return None
+        if len(values) < 3 or any(channel < 0 or channel > 255 for channel in values[:4]):
+            return None
+        if len(values) >= 4 and values[3] != 255:
+            literal = "#%02x%02x%02x%02x" % tuple(values[:4])
+        else:
+            literal = "#%02x%02x%02x" % tuple(values[:3])
+        return _renforge_editor_normalize_style_color(literal)
+
+
     def _renforge_editor_style_color_from_widget(widget):
         if widget is None:
             return None
@@ -532,48 +546,75 @@ init 1100 python:
             color = getattr(widget, "color", None)
         if isinstance(color, str):
             return _renforge_editor_normalize_style_color(color)
-        if isinstance(color, (builtins.list, builtins.tuple)) and len(color) >= 3:
-            try:
-                return _renforge_editor_normalize_style_color(
-                    "#%02x%02x%02x" % (int(color[0]), int(color[1]), int(color[2]))
-                )
-            except Exception:
-                return None
-        # Ren'Py Color objects expose rgba channels.
+        if isinstance(color, (builtins.list, builtins.tuple)):
+            return _renforge_editor_style_color_from_channels(color)
+        # Ren'Py Color objects expose RGBA channels.
         try:
-            channels = list(color)
-            if len(channels) >= 3:
-                return _renforge_editor_normalize_style_color(
-                    "#%02x%02x%02x" % (int(channels[0]), int(channels[1]), int(channels[2]))
-                )
+            return _renforge_editor_style_color_from_channels(list(color))
         except Exception:
-            pass
-        return None
+            return None
 
 
-    def _renforge_editor_measure_text_rect(widget):
-        if widget is None:
+    def _renforge_editor_measure_text_rect(screen, widget):
+        """Measure a Text in logical screen coordinates from rendered child offsets."""
+        if screen is None or widget is None:
             return None
         width = int(getattr(renpy.config, "screen_width", 1280) or 1280)
         height = int(getattr(renpy.config, "screen_height", 720) or 720)
         render_for_size = getattr(getattr(renpy.display, "render", None), "render_for_size", None)
-        place = getattr(getattr(renpy.display, "displayable", None), "place", None)
-        get_placement = getattr(widget, "get_placement", None)
-        if not callable(render_for_size) or not callable(place) or not callable(get_placement):
+        if not callable(render_for_size):
             return None
         try:
-            surf = render_for_size(widget, width, height, 0, 0)
-            sw = getattr(surf, "width", None)
-            sh = getattr(surf, "height", None)
-            if sw is None or sh is None:
-                sw, sh = surf.get_size()
-            x, y = place(width, height, float(sw), float(sh), get_placement())
-            rect = [int(round(x)), int(round(y)), int(round(sw)), int(round(sh))]
+            # Ensure layout containers have current per-child offsets.
+            render_for_size(screen, width, height, 0, 0)
         except Exception:
             return None
-        if rect[2] <= 0 or rect[3] <= 0:
+
+        seen = set()
+
+        def walk(node, base_x, base_y, depth):
+            if node is None or depth > _CACHE_WALK_MAX_DEPTH or id(node) in seen:
+                return None
+            seen.add(id(node))
+            if id(node) == id(widget):
+                try:
+                    surf = render_for_size(widget, width, height, 0, 0)
+                    sw = getattr(surf, "width", None)
+                    sh = getattr(surf, "height", None)
+                    if sw is None or sh is None:
+                        sw, sh = surf.get_size()
+                    rect = [int(round(base_x)), int(round(base_y)), int(round(sw)), int(round(sh))]
+                except Exception:
+                    return None
+                return rect if rect[2] > 0 and rect[3] > 0 else None
+
+            class_name = getattr(getattr(node, "__class__", None), "__name__", "unknown")
+            # Transform child coordinates require the render matrix, not additive
+            # offsets. Keep those text descendants unselectable until proven.
+            if class_name == "Transform":
+                return None
+            children = _renforge_editor_children(node)
+            if not children:
+                return None
+            offsets = getattr(node, "offsets", None)
+            for index, child in enumerate(children):
+                if offsets is not None and index < len(offsets):
+                    try:
+                        offset_x = int(offsets[index][0])
+                        offset_y = int(offsets[index][1])
+                    except Exception:
+                        continue
+                elif len(children) == 1 and class_name == "ScreenDisplayable":
+                    offset_x = offset_y = 0
+                else:
+                    # No rendered placement proof for this branch.
+                    continue
+                found = walk(child, base_x + offset_x, base_y + offset_y, depth + 1)
+                if found is not None:
+                    return found
             return None
-        return rect
+
+        return walk(screen, 0, 0, 0)
 
 
     def _renforge_editor_style_color_capable():
@@ -1430,6 +1471,8 @@ init 1100 python:
         screen, widgets = _renforge_editor_widget_map(screen_name)
         if screen is None:
             return None, "MISSING_SCREEN", None
+        cache_index = instances.get(screen_name) if instances else None
+        cache_entry = cache_index["entries"].get(id(widget)) if cache_index else None
         named_widget = None
         if isinstance(widgets, builtins.dict):
             named_widget = widgets.get(widget_id)
@@ -1483,7 +1526,15 @@ init 1100 python:
                     "layout": layout_name,
                 }
             )
-        discriminator = {"kind": "static", "instance_count": 1, "ordinal": int(ordinal)}
+        discriminator = {"kind": "static", "instance_count": 1}
+        if cache_entry is not None:
+            measured = _renforge_editor_instance_discriminator(
+                cache_entry,
+                cache_index["statement_siblings"],
+            )
+            if measured is not None:
+                discriminator = measured
+        discriminator["ordinal"] = int(ordinal)
         key = {
             "screen": screen_name,
             "invocation_path": screen_name,
@@ -1514,7 +1565,7 @@ init 1100 python:
                     is_text = False
                 if not is_text:
                     continue
-                rect = _renforge_editor_measure_text_rect(widget)
+                rect = _renforge_editor_measure_text_rect(screen, widget)
                 if rect is None:
                     continue
                 runtime_key, resolve_error, named_widget = _renforge_editor_runtime_key_from_text_widget(

--- a/src/renforge/bridge/editor.rpy
+++ b/src/renforge/bridge/editor.rpy
@@ -176,6 +176,14 @@ screen _renforge_editor_overlay():
                         hover_background Solid("#8b5cf6")
                         insensitive_background Solid("#3f3f46")
                         text_color "#ffffff"
+                    if _renforge_editor_style_color_capable():
+                        textbutton _renforge_editor_style_color_label():
+                            id "rf_style_color"
+                            action Function(_renforge_editor_consume, _renforge_editor_cycle_style_color_preview)
+                            sensitive not _renforge_editor_state().save_in_progress
+                            background Solid("#2457d6")
+                            hover_background Solid("#3b6fe0")
+                            text_color "#ffffff"
 
         if _renforge_editor_opacity() < 0.25:
             $ _rf_exit_rect = _renforge_editor_control_rect("rf_exit")
@@ -274,6 +282,7 @@ init 1100 python:
             state.selected_rect = None
             state.preview_position = None
             state.preview_size = None
+            state.style_color_input = ""
             state.pointer = [0, 0]
             state.drag_active = False
             state.drag_offset = [0, 0]
@@ -311,6 +320,10 @@ init 1100 python:
             state.pending_analysis_key = None
             state.pending_transaction_id = None
             state.pending_transaction_state = None
+            state.pending_operation = None
+            state.last_committed_transaction_id = None
+            state.pending_commit_is_style_color = False
+            state.refuse_next_style_attestation = False
             state.pending_commit_request_id = None
             state.pending_status_request_id = None
             state.pending_attest_request_id = None
@@ -367,6 +380,16 @@ init 1100 python:
             state.selected_source_size = None
         if not hasattr(state, "preview_size"):
             state.preview_size = None
+        if not hasattr(state, "style_color_input"):
+            state.style_color_input = ""
+        if not hasattr(state, "pending_operation"):
+            state.pending_operation = None
+        if not hasattr(state, "last_committed_transaction_id"):
+            state.last_committed_transaction_id = None
+        if not hasattr(state, "pending_commit_is_style_color"):
+            state.pending_commit_is_style_color = False
+        if not hasattr(state, "refuse_next_style_attestation"):
+            state.refuse_next_style_attestation = False
         return state
 
 
@@ -449,12 +472,125 @@ init 1100 python:
 
     def _renforge_editor_can_undo():
         state = _renforge_editor_state()
-        return state.history_index >= 0
+        return (
+            state.history_index >= 0
+            or (
+                bool(state.last_committed_transaction_id)
+                and not bool(state.save_in_progress)
+            )
+        )
 
 
     def _renforge_editor_can_redo():
         state = _renforge_editor_state()
         return state.history_index + 1 < len(state.history_entries)
+
+
+    def _renforge_editor_normalize_style_color(value):
+        if not isinstance(value, str):
+            return None
+        normalized = value.strip().lower()
+        if not normalized.startswith("#"):
+            return None
+        body = normalized[1:]
+        if any(char not in "0123456789abcdef" for char in body):
+            return None
+        if len(body) == 3:
+            body = "".join(ch * 2 for ch in body)
+        elif len(body) == 8 and body.endswith("ff"):
+            body = body[:6]
+        elif len(body) == 6:
+            pass
+        elif len(body) == 8:
+            return "#" + body
+        else:
+            return None
+        return "#" + body
+
+
+    def _renforge_editor_literal_style_color(value):
+        """Validate a writable colour without collapsing its source hex family."""
+        if not isinstance(value, str):
+            return None
+        literal = value.strip().lower()
+        if not literal.startswith("#"):
+            return None
+        body = literal[1:]
+        if len(body) not in (3, 6, 8):
+            return None
+        if any(char not in "0123456789abcdef" for char in body):
+            return None
+        return literal
+
+
+    def _renforge_editor_style_color_from_widget(widget):
+        if widget is None:
+            return None
+        style = getattr(widget, "style", None)
+        color = getattr(style, "color", None) if style is not None else None
+        if color is None:
+            color = getattr(widget, "color", None)
+        if isinstance(color, str):
+            return _renforge_editor_normalize_style_color(color)
+        if isinstance(color, (builtins.list, builtins.tuple)) and len(color) >= 3:
+            try:
+                return _renforge_editor_normalize_style_color(
+                    "#%02x%02x%02x" % (int(color[0]), int(color[1]), int(color[2]))
+                )
+            except Exception:
+                return None
+        # Ren'Py Color objects expose rgba channels.
+        try:
+            channels = list(color)
+            if len(channels) >= 3:
+                return _renforge_editor_normalize_style_color(
+                    "#%02x%02x%02x" % (int(channels[0]), int(channels[1]), int(channels[2]))
+                )
+        except Exception:
+            pass
+        return None
+
+
+    def _renforge_editor_measure_text_rect(widget):
+        if widget is None:
+            return None
+        width = int(getattr(renpy.config, "screen_width", 1280) or 1280)
+        height = int(getattr(renpy.config, "screen_height", 720) or 720)
+        render_for_size = getattr(getattr(renpy.display, "render", None), "render_for_size", None)
+        place = getattr(getattr(renpy.display, "displayable", None), "place", None)
+        get_placement = getattr(widget, "get_placement", None)
+        if not callable(render_for_size) or not callable(place) or not callable(get_placement):
+            return None
+        try:
+            surf = render_for_size(widget, width, height, 0, 0)
+            sw = getattr(surf, "width", None)
+            sh = getattr(surf, "height", None)
+            if sw is None or sh is None:
+                sw, sh = surf.get_size()
+            x, y = place(width, height, float(sw), float(sh), get_placement())
+            rect = [int(round(x)), int(round(y)), int(round(sw)), int(round(sh))]
+        except Exception:
+            return None
+        if rect[2] <= 0 or rect[3] <= 0:
+            return None
+        return rect
+
+
+    def _renforge_editor_style_color_capable():
+        state = _renforge_editor_state()
+        caps = state.current_capabilities or {}
+        return bool(caps.get("style_color") is True and state.selected_lock_reason in (None, ""))
+
+
+    def _renforge_editor_style_color_label():
+        state = _renforge_editor_state()
+        target = state.targets.get(state.selected_target_key) if state.selected_target_key else None
+        color = None
+        if isinstance(target, builtins.dict):
+            color = target.get("style_color") or target.get("style_color_baseline")
+        if not color:
+            color = state.style_color_input or "#------"
+        return "Color %s" % color
 
 
     def _renforge_editor_has_selection():
@@ -570,7 +706,7 @@ init 1100 python:
                         if auth.get("ok") is not True:
                             return auth
                         command_payload = builtins.dict(request.get("payload") or {})
-                        if request.get("command") == "commit":
+                        if request.get("command") in ("commit", "undo_commit"):
                             command_payload["session_id"] = auth.get("session_id")
                         command_frame = {
                             "protocol": "renforge-editor",
@@ -1252,6 +1388,200 @@ init 1100 python:
         return candidates
 
 
+    def _renforge_editor_active_game_screens():
+        names = []
+        seen = set()
+        state = _renforge_editor_state()
+        for name in (state.editor_session_screen, state.screen, state.selected_screen):
+            if isinstance(name, str) and name and name not in _EDITOR_SCREENS and name not in seen:
+                seen.add(name)
+                names.append(name)
+        try:
+            sl = renpy.game.context().scene_lists
+            layer_map = getattr(sl, "layers", {}) or {}
+            for sle in layer_map.get("screens", []) or []:
+                d = getattr(sle, "displayable", None)
+                sn = getattr(d, "screen_name", None)
+                if isinstance(sn, (builtins.list, builtins.tuple)) and sn:
+                    name = sn[0]
+                elif sn:
+                    name = sn
+                else:
+                    tag = getattr(sle, "tag", None)
+                    name = tag
+                if isinstance(name, str) and name and name not in _EDITOR_SCREENS and name not in seen:
+                    seen.add(name)
+                    names.append(name)
+        except Exception:
+            pass
+        return names
+
+
+    def _renforge_editor_runtime_key_from_text_widget(screen_name, widget, widget_id, ordinal, instances=None):
+        if not isinstance(screen_name, str) or not screen_name:
+            return None, "MISSING_INVOCATION_PATH", None
+        if not isinstance(widget_id, str) or not widget_id:
+            return None, "SYNTHETIC_WIDGET_ID", None
+        try:
+            if not isinstance(widget, renpy.text.text.Text):
+                return None, "STATEMENT_KIND_MISMATCH", None
+        except Exception:
+            return None, "STATEMENT_KIND_MISMATCH", None
+        screen, widgets = _renforge_editor_widget_map(screen_name)
+        if screen is None:
+            return None, "MISSING_SCREEN", None
+        named_widget = None
+        if isinstance(widgets, builtins.dict):
+            named_widget = widgets.get(widget_id)
+        if named_widget is None:
+            named_widget = widget
+        source_location = _renforge_editor_location(named_widget)
+        if source_location is None:
+            source_location = _renforge_editor_location(widget)
+        if source_location is None:
+            return None, "MISSING_SOURCE_LOCATION", None
+        ancestry_nodes = _renforge_editor_find_ancestry(screen, widget)
+        if not ancestry_nodes:
+            ancestry_nodes = _renforge_editor_find_ancestry(screen, named_widget)
+        if not ancestry_nodes:
+            return None, "UNKNOWN_ANCESTRY_TYPE", None
+        ancestry = []
+        for index, node in enumerate(ancestry_nodes):
+            class_name = getattr(getattr(node, "__class__", None), "__name__", "unknown")
+            if class_name not in _ALLOWED_ANCESTRY_TYPES:
+                return None, "UNKNOWN_ANCESTRY_TYPE", None
+            crop_state = _renforge_editor_crop_state(node, focus=None, target=widget)
+            if crop_state not in (
+                "none",
+                "viewport",
+                "crop_displayable",
+                "transform_crop",
+                "transform_crop_composite",
+                "transform_crop_partial",
+                "transform_crop_unproven",
+                "clipping_true",
+            ):
+                return None, "UNKNOWN_CROP_STATE", None
+            editor_owned = bool(
+                screen_name in _EDITOR_SCREENS
+                or getattr(node, "_renforge_editor_owner", None) == _EDITOR_OWNER
+                or getattr(named_widget, "_renforge_editor_owner", None) == _EDITOR_OWNER
+            )
+            style = getattr(node, "style", None)
+            layout = getattr(style, "box_layout", None) if style is not None else None
+            if layout is None:
+                layout = getattr(node, "default_layout", None)
+            layout_name = layout if isinstance(layout, builtins.str) else None
+            ancestry.append(
+                {
+                    "index": int(index),
+                    "type": class_name,
+                    "source_location": _renforge_editor_location(node),
+                    "screen_owner": _EDITOR_OWNER if editor_owned else "game",
+                    "crop_state": crop_state,
+                    "editor_owned": editor_owned,
+                    "layout": layout_name,
+                }
+            )
+        discriminator = {"kind": "static", "instance_count": 1, "ordinal": int(ordinal)}
+        key = {
+            "screen": screen_name,
+            "invocation_path": screen_name,
+            "widget_id": widget_id,
+            "source_location": source_location,
+            "instance_discriminator": discriminator,
+            "ancestry": ancestry,
+        }
+        return key, None, named_widget
+
+
+    def _renforge_editor_text_candidates():
+        """Discover non-focusable Text targets with literal ids (scene_tree_text)."""
+        candidates = []
+        instances = {}
+        ordinal = 100000
+        for screen_name in _renforge_editor_active_game_screens():
+            screen, widgets = _renforge_editor_widget_map(screen_name)
+            if screen is None or not isinstance(widgets, builtins.dict):
+                continue
+            _renforge_editor_screen_instances(screen_name, instances)
+            for widget_id, widget in list(widgets.items()):
+                if not isinstance(widget_id, str) or not widget_id:
+                    continue
+                try:
+                    is_text = isinstance(widget, renpy.text.text.Text)
+                except Exception:
+                    is_text = False
+                if not is_text:
+                    continue
+                rect = _renforge_editor_measure_text_rect(widget)
+                if rect is None:
+                    continue
+                runtime_key, resolve_error, named_widget = _renforge_editor_runtime_key_from_text_widget(
+                    screen_name,
+                    widget,
+                    widget_id,
+                    ordinal,
+                    instances,
+                )
+                ordinal += 1
+                owner_hit = bool(screen_name in _EDITOR_SCREENS)
+                if runtime_key is not None:
+                    for node in runtime_key.get("ancestry", []):
+                        if bool(node.get("editor_owned")):
+                            owner_hit = True
+                            break
+                # Read painted/runtime style from the displayable only. Target
+                # preview maps must not override attestation after reload: a
+                # stale dirty colour would refuse a correct product undo.
+                style_color = _renforge_editor_style_color_from_widget(widget)
+                candidates.append(
+                    {
+                        "focus": None,
+                        "rect": rect,
+                        "ordinal": int(ordinal - 1),
+                        "runtime_key": runtime_key,
+                        "resolve_error": resolve_error,
+                        "named_widget": named_widget,
+                        "focused_widget": widget,
+                        "editor_owned": owner_hit,
+                        "measurement_method": "scene_tree_text",
+                        "style_color": style_color,
+                    }
+                )
+        counts = {}
+        for candidate in candidates:
+            key = candidate.get("runtime_key")
+            if not isinstance(key, builtins.dict):
+                continue
+            signature = (
+                key.get("screen"),
+                key.get("widget_id"),
+                tuple(key.get("source_location") or []),
+            )
+            counts[signature] = counts.get(signature, 0) + 1
+        for candidate in candidates:
+            key = candidate.get("runtime_key")
+            if not isinstance(key, builtins.dict):
+                continue
+            signature = (
+                key.get("screen"),
+                key.get("widget_id"),
+                tuple(key.get("source_location") or []),
+            )
+            if counts.get(signature, 0) <= 1:
+                continue
+            discriminator = key.get("instance_discriminator") or {}
+            if discriminator.get("kind") in ("loop", "use"):
+                continue
+            candidate["resolve_error"] = "MULTI_INSTANCE_UNSUPPORTED"
+        return candidates
+
+
+    def _renforge_editor_all_candidates():
+        return list(_renforge_editor_focus_candidates()) + list(_renforge_editor_text_candidates())
+
+
     def _renforge_editor_barrier():
         renpy.restart_interaction()
         data = renpy.screenshot_to_bytes(None)
@@ -1275,14 +1605,20 @@ init 1100 python:
             return None, "UNMEASURED"
         script_generation = int(_renforge_editor_state().script_generation)
         focused_widget = candidate.get("focused_widget")
+        measurement_method = candidate.get("measurement_method") or "focus_list"
         observation = {
             "runtime_key": runtime_key,
             "rect": [int(rect[0]), int(rect[1]), int(rect[2]), int(rect[3])],
-            "measurement_method": "focus_list",
+            "measurement_method": measurement_method,
             "frame_id": frame_id,
             "script_generation": script_generation,
             "object_id": id(focused_widget) if focused_widget is not None else None,
         }
+        style_color = candidate.get("style_color")
+        if style_color is None and focused_widget is not None:
+            style_color = _renforge_editor_style_color_from_widget(focused_widget)
+        if style_color is not None:
+            observation["style_color"] = style_color
         return observation, None
 
 
@@ -1400,41 +1736,56 @@ init 1100 python:
         state = _renforge_editor_state()
         properties = {}
         for target in state.targets.values():
-            if target.get("screen") != screen or not target.get("dirty"):
+            if target.get("screen") != screen:
                 continue
+            widget_id = target.get("widget_id")
+            if not widget_id:
+                continue
+            props = {}
+            style_color = _renforge_editor_literal_style_color(target.get("style_color"))
+            comparable_style = _renforge_editor_normalize_style_color(style_color)
+            baseline_style = _renforge_editor_normalize_style_color(target.get("style_color_baseline"))
+            style_dirty = bool(
+                style_color is not None
+                and comparable_style != baseline_style
+                and (target.get("capabilities") or {}).get("style_color") is True
+            )
             position = target.get("position")
             runtime_baseline = target.get("runtime_baseline")
             source_position = target.get("source_position")
-            widget_id = target.get("widget_id")
-            if not (
-                isinstance(position, (builtins.list, tuple))
+            position_dirty = bool(
+                target.get("dirty")
+                and isinstance(position, (builtins.list, tuple))
                 and len(position) == 2
                 and isinstance(runtime_baseline, (builtins.list, tuple))
                 and len(runtime_baseline) == 2
                 and isinstance(source_position, (builtins.list, tuple))
                 and len(source_position) == 2
-                and widget_id
-            ):
-                continue
-            next_x = int(source_position[0]) + int(position[0]) - int(runtime_baseline[0])
-            next_y = int(source_position[1]) + int(position[1]) - int(runtime_baseline[1])
-            source_key = target.get("source_key") or {}
-            position_mode = source_key.get("position_mode") if builtins.isinstance(source_key, builtins.dict) else None
-            props = _renforge_editor_preview_properties(next_x, next_y, position_mode)
-            size = target.get("size")
-            runtime_size = target.get("runtime_size")
-            source_size = target.get("source_size")
-            if (
-                isinstance(size, (builtins.list, tuple))
-                and len(size) == 2
-                and isinstance(runtime_size, (builtins.list, tuple))
-                and len(runtime_size) == 2
-                and isinstance(source_size, (builtins.list, tuple))
-                and len(source_size) == 2
-            ):
-                props["xsize"] = int(source_size[0]) + int(size[0]) - int(runtime_size[0])
-                props["ysize"] = int(source_size[1]) + int(size[1]) - int(runtime_size[1])
-            properties[str(widget_id)] = props
+                and (target.get("capabilities") or {}).get("move") is not False
+            )
+            if position_dirty:
+                next_x = int(source_position[0]) + int(position[0]) - int(runtime_baseline[0])
+                next_y = int(source_position[1]) + int(position[1]) - int(runtime_baseline[1])
+                source_key = target.get("source_key") or {}
+                position_mode = source_key.get("position_mode") if builtins.isinstance(source_key, builtins.dict) else None
+                props.update(_renforge_editor_preview_properties(next_x, next_y, position_mode))
+                size = target.get("size")
+                runtime_size = target.get("runtime_size")
+                source_size = target.get("source_size")
+                if (
+                    isinstance(size, (builtins.list, tuple))
+                    and len(size) == 2
+                    and isinstance(runtime_size, (builtins.list, tuple))
+                    and len(runtime_size) == 2
+                    and isinstance(source_size, (builtins.list, tuple))
+                    and len(source_size) == 2
+                ):
+                    props["xsize"] = int(source_size[0]) + int(size[0]) - int(runtime_size[0])
+                    props["ysize"] = int(source_size[1]) + int(size[1]) - int(runtime_size[1])
+            if style_dirty:
+                props["color"] = style_color
+            if props:
+                properties[str(widget_id)] = props
         return properties
 
 
@@ -1561,13 +1912,33 @@ init 1100 python:
         ):
             analysis_id = target.get("analysis_id")
             source_key = target.get("source_key")
+            if not (analysis_id and isinstance(source_key, builtins.dict)):
+                return []
+            capabilities = target.get("capabilities") or {}
+            style_color = _renforge_editor_literal_style_color(target.get("style_color"))
+            baseline_literal = _renforge_editor_literal_style_color(target.get("style_color_baseline"))
+            if capabilities.get("style_color") is True:
+                if (
+                    style_color is None
+                    or baseline_literal is None
+                    or len(style_color) != len(baseline_literal)
+                    or _renforge_editor_normalize_style_color(style_color)
+                    == _renforge_editor_normalize_style_color(baseline_literal)
+                ):
+                    return []
+                intents.append(
+                    {
+                        "analysis_id": analysis_id,
+                        "source_key": source_key,
+                        "color": style_color,
+                    }
+                )
+                continue
             position = target.get("position")
             runtime_baseline = target.get("runtime_baseline")
             source_position = target.get("source_position")
             if not (
-                analysis_id
-                and isinstance(source_key, builtins.dict)
-                and isinstance(position, (builtins.list, tuple))
+                isinstance(position, (builtins.list, tuple))
                 and len(position) == 2
                 and isinstance(runtime_baseline, (builtins.list, tuple))
                 and len(runtime_baseline) == 2
@@ -1613,7 +1984,13 @@ init 1100 python:
         if not isinstance(command, builtins.dict):
             return {"ok": False, "error": "NO_HISTORY"}
         value = command.get("before") if use_before else command.get("after")
-        if command.get("kind") == "size":
+        if command.get("kind") == "style_color":
+            state = _renforge_editor_state()
+            previous_key = state.selected_target_key
+            state.selected_target_key = command.get("target_key")
+            result = _renforge_editor_set_style_color(value, record=False)
+            state.selected_target_key = previous_key
+        elif command.get("kind") == "size":
             result = _renforge_editor_set_target_size(command.get("target_key"), value)
         elif command.get("kind") == "reset":
             result = _renforge_editor_set_target_position(command.get("target_key"), value)
@@ -1626,6 +2003,15 @@ init 1100 python:
                 )
                 if not size_result.get("ok", False):
                     result = size_result
+            color_key = "before_color" if use_before else "after_color"
+            color_value = command.get(color_key)
+            if color_value is not None:
+                previous_key = _renforge_editor_state().selected_target_key
+                _renforge_editor_state().selected_target_key = command.get("target_key")
+                color_result = _renforge_editor_set_style_color(color_value, record=False)
+                _renforge_editor_state().selected_target_key = previous_key
+                if not color_result.get("ok", False):
+                    result = color_result
         else:
             result = _renforge_editor_set_target_position(command.get("target_key"), value)
         _renforge_editor_refresh_save_enabled()
@@ -1633,15 +2019,111 @@ init 1100 python:
         return result
 
 
+    def _renforge_editor_set_style_color(color, *, record=True):
+        state = _renforge_editor_state()
+        if not _renforge_editor_style_color_capable():
+            return {"ok": False, "error": "STYLE_COLOR_UNAVAILABLE"}
+        literal = _renforge_editor_literal_style_color(color)
+        if literal is None:
+            return {"ok": False, "error": "STYLE_COLOR_INVALID"}
+        target_key = state.selected_target_key
+        target = state.targets.get(target_key)
+        if not isinstance(target, builtins.dict):
+            return {"ok": False, "error": "TARGET_NOT_FOUND"}
+        baseline_literal = _renforge_editor_literal_style_color(target.get("style_color_baseline"))
+        previous_literal = _renforge_editor_literal_style_color(target.get("style_color")) or baseline_literal
+        if baseline_literal is None or len(literal) != len(baseline_literal):
+            return {"ok": False, "error": "STYLE_COLOR_HEX_FAMILY_MISMATCH"}
+        normalized = _renforge_editor_normalize_style_color(literal)
+        baseline = _renforge_editor_normalize_style_color(baseline_literal)
+        previous = _renforge_editor_normalize_style_color(previous_literal)
+        if previous == normalized:
+            state.style_color_input = previous_literal or literal
+            return {"ok": True, "color": previous_literal or literal, "changed": False}
+        if record:
+            if state.history_index + 1 < len(state.history_entries):
+                state.history_entries = state.history_entries[: state.history_index + 1]
+            state.history_entries.append(
+                {
+                    "target_key": target_key,
+                    "kind": "style_color",
+                    "before": previous_literal,
+                    "after": literal,
+                }
+            )
+            state.history = list(state.history_entries)
+            state.history_index = len(state.history_entries) - 1
+        target["style_color"] = literal
+        target["dirty"] = bool(normalized != baseline)
+        state.style_color_input = literal
+        state.save_button_state = "idle"
+        _renforge_editor_set_current_analysis(
+            state,
+            target.get("analysis_id"),
+            target.get("source_key"),
+            target.get("capabilities"),
+        )
+        _renforge_editor_show_target_overrides(target.get("screen"))
+        state.last_preview_method = "_widget_properties_color"
+        _renforge_editor_refresh_save_enabled()
+        renpy.restart_interaction()
+        return {
+            "ok": True,
+            "color": literal,
+            "changed": True,
+            "dirty": bool(target.get("dirty")),
+            "method": "_widget_properties_color",
+            "source_unchanged": True,
+        }
+
+
+    def _renforge_editor_cycle_style_color_preview():
+        """Minimal in-game control: toggle between baseline and a fixed blue proof colour."""
+        state = _renforge_editor_state()
+        target = state.targets.get(state.selected_target_key)
+        if not isinstance(target, builtins.dict):
+            return {"ok": False, "error": "TARGET_NOT_FOUND"}
+        baseline = _renforge_editor_literal_style_color(target.get("style_color_baseline")) or "#e22b2b"
+        current = _renforge_editor_literal_style_color(target.get("style_color")) or baseline
+        if len(baseline) == 4:
+            proof_color = "#25d"
+        elif len(baseline) == 9:
+            proof_color = "#2457d6" + baseline[-2:]
+        else:
+            proof_color = "#2457d6"
+        next_color = proof_color if current != proof_color else baseline
+        return _renforge_editor_set_style_color(next_color, record=True)
+
+
     def _renforge_editor_undo():
         state = _renforge_editor_state()
         if not _renforge_editor_can_undo():
             state.status_text = "Undo unavailable"
             return {"ok": False, "error": "UNDO_UNAVAILABLE"}
-        command = state.history_entries[state.history_index]
-        state.history_index -= 1
-        state.status_text = "Undo"
-        return _renforge_editor_apply_history_command(command, use_before=True)
+        if state.history_index >= 0:
+            command = state.history_entries[state.history_index]
+            state.history_index -= 1
+            state.status_text = "Undo"
+            return _renforge_editor_apply_history_command(command, use_before=True)
+        transaction_id = state.last_committed_transaction_id
+        if not transaction_id or state.save_in_progress:
+            state.status_text = "Undo unavailable"
+            return {"ok": False, "error": "UNDO_UNAVAILABLE"}
+        state.save_in_progress = True
+        state.save_button_state = "saving"
+        state.save_requested = True
+        state.save_error = None
+        state.save_last_error = None
+        state.pending_operation = "undo_commit"
+        state.status_text = "Undoing"
+        pending = _renforge_editor_ensure_coordinator().submit_host(
+            "undo_commit",
+            {"transaction_id": transaction_id},
+            {"command": "undo_commit", "transaction_id": transaction_id},
+        )
+        state.pending_commit_request_id = pending
+        renpy.restart_interaction()
+        return {"ok": True, "request_id": pending, "transaction_id": transaction_id, "kind": "product_undo"}
 
 
     def _renforge_editor_redo():
@@ -1664,13 +2146,21 @@ init 1100 python:
         baseline = list(target.get("runtime_baseline") or [])
         before_size = list(target.get("size") or [])
         baseline_size = list(target.get("runtime_size") or [])
+        before_color = _renforge_editor_literal_style_color(target.get("style_color"))
+        baseline_color = _renforge_editor_literal_style_color(target.get("style_color_baseline"))
         position_dirty = len(before) == 2 and len(baseline) == 2 and before != baseline
         size_dirty = (
             len(before_size) == 2
             and len(baseline_size) == 2
             and before_size != baseline_size
         )
-        if not position_dirty and not size_dirty:
+        style_dirty = (
+            before_color is not None
+            and baseline_color is not None
+            and _renforge_editor_normalize_style_color(before_color)
+            != _renforge_editor_normalize_style_color(baseline_color)
+        )
+        if not position_dirty and not size_dirty and not style_dirty:
             return {"ok": False, "error": "RESET_UNAVAILABLE"}
         if len(before) != 2 or len(baseline) != 2:
             return {"ok": False, "error": "RESET_UNAVAILABLE"}
@@ -1683,6 +2173,8 @@ init 1100 python:
             "after": baseline,
             "before_size": before_size if len(before_size) == 2 else None,
             "after_size": baseline_size if len(baseline_size) == 2 else None,
+            "before_color": before_color if style_dirty else None,
+            "after_color": baseline_color if style_dirty else None,
         }
         state.history_entries.append(command)
         state.history = [list(entry.get("after") or []) for entry in state.history_entries]
@@ -1954,7 +2446,7 @@ init 1100 python:
         selected_screen = selected_key.get("screen")
         selected_widget = selected_key.get("widget_id")
         selected_source = tuple(selected_key.get("source_location") or [])
-        for candidate in _renforge_editor_focus_candidates():
+        for candidate in _renforge_editor_all_candidates():
             if candidate.get("editor_owned"):
                 continue
             key = candidate.get("runtime_key")
@@ -1967,6 +2459,8 @@ init 1100 python:
                     and key.get("widget_id") == selected_widget
                     and tuple(key.get("source_location") or []) == selected_source
                 ):
+                    loose_matches.append(candidate)
+                elif _renforge_editor_rebind_signature(key) == _renforge_editor_rebind_signature(selected_key):
                     loose_matches.append(candidate)
         if len(matches) == 0:
             if len(loose_matches) == 1:
@@ -1986,9 +2480,51 @@ init 1100 python:
             state.accepted_observations[:] = state.accepted_observations[-20:]
 
 
+    def _renforge_editor_hit_candidates(x, y):
+        """Return focus hits first; only fall back to text when no focusable covers the point."""
+        focus_hits = []
+        for candidate in reversed(_renforge_editor_focus_candidates()):
+            if candidate.get("editor_owned"):
+                continue
+            rect = candidate.get("rect") or []
+            if len(rect) != 4:
+                continue
+            if rect[0] <= int(x) < rect[0] + rect[2] and rect[1] <= int(y) < rect[1] + rect[3]:
+                focus_hits.append(candidate)
+        if focus_hits:
+            return focus_hits
+        text_hits = []
+        for candidate in reversed(_renforge_editor_text_candidates()):
+            if candidate.get("editor_owned"):
+                continue
+            rect = candidate.get("rect") or []
+            if len(rect) != 4:
+                continue
+            if rect[0] <= int(x) < rect[0] + rect[2] and rect[1] <= int(y) < rect[1] + rect[3]:
+                text_hits.append(candidate)
+        return text_hits
+
+
     def _renforge_editor_select(x, y):
         state = _renforge_editor_state()
-        for candidate in reversed(_renforge_editor_focus_candidates()):
+        hits = _renforge_editor_hit_candidates(x, y)
+        if not hits:
+            return {"ok": False, "error": "NO_FOCUSABLE_TARGET"}
+        # Fail closed when multiple non-focusable text targets cover the same point.
+        if (
+            len(hits) > 1
+            and all(c.get("measurement_method") == "scene_tree_text" for c in hits)
+        ):
+            state.pointer = [int(x), int(y)]
+            state.selected_runtime_key = None
+            state.selected_widget_id = None
+            state.selected_lock_reason = "AMBIGUOUS_HIT"
+            state.selected_rect = None
+            _renforge_editor_clear_current_analysis(state)
+            state.save_enabled = False
+            _renforge_editor_set_label(x, y)
+            return {"ok": False, "lock_reason": "AMBIGUOUS_HIT", "error": "AMBIGUOUS_HIT"}
+        for candidate in hits:
             if candidate.get("editor_owned"):
                 continue
             rect = candidate.get("rect") or []
@@ -2059,6 +2595,7 @@ init 1100 python:
                 state.selected_source_size = list(target.get("source_size") or []) or None
                 state.preview_position = position
                 state.preview_size = size if len(size) == 2 else None
+                state.style_color_input = target.get("style_color") or target.get("style_color_baseline") or ""
                 selected_size = size if len(size) == 2 else rect[2:4]
                 state.selected_rect = [
                     int(position[0]),
@@ -2362,7 +2899,10 @@ init 1100 python:
         if pygame is not None:
             if event_type == getattr(pygame, "MOUSEBUTTONDOWN", None) and getattr(event, "button", 0) == 1:
                 _renforge_editor_select(pointer_x, pointer_y)
-                if not state.selected_lock_reason:
+                if (
+                    not state.selected_lock_reason
+                    and (state.current_capabilities or {}).get("move", True) is True
+                ):
                     _renforge_editor_apply_drag_from_pointer(pointer_x, pointer_y, shift)
                 raise renpy.IgnoreEvent()
             if event_type == getattr(pygame, "MOUSEMOTION", None) and state.drag_active:
@@ -2429,12 +2969,13 @@ init 1100 python:
                         state.selected_analysis_pending = False
                         _renforge_editor_clear_current_analysis(state)
                         state.status_text = "Analyze failed"
-                    elif command == "commit":
+                    elif command in ("commit", "undo_commit"):
                         state.save_in_progress = False
                         state.save_enabled = False
                         state.status_text = "Commit failed"
                         state.save_requested = False
                         state.pending_transaction_id = None
+                        state.pending_operation = None
                         state.pending_handshake_generation = None
                         state.pending_handshake_sent = False
                         state.pending_reload_requested = False
@@ -2448,6 +2989,7 @@ init 1100 python:
                         state.save_enabled = False
                         state.save_requested = False
                         state.pending_transaction_id = None
+                        state.pending_operation = None
                         state.pending_handshake_generation = None
                         state.pending_handshake_sent = False
                         state.pending_reload_requested = False
@@ -2504,6 +3046,11 @@ init 1100 python:
                                 state.selected_original_size = None
                                 state.preview_size = None
                             state.selected_target_key = target_key
+                            source_key = state.current_source_key or {}
+                            baseline_style = None
+                            if isinstance(source_key, builtins.dict):
+                                baseline_style = _renforge_editor_literal_style_color(source_key.get("style_color"))
+                            state.style_color_input = baseline_style or ""
                             state.targets[target_key] = {
                                 "analysis_id": state.current_analysis_id,
                                 "source_key": state.current_source_key,
@@ -2517,6 +3064,8 @@ init 1100 python:
                                 "runtime_size": list(state.selected_original_size) if state.selected_original_size is not None else None,
                                 "source_size": list(state.selected_source_size) if state.selected_source_size is not None else None,
                                 "size": list(state.selected_original_size) if state.selected_original_size is not None else None,
+                                "style_color_baseline": baseline_style,
+                                "style_color": baseline_style,
                                 "dirty": False,
                                 "generation": int(state.script_generation),
                             }
@@ -2526,13 +3075,14 @@ init 1100 python:
                         state.save_enabled = False
                         state.status_text = "Locked"
                         _renforge_editor_clear_current_analysis(state)
-                elif command == "commit":
+                elif command in ("commit", "undo_commit"):
                     state.pending_transaction_id = result.get("transaction_id")
                     state.pending_transaction_state = result.get("state")
+                    state.pending_operation = command
                     if state.pending_transaction_id is None:
                         state.save_in_progress = False
                         state.save_enabled = False
-                        state.save_last_error = "commit missing transaction id"
+                        state.save_last_error = "%s missing transaction id" % command
                         state.status_text = "Commit failed"
                     else:
                         state.pending_reload_draw_generation = None
@@ -2545,7 +3095,7 @@ init 1100 python:
                         state.save_in_progress = True
                         state.save_error = None
                         state.save_last_error = None
-                        state.status_text = "Commit queued"
+                        state.status_text = "Undo queued" if command == "undo_commit" else "Commit queued"
                 elif command == "commit_status":
                     state.last_commit_status = result
                     state.pending_transaction_state = result.get("state")
@@ -2561,6 +3111,8 @@ init 1100 python:
                         state.save_error = str(state.save_last_error)
                 elif command == "reload_handshake":
                     if result.get("state") == "committed":
+                        committed_tx = state.pending_transaction_id
+                        operation = state.pending_operation
                         state.pending_handshake_generation = None
                         state.save_in_progress = False
                         state.save_last_error = None
@@ -2572,6 +3124,14 @@ init 1100 python:
                         state.pending_reload_draw_generation = None
                         state.save_enabled = False
                         state.save_requested = False
+                        if operation == "undo_commit":
+                            state.last_committed_transaction_id = None
+                        elif bool(state.pending_commit_is_style_color):
+                            state.last_committed_transaction_id = committed_tx
+                        else:
+                            state.last_committed_transaction_id = None
+                        state.pending_commit_is_style_color = False
+                        state.pending_operation = None
                         selected_rect = list(state.selected_rect or [])
                         state.targets = {}
                         _renforge_editor_reset_history()
@@ -2610,13 +3170,14 @@ init 1100 python:
                     state.selected_analysis_pending = False
                     _renforge_editor_clear_current_analysis(state)
                     state.status_text = "Analyze failed"
-                elif command == "commit":
+                elif command in ("commit", "undo_commit"):
                     state.save_in_progress = False
                     state.save_enabled = False
                     state.status_text = "Commit failed"
                     state.save_button_state = "idle"
                     state.save_requested = False
                     state.pending_transaction_id = None
+                    state.pending_operation = None
                     state.pending_handshake_generation = None
                     state.pending_handshake_sent = False
                     state.pending_reload_requested = False
@@ -2631,6 +3192,7 @@ init 1100 python:
                     state.save_enabled = False
                     state.save_requested = False
                     state.pending_transaction_id = None
+                    state.pending_operation = None
                     state.pending_handshake_generation = None
                     state.pending_handshake_sent = False
                     state.pending_reload_requested = False
@@ -2783,6 +3345,14 @@ init 1100 python:
         state.save_requested = True
         state.save_error = None
         state.save_last_error = None
+        state.pending_commit_is_style_color = bool(
+            intents
+            and all(
+                isinstance(intent, builtins.dict)
+                and _renforge_editor_literal_style_color(intent.get("color")) is not None
+                for intent in intents
+            )
+        )
         state.status_text = "Saving"
         pending = _renforge_editor_ensure_coordinator().submit_host(
             "commit",
@@ -3014,14 +3584,14 @@ init 1100 python:
             return {"ok": False, "error": "runtime_key required"}
         candidates = [
             candidate
-            for candidate in _renforge_editor_focus_candidates()
+            for candidate in _renforge_editor_all_candidates()
             if candidate.get("runtime_key") == runtime_key
         ]
         if not candidates:
             # fallback by stable signature
             candidates = []
             wanted = _renforge_editor_rebind_signature(runtime_key)
-            for candidate in _renforge_editor_focus_candidates():
+            for candidate in _renforge_editor_all_candidates():
                 candidate_key = candidate.get("runtime_key")
                 if not isinstance(candidate_key, builtins.dict):
                     continue
@@ -3075,7 +3645,7 @@ init 1100 python:
                 return {"ok": False, "error": "widget_id missing"}
             targets = [
                 candidate
-                for candidate in _renforge_editor_focus_candidates()
+                for candidate in _renforge_editor_all_candidates()
                 if candidate.get("runtime_key") is not None
                 and _renforge_editor_same_target_key(candidate.get("runtime_key"), expected_runtime_key)
                 and isinstance(candidate.get("runtime_key", {}).get("source_location"), list)
@@ -3083,7 +3653,7 @@ init 1100 python:
             if not targets:
                 wanted = _renforge_editor_rebind_signature(expected_runtime_key)
                 signature_matches = []
-                for candidate in _renforge_editor_focus_candidates():
+                for candidate in _renforge_editor_all_candidates():
                     candidate_key = candidate.get("runtime_key")
                     if not isinstance(candidate_key, builtins.dict):
                         continue
@@ -3095,6 +3665,21 @@ init 1100 python:
                     targets = signature_matches
             if len(targets) != 1:
                 return {"ok": False, "error": "TARGET_NOT_FOUND", "widget_id": widget_id}
+            # Forced-refusal test path for style-colour attestation rollback.
+            expected_style = _renforge_editor_normalize_style_color(expected.get("style_color"))
+            if (
+                expected_style is not None
+                and os.environ.get("RENFORGE_STYLE_COLOR_LIVE") == "1"
+                and bool(state.refuse_next_style_attestation)
+            ):
+                state.refuse_next_style_attestation = False
+                return {
+                    "ok": False,
+                    "error": "STYLE_COLOR_ATTESTATION_REFUSED",
+                    "state": "refused",
+                    "widget_id": widget_id,
+                    "expected": expected_style,
+                }
             observation, observe_error = _renforge_editor_observation_for_candidate(targets[0])
             if observation is None:
                 return {"ok": False, "error": observe_error or "UNMEASURED", "widget_id": widget_id}
@@ -3105,6 +3690,16 @@ init 1100 python:
                     "expected": generation,
                     "known": observation.get("script_generation"),
                 }
+            if expected_style is not None:
+                observed_style = _renforge_editor_normalize_style_color(observation.get("style_color"))
+                if observed_style != expected_style:
+                    return {
+                        "ok": False,
+                        "error": "TARGET_STYLE_COLOR_MISMATCH",
+                        "widget_id": widget_id,
+                        "expected": expected_style,
+                        "observed": observed_style,
+                    }
             expected_position = expected.get("position")
             rect = observation.get("rect") or []
             if isinstance(expected_position, (builtins.list, tuple)) and len(expected_position) == 2:
@@ -3254,6 +3849,10 @@ init 1100 python:
                 else {}
             ),
             "pending_transaction_id": state.pending_transaction_id,
+            "pending_operation": state.pending_operation,
+            "last_committed_transaction_id": state.last_committed_transaction_id,
+            "style_color_input": state.style_color_input,
+            "refuse_next_style_attestation": bool(state.refuse_next_style_attestation),
             "pending_handshake_generation": state.pending_handshake_generation,
             "pending_handshake_sent": state.pending_handshake_sent,
             "pending_reload_requested": state.pending_reload_requested,
@@ -3390,6 +3989,23 @@ init 1100 python:
         }
 
 
+
+    def _renforge_editor_h_style_color(payload):
+        payload = payload or {}
+        color = payload.get("color")
+        if color is None:
+            return {"ok": False, "error": "color required"}
+        return _renforge_editor_set_style_color(color, record=True)
+
+
+    def _renforge_editor_h_force_style_attestation_refusal(payload):
+        if os.environ.get("RENFORGE_STYLE_COLOR_LIVE") != "1":
+            return {"ok": False, "error": "LIVE_TEST_HOOK_UNAVAILABLE"}
+        state = _renforge_editor_state()
+        state.refuse_next_style_attestation = True
+        return {"ok": True, "refuse_next_style_attestation": True}
+
+
     _renforge_editor_state()
     _renforge_editor_ensure_coordinator()
     if callable(getattr(renpy.config, "periodic_callbacks", None)):
@@ -3411,6 +4027,9 @@ init 1100 python:
         handlers["editor_task0_redo"] = _renforge_editor_h_redo
         handlers["editor_task0_reset"] = _renforge_editor_h_reset
         handlers["editor_task0_save"] = _renforge_editor_h_save
+        handlers["editor_task0_style_color"] = _renforge_editor_h_style_color
+        if os.environ.get("RENFORGE_STYLE_COLOR_LIVE") == "1":
+            handlers["editor_task0_force_style_attestation_refusal"] = _renforge_editor_h_force_style_attestation_refusal
         handlers["editor_task0_observe_selected"] = _renforge_editor_h_observe_selected
         handlers["editor_task0_restore_preview"] = _renforge_editor_h_restore_preview
         handlers["editor_task0_set_opacity"] = _renforge_editor_h_set_opacity

--- a/src/renforge/editor/coordinator.py
+++ b/src/renforge/editor/coordinator.py
@@ -34,12 +34,15 @@ from .source import (
     DEFAULT_ALIGN_PARENT_SIZE,
     BarStatement,
     EditorSourceError,
+    TextColorStyleStatement,
     align_geometry_matches_parent,
     analyze_button_statement,
     analyze_editable_statement,
+    analyze_text_color_style,
     analyze_textbutton_block_statement,
     apply_button_patch,
     apply_editable_statement_patch,
+    apply_text_color_patch,
     apply_textbutton_patch,
     is_slider_style_bar_line,
     is_textbutton_block_header,
@@ -76,6 +79,17 @@ class _AnalysisRecord:
     independent_frame_id: str
     original_size: list[int] | None = None
     runtime_size: list[int] | None = None
+
+
+@dataclass(frozen=True)
+class _SelectedIntent:
+    record: _AnalysisRecord
+    source_key: dict[str, Any]
+    x: int | None = None
+    y: int | None = None
+    width: int | None = None
+    height: int | None = None
+    color: str | None = None
 
 
 @dataclass
@@ -484,6 +498,8 @@ class EditorCoordinator:
             return self._command_analyze_target(payload)
         if command == "commit":
             return self._command_commit(payload)
+        if command == "undo_commit":
+            return self._command_undo_commit(payload)
         if command == "commit_status":
             return self._command_commit_status(payload)
         if command == "reload_handshake":
@@ -549,7 +565,21 @@ class EditorCoordinator:
             widget_id = self._require_runtime_widget_id(runtime_key)
             header_line = lines[source_line - 1]
             header_kind = peek_statement_kind(header_line)
-            if header_kind == "button":
+            position_mode: str | None = None
+            if header_kind == "text":
+                statement = analyze_text_color_style(
+                    header_line,
+                    expected_widget_id=widget_id,
+                )
+                statement_kind = "text"
+                position_mode = None
+                original_position = list(runtime_position)
+                if lock_reason is None and statement.style_lock_code is not None:
+                    lock_reason = self._lock_reason(
+                        statement.style_lock_code,
+                        statement.style_lock_message or statement.style_lock_code,
+                    )
+            elif header_kind == "button":
                 statement = analyze_button_statement(
                     source_text,
                     source_line=source_line,
@@ -568,12 +598,13 @@ class EditorCoordinator:
                     header_line,
                     expected_widget_id=widget_id,
                 )
-            # Runtime-delta modes (align/offset): original_position is focus TL.
-            position_mode = getattr(statement, "position_mode", "xy")
-            if uses_runtime_delta_position(position_mode):
-                original_position = list(runtime_position)
-            else:
-                original_position = [int(statement.xpos), int(statement.ypos)]
+            if not isinstance(statement, TextColorStyleStatement):
+                # Runtime-delta modes (align/offset): original_position is focus TL.
+                position_mode = getattr(statement, "position_mode", "xy")
+                if uses_runtime_delta_position(position_mode):
+                    original_position = list(runtime_position)
+                else:
+                    original_position = [int(statement.xpos), int(statement.ypos)]
             ancestry = runtime_key.get("ancestry")
             normalized_ancestry = (
                 [
@@ -607,6 +638,9 @@ class EditorCoordinator:
                 "baseline_sha256": source_sha,
                 "position_mode": position_mode,
             }
+            if isinstance(statement, TextColorStyleStatement):
+                source_key["style_mode"] = statement.style_mode
+                source_key["style_color"] = statement.color
             # Issue #47: bar-only resize capability from pure xsize/ysize.
             if statement_kind == "bar" and isinstance(statement, BarStatement):
                 if (
@@ -624,7 +658,11 @@ class EditorCoordinator:
                             statement.resize_lock_code,
                             statement.resize_lock_message or statement.resize_lock_code,
                         )
-            if uses_runtime_delta_position(position_mode):
+            if (
+                not isinstance(statement, TextColorStyleStatement)
+                and isinstance(position_mode, str)
+                and uses_runtime_delta_position(position_mode)
+            ):
                 # Shared authored + measured baseline fields for delta write-back.
                 authored = (
                     [float(statement.xpos), float(statement.ypos)]
@@ -636,7 +674,7 @@ class EditorCoordinator:
                     int(runtime_position[0]),
                     int(runtime_position[1]),
                 ]
-            if position_mode == "align":
+            if position_mode == "align" and not isinstance(statement, TextColorStyleStatement):
                 # Align-only geometry gate: parent must prove full-screen 1280×720.
                 parent_size = tuple(
                     getattr(statement, "align_parent_size", DEFAULT_ALIGN_PARENT_SIZE)
@@ -682,15 +720,16 @@ class EditorCoordinator:
                             "independent observation must provide positive widget width and height",
                         )
             if lock_reason is None:
-                if observation.get("measurement_method") != "focus_list":
+                expected_measurement = "scene_tree_text" if statement_kind == "text" else "focus_list"
+                if observation.get("measurement_method") != expected_measurement:
                     lock_reason = self._lock_reason(
                         "MEASUREMENT_METHOD_INVALID",
-                        "input observation measurement_method must be focus_list",
+                        f"input observation measurement_method must be {expected_measurement}",
                     )
-                elif independent.get("measurement_method") != "focus_list":
+                elif independent.get("measurement_method") != expected_measurement:
                     lock_reason = self._lock_reason(
                         "INDEPENDENT_MEASUREMENT_INVALID",
-                        "independent measurement_method must be focus_list",
+                        f"independent measurement_method must be {expected_measurement}",
                     )
                 elif not self._runtime_keys_equivalent_for_reobservation(runtime_key, independent.get("runtime_key")):
                     lock_reason = self._lock_reason(
@@ -701,6 +740,15 @@ class EditorCoordinator:
                     lock_reason = self._lock_reason(
                         "INDEPENDENT_FRAME_NOT_FRESH",
                         "independent observation did not provide a fresh frame",
+                    )
+                elif (
+                    isinstance(statement, TextColorStyleStatement)
+                    and self._normalize_style_color(independent.get("style_color"))
+                    != self._normalize_style_color(statement.color)
+                ):
+                    lock_reason = self._lock_reason(
+                        "RUNTIME_STYLE_COLOR_MISMATCH",
+                        "independent runtime colour does not match the authored literal",
                     )
                 elif statement.widget_id != widget_id:
                     lock_reason = self._lock_reason("ID_MISMATCH", "source literal id does not match runtime widget id")
@@ -719,7 +767,8 @@ class EditorCoordinator:
             lock_reason = self._lock_reason("SOURCE_READ_FAILED", f"unable to read source: {exc}")
 
         analysis_id = uuid.uuid4().hex
-        can_move = lock_reason is None
+        can_style_color = lock_reason is None and source_key is not None and source_key.get("statement_kind") == "text"
+        can_move = lock_reason is None and not can_style_color
         can_resize = (
             can_move
             and original_size is not None
@@ -748,7 +797,21 @@ class EditorCoordinator:
             "source_key": source_key,
             "original_position": original_position,
             "original_size": list(original_size) if original_size is not None else None,
-            "capabilities": {"move": can_move, "resize": can_resize},
+            "capabilities": {
+                "move": can_move,
+                "resize": can_resize,
+                **(
+                    {
+                        "style_color": True,
+                        "style_color_preview": True,
+                        "style_color_commit": True,
+                        "style_color_undo": True,
+                        "style_color_attestation_rollback": True,
+                    }
+                    if can_style_color
+                    else {}
+                ),
+            },
             "lock_reason": lock_reason,
         }
 
@@ -767,7 +830,7 @@ class EditorCoordinator:
             raise EditorError("RUNTIME_PROBE_UNAVAILABLE", "runtime probe is not attached")
 
         seen_analysis_ids: set[str] = set()
-        selected_records: list[tuple[_AnalysisRecord, int, int, int | None, int | None, dict[str, Any]]] = []
+        selected_records: list[_SelectedIntent] = []
         source_paths: set[str] = set()
         with self._lock:
             generation = self._script_generation
@@ -784,17 +847,6 @@ class EditorCoordinator:
             source_key = intent.get("source_key")
             if not isinstance(source_key, dict):
                 raise EditorError("SOURCE_KEY_INVALID", "intent source_key must be an object")
-            x = intent.get("x")
-            y = intent.get("y")
-            if not isinstance(x, int) or not isinstance(y, int):
-                raise EditorError("INTENT_POSITION_INVALID", "intent x and y must be integers")
-            width = intent.get("w", intent.get("width"))
-            height = intent.get("h", intent.get("height"))
-            if width is not None or height is not None:
-                if type(width) is not int or type(height) is not int:
-                    raise EditorError("INTENT_SIZE_INVALID", "intent w and h must both be integers when resizing")
-                if int(width) <= 0 or int(height) <= 0:
-                    raise EditorError("BAR_SIZE_NON_POSITIVE", "intent size must be positive")
             with self._lock:
                 record = self._analyses.get(analysis_id)
             if record is None:
@@ -809,28 +861,65 @@ class EditorCoordinator:
                 raise EditorError("ANALYSIS_SOURCE_KEY_MISSING", "analysis does not include a writable source key")
             if record.source_key != source_key:
                 raise EditorError("SOURCE_KEY_MISMATCH", "intent source_key does not match analyzed source key")
-            if width is not None or height is not None:
-                if (
-                    record.original_size is None
-                    or record.runtime_size is None
-                    or source_key.get("size_mode") != BAR_SIZE_MODE_XSIZE_YSIZE
-                ):
+            color = intent.get("color")
+            is_style_color = source_key.get("statement_kind") == "text"
+            if is_style_color:
+                if not isinstance(color, str):
+                    raise EditorError("INTENT_STYLE_COLOR_INVALID", "text style intent color must be a string")
+                literal_color = self._literal_style_color(color)
+                literal_baseline = self._literal_style_color(source_key.get("style_color"))
+                if literal_color is None:
+                    raise EditorError("INTENT_STYLE_COLOR_INVALID", "text style intent color must be a supported hex literal")
+                if literal_baseline is None:
+                    raise EditorError("SOURCE_KEY_INVALID", "style source key is missing its literal baseline colour")
+                if len(literal_color) != len(literal_baseline):
                     raise EditorError(
-                        "ANALYSIS_RESIZE_UNSUPPORTED",
-                        "analysis does not unlock resize for this target",
+                        "STYLE_COLOR_HEX_FAMILY_MISMATCH",
+                        "text style intent must preserve the authored hex literal length",
                     )
+                if any(key in intent for key in ("x", "y", "w", "h", "width", "height")):
+                    raise EditorError("INTENT_STYLE_MIXED", "style color intent cannot include position or size fields")
+                if source_key.get("style_mode") != "literal_hex":
+                    raise EditorError("ANALYSIS_STYLE_COLOR_UNSUPPORTED", "analysis does not unlock literal style color")
+                selected = _SelectedIntent(
+                    record=record,
+                    source_key=source_key,
+                    color=literal_color,
+                )
+            else:
+                if color is not None:
+                    raise EditorError("ANALYSIS_STYLE_COLOR_UNSUPPORTED", "style color is only supported for text")
+                x = intent.get("x")
+                y = intent.get("y")
+                if not isinstance(x, int) or not isinstance(y, int):
+                    raise EditorError("INTENT_POSITION_INVALID", "intent x and y must be integers")
+                width = intent.get("w", intent.get("width"))
+                height = intent.get("h", intent.get("height"))
+                if width is not None or height is not None:
+                    if type(width) is not int or type(height) is not int:
+                        raise EditorError("INTENT_SIZE_INVALID", "intent w and h must both be integers when resizing")
+                    if int(width) <= 0 or int(height) <= 0:
+                        raise EditorError("BAR_SIZE_NON_POSITIVE", "intent size must be positive")
+                    if (
+                        record.original_size is None
+                        or record.runtime_size is None
+                        or source_key.get("size_mode") != BAR_SIZE_MODE_XSIZE_YSIZE
+                    ):
+                        raise EditorError(
+                            "ANALYSIS_RESIZE_UNSUPPORTED",
+                            "analysis does not unlock resize for this target",
+                        )
+                selected = _SelectedIntent(
+                    record=record,
+                    source_key=source_key,
+                    x=x,
+                    y=y,
+                    width=int(width) if width is not None else None,
+                    height=int(height) if height is not None else None,
+                )
             relative_path = self._require_source_relative_path(source_key)
             source_paths.add(relative_path)
-            selected_records.append(
-                (
-                    record,
-                    x,
-                    y,
-                    int(width) if width is not None else None,
-                    int(height) if height is not None else None,
-                    source_key,
-                )
-            )
+            selected_records.append(selected)
 
         if len(source_paths) != 1:
             raise EditorError("MULTI_FILE_UNSUPPORTED", "all intents must resolve to exactly one source file")
@@ -840,7 +929,9 @@ class EditorCoordinator:
         current_bytes = source_path.read_bytes()
         current_sha = sha256_bytes(current_bytes)
 
-        for record, _x, _y, _w, _h, source_key in selected_records:
+        for selected in selected_records:
+            record = selected.record
+            source_key = selected.source_key
             baseline = source_key.get("baseline_sha256")
             if not isinstance(baseline, str):
                 raise EditorError("SOURCE_BASELINE_INVALID", "source_key baseline_sha256 is missing")
@@ -851,14 +942,30 @@ class EditorCoordinator:
                 raise EditorError("INDEPENDENT_OBSERVATION_INVALID", "runtime probe returned invalid observation")
             if not self._runtime_keys_equivalent_for_reobservation(record.runtime_key, independent.get("runtime_key")):
                 raise EditorError("RUNTIME_KEY_MISMATCH", "runtime reanalysis key mismatch")
-            if independent.get("measurement_method") != "focus_list":
-                raise EditorError("MEASUREMENT_METHOD_INVALID", "independent reanalysis must use focus_list")
+            expected_measurement = "scene_tree_text" if selected.color is not None else "focus_list"
+            if independent.get("measurement_method") != expected_measurement:
+                raise EditorError(
+                    "MEASUREMENT_METHOD_INVALID",
+                    f"independent reanalysis must use {expected_measurement}",
+                )
             if self._coerce_generation(independent.get("script_generation")) != generation:
                 raise EditorError("SCRIPT_GENERATION_MISMATCH", "runtime reanalysis returned stale generation")
             if independent.get("frame_id") == record.independent_frame_id:
                 raise EditorError("INDEPENDENT_FRAME_NOT_FRESH", "runtime reanalysis did not produce a fresh frame")
+            if (
+                selected.color is not None
+                and self._normalize_style_color(independent.get("style_color"))
+                != self._normalize_style_color(selected.color)
+            ):
+                raise EditorError(
+                    "RUNTIME_STYLE_COLOR_MISMATCH",
+                    "runtime preview colour does not match the requested style intent",
+                )
 
-        staged_bytes = self._apply_same_file_intents(current_bytes, selected_records)
+        try:
+            staged_bytes = self._apply_same_file_intents(current_bytes, selected_records)
+        except EditorSourceError as exc:
+            raise EditorError(exc.code, str(exc)) from exc
         transaction_id = uuid.uuid4().hex
         transaction = _TransactionRecord(
             transaction_id=transaction_id,
@@ -869,33 +976,7 @@ class EditorCoordinator:
             original_sha256=current_sha,
             staged_sha256=sha256_bytes(staged_bytes),
             generation=generation,
-            expected_targets=[
-                {
-                    "analysis_id": record.analysis_id,
-                    "source_key": source_key,
-                    "runtime_key": deepcopy(record.runtime_key),
-                    "position": [
-                        int(record.runtime_position[0]) + int(x) - int(record.original_position[0]),
-                        int(record.runtime_position[1]) + int(y) - int(record.original_position[1]),
-                    ],
-                    **(
-                        {
-                            "size": [
-                                int(record.runtime_size[0]) + int(width) - int(record.original_size[0]),
-                                int(record.runtime_size[1]) + int(height) - int(record.original_size[1]),
-                            ]
-                        }
-                        if (
-                            width is not None
-                            and height is not None
-                            and record.original_size is not None
-                            and record.runtime_size is not None
-                        )
-                        else {}
-                    ),
-                }
-                for record, x, y, width, height, source_key in selected_records
-            ],
+            expected_targets=[self._expected_target_for_intent(selected) for selected in selected_records],
             state="staged",
         )
         with self._lock:
@@ -925,6 +1006,121 @@ class EditorCoordinator:
         self._schedule_attestation_timeout(transaction)
 
         return {"transaction_id": transaction_id, "state": "published", "reload_required": True}
+
+    def _expected_target_for_intent(self, selected: _SelectedIntent) -> dict[str, Any]:
+        record = selected.record
+        expected: dict[str, Any] = {
+            "analysis_id": record.analysis_id,
+            "source_key": selected.source_key,
+            "runtime_key": deepcopy(record.runtime_key),
+        }
+        if selected.color is not None:
+            previous = self._literal_style_color(selected.source_key.get("style_color"))
+            if previous is None:
+                raise EditorError("SOURCE_KEY_INVALID", "style source key is missing its baseline colour")
+            expected["style_color"] = selected.color
+            expected["previous_style_color"] = previous
+            return expected
+
+        if selected.x is None or selected.y is None:
+            raise EditorError("INTENT_POSITION_INVALID", "position intent is missing x or y")
+        expected["position"] = [
+            int(record.runtime_position[0]) + selected.x - int(record.original_position[0]),
+            int(record.runtime_position[1]) + selected.y - int(record.original_position[1]),
+        ]
+        if (
+            selected.width is not None
+            and selected.height is not None
+            and record.original_size is not None
+            and record.runtime_size is not None
+        ):
+            expected["size"] = [
+                int(record.runtime_size[0]) + selected.width - int(record.original_size[0]),
+                int(record.runtime_size[1]) + selected.height - int(record.original_size[1]),
+            ]
+        return expected
+
+    def _command_undo_commit(self, payload: dict[str, Any]) -> dict[str, Any]:
+        session_id = self._require_string(payload, "session_id")
+        if session_id != self._session_id:
+            raise EditorError("SESSION_ID_MISMATCH", "undo session_id does not match current editor session")
+        prior_id = self._require_string(payload, "transaction_id")
+        with self._lock:
+            prior = self._transactions.get(prior_id)
+            generation = self._script_generation
+        if prior is None:
+            raise EditorError("TRANSACTION_NOT_FOUND", f"transaction not found: {prior_id}")
+        if prior.state != "committed":
+            raise EditorError("UNDO_TRANSACTION_INVALID", "only a committed transaction can be undone")
+        if not prior.expected_targets or any(
+            self._literal_style_color(target.get("style_color")) is None
+            or self._literal_style_color(target.get("previous_style_color")) is None
+            for target in prior.expected_targets
+        ):
+            raise EditorError("UNDO_STYLE_COLOR_ONLY", "product commit undo is limited to text style color")
+
+        current_bytes = prior.source_absolute_path.read_bytes()
+        current_sha = sha256_bytes(current_bytes)
+        if current_sha != prior.staged_sha256:
+            raise EditorError("STALE_SOURCE", "source file changed after the committed transaction")
+
+        expected_targets: list[dict[str, Any]] = []
+        for target in prior.expected_targets:
+            reversed_target = deepcopy(target)
+            current_color = self._literal_style_color(target.get("style_color"))
+            previous_color = self._literal_style_color(target.get("previous_style_color"))
+            if current_color is None or previous_color is None:
+                raise EditorError("UNDO_STYLE_COLOR_ONLY", "style undo target is missing colour evidence")
+            reversed_target["style_color"] = previous_color
+            reversed_target["previous_style_color"] = current_color
+            expected_targets.append(reversed_target)
+
+        transaction_id = uuid.uuid4().hex
+        transaction = _TransactionRecord(
+            transaction_id=transaction_id,
+            source_relative_path=prior.source_relative_path,
+            source_absolute_path=prior.source_absolute_path,
+            original_bytes=current_bytes,
+            staged_bytes=prior.original_bytes,
+            original_sha256=current_sha,
+            staged_sha256=sha256_bytes(prior.original_bytes),
+            generation=generation,
+            expected_targets=expected_targets,
+            state="staged",
+        )
+        with self._lock:
+            self._transactions[transaction_id] = transaction
+        self._persist_transaction(transaction)
+
+        lint_result = self._validate_shadow(transaction)
+        if not lint_result.ok:
+            transaction.state = "failed"
+            transaction.diagnostics = self._lint_diagnostics(lint_result)
+            self._persist_transaction(transaction)
+            raise EditorError(
+                "VALIDATION_FAILED",
+                "Ren'Py lint failed while validating product undo",
+                details={"transaction_id": transaction_id},
+            )
+        transaction.diagnostics = {
+            **self._lint_diagnostics(lint_result),
+            "undo_of_transaction_id": prior_id,
+        }
+        if sha256_bytes(prior.source_absolute_path.read_bytes()) != transaction.original_sha256:
+            transaction.state = "failed"
+            self._persist_transaction(transaction)
+            raise EditorError("STALE_SOURCE", "source file changed before undo publication")
+
+        atomic_write_file(prior.source_absolute_path, transaction.staged_bytes)
+        transaction.state = "published"
+        self._persist_transaction(transaction)
+        self._schedule_attestation_timeout(transaction)
+        return {
+            "transaction_id": transaction_id,
+            "undo_of_transaction_id": prior_id,
+            "state": "published",
+            "reload_required": True,
+        }
 
     def _command_commit_status(self, payload: dict[str, Any]) -> dict[str, Any]:
         transaction_id = self._require_string(payload, "transaction_id")
@@ -970,12 +1166,21 @@ class EditorCoordinator:
             # alone, the published bytes stayed in the author's file until the
             # attestation timer fired seconds later.
             self._conditional_rollback(record)
+            # Game already reloaded; forget the pre-reload generation so later
+            # analyses can re-lock to the live script_generation (including any
+            # follow-up reload that re-syncs rolled-back source into memory).
+            with self._lock:
+                self._script_generation = -1
             raise
         if not isinstance(result, dict):
             self._conditional_rollback(record)
+            with self._lock:
+                self._script_generation = -1
             raise EditorError("ATTESTATION_FAILED", "runtime probe returned invalid attestation payload")
         if result.get("ok") is not True or result.get("state") != "all_targets_attested":
             self._conditional_rollback(record)
+            with self._lock:
+                self._script_generation = -1
             raise EditorError("ATTESTATION_FAILED", "runtime attestation did not reach all_targets_attested")
 
         with self._lock:
@@ -1174,6 +1379,43 @@ class EditorCoordinator:
             return value
         return None
 
+    def _normalize_style_color(self, value: Any) -> str | None:
+        """Return a comparable hex colour, collapsing opaque alpha and short form."""
+        if not isinstance(value, str):
+            return None
+        normalized = value.strip().lower()
+        if not normalized.startswith("#"):
+            return None
+        body = normalized[1:]
+        if any(char not in "0123456789abcdef" for char in body):
+            return None
+        if len(body) == 3:
+            body = "".join(ch * 2 for ch in body)
+        elif len(body) == 8 and body.endswith("ff"):
+            body = body[:6]
+        elif len(body) == 6:
+            pass
+        elif len(body) == 8:
+            # Keep non-opaque alpha colours as 8-digit so they never match 6-digit authored forms accidentally.
+            return "#" + body
+        else:
+            return None
+        return "#" + body
+
+    def _literal_style_color(self, value: Any) -> str | None:
+        """Validate a writable hex literal while preserving its authored family."""
+        if not isinstance(value, str):
+            return None
+        literal = value.strip().lower()
+        if not literal.startswith("#"):
+            return None
+        body = literal[1:]
+        if len(body) not in (3, 6, 8):
+            return None
+        if any(char not in "0123456789abcdef" for char in body):
+            return None
+        return literal
+
     def _extract_position(self, observation: dict[str, Any]) -> list[int]:
         rect = observation.get("rect")
         if not isinstance(rect, list) or len(rect) < 2:
@@ -1197,12 +1439,18 @@ class EditorCoordinator:
     def _apply_same_file_intents(
         self,
         source_bytes: bytes,
-        selected_records: list[tuple[_AnalysisRecord, int, int, int | None, int | None, dict[str, Any]]],
+        selected_records: list[_SelectedIntent],
     ) -> bytes:
         lines = source_bytes.decode("utf-8").splitlines(keepends=True)
         seen_targets: set[tuple[str, int, str]] = set()
 
-        for _record, x, y, width, height, source_key in selected_records:
+        for selected in selected_records:
+            x = selected.x
+            y = selected.y
+            width = selected.width
+            height = selected.height
+            color = selected.color
+            source_key = selected.source_key
             line_no = source_key.get("line")
             widget_id = source_key.get("widget_id")
             if not isinstance(line_no, int) or not isinstance(widget_id, str):
@@ -1231,6 +1479,22 @@ class EditorCoordinator:
                         "STATEMENT_KIND_MISMATCH",
                         "source_key statement_kind does not match source line",
                     )
+            if actual_kind == "text":
+                if color is None or any(value is not None for value in (x, y, width, height)):
+                    raise EditorError("INTENT_STYLE_COLOR_INVALID", "text style intent shape is invalid")
+                statement = analyze_text_color_style(
+                    lines[line_no - 1],
+                    expected_widget_id=widget_id,
+                )
+                lines[line_no - 1] = apply_text_color_patch(
+                    lines[line_no - 1].encode("utf-8"),
+                    statement,
+                    color=color,
+                ).decode("utf-8")
+                continue
+
+            if x is None or y is None:
+                raise EditorError("INTENT_POSITION_INVALID", "position intent is missing x or y")
             if actual_kind == "button":
                 if width is not None or height is not None:
                     raise EditorError(

--- a/src/renforge/editor_style_color_runner.py
+++ b/src/renforge/editor_style_color_runner.py
@@ -1,4 +1,4 @@
-"""Live evidence runner for issue #50 text colour style source-write contract."""
+"""Live evidence runner for issue #50 text colour product path."""
 
 from __future__ import annotations
 
@@ -12,13 +12,12 @@ from typing import Any
 
 from PIL import Image
 
-from renforge.editor.paths import atomic_write_file
 from renforge.editor.source import (
     TEXT_STYLE_COLOR_MODE_LITERAL,
     analyze_text_color_style,
     apply_text_color_patch,
 )
-from renforge.editor_task0_runner import _require_ok
+from renforge.editor_task0_runner import _require_ok, _wait_for_status
 
 FIXTURE_SCREEN = "renforge_editor_style_fixture"
 TARGET_ID = "style_color_target"
@@ -61,7 +60,7 @@ def _parse_color_from_target_line(source_text: str, widget_id: str) -> str | Non
     match = re.search(r'\bcolor\s+([\'"])(#[0-9A-Fa-f]{3,8})\1', line)
     if not match:
         return None
-    return match.group(2)
+    return match.group(2).lower()
 
 
 def _independent_expected_after_color_patch(before_text: str, *, color: str) -> str:
@@ -141,11 +140,7 @@ def _sample_region_paint(
     *,
     image: Image.Image | None = None,
 ) -> dict[str, Any]:
-    """Independent screenshot paint stats for saturated non-dark pixels.
-
-    Colour class is derived only from PNG samples — never from scene-tree style
-    metadata or editor claims.
-    """
+    """Independent screenshot paint stats for saturated non-dark pixels."""
     if image is None:
         image = Image.open(io.BytesIO(client.screenshot())).convert("RGB")
     x0 = max(0, int(bounds["x"]))
@@ -160,8 +155,6 @@ def _sample_region_paint(
                 rgb = (pixel, pixel, pixel)
             else:
                 rgb = (int(pixel[0]), int(pixel[1]), int(pixel[2]))
-            # Dark fixture background is ~#0a0a12. Drop near-black and near-grey
-            # anti-alias fringes so glyph chroma dominates.
             if max(rgb) < 50:
                 continue
             if max(rgb) - min(rgb) < 25:
@@ -182,7 +175,6 @@ def _sample_region_paint(
         round(sum(p[1] for p in painted) / len(painted)),
         round(sum(p[2] for p in painted) / len(painted)),
     )
-    # Also record one high-chroma sample near the geometric centre.
     cx = (x0 + x1) // 2
     cy = (y0 + y1) // 2
     sample_point = None
@@ -236,7 +228,6 @@ def _wait_paint(
             **_sample_region_paint(client, last_bounds),
             "bounds_from_scene_tree": bounds_from_scene_tree,
         }
-        # Prefer the high-chroma centre sample when mean is muddy.
         dominant = last_paint.get("sample_dominant") or last_paint.get("dominant")
         if (
             bounds_from_scene_tree
@@ -254,8 +245,15 @@ def _wait_paint(
     return last_bounds, last_paint
 
 
+def _source_generation(status: dict[str, Any]) -> int:
+    try:
+        return int(status.get("script_generation"))
+    except Exception:
+        return 0
+
+
 def _attempt_product_select(client: Any, bounds: dict[str, int]) -> dict[str, Any]:
-    """Click via the production select path (focus_list only)."""
+    """Click via the production select path (focus + non-focusable text)."""
     x = int(bounds["x"]) + max(1, int(bounds["width"]) // 2)
     y = int(bounds["y"]) + max(1, int(bounds["height"]) // 2)
     selection = client.request("editor_task0_select", {"x": x, "y": y})
@@ -286,7 +284,23 @@ def _attempt_product_select(client: Any, bounds: dict[str, int]) -> dict[str, An
         "pending_transaction_id": (
             (status or {}).get("pending_transaction_id") if isinstance(status, dict) else None
         ),
+        "observation": (selection or {}).get("observation") if isinstance(selection, dict) else None,
     }
+
+
+def _wait_style_analysis(client: Any, *, timeout: float = 20.0) -> dict[str, Any]:
+    return _wait_for_status(
+        client,
+        lambda status: (
+            status.get("selected_widget_id") == TARGET_ID
+            and status.get("selected_lock_reason") in (None, "")
+            and bool(status.get("current_analysis_id"))
+            and (status.get("current_source_key") or {}).get("statement_kind") == "text"
+            and (status.get("current_capabilities") or {}).get("style_color") is True
+        ),
+        timeout=timeout,
+        poll_name="style color analysis unlock",
+    )
 
 
 def _lock_probe(source_text: str, widget_id: str, expected_code: str) -> dict[str, Any]:
@@ -300,10 +314,14 @@ def _lock_probe(source_text: str, widget_id: str, expected_code: str) -> dict[st
     }
 
 
+def _sha256_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
 def run_editor_style_color_live_scenario(client: Any, *, fixture_path: Path) -> dict[str, Any]:
-    """Evidence-gated live scenario for text colour style (issue #50)."""
+    """Evidence-gated live scenario for text colour product path (issue #50)."""
     baseline = fixture_path.read_bytes()
-    baseline_sha = hashlib.sha256(baseline).hexdigest()
+    baseline_sha = _sha256_bytes(baseline)
     baseline_text = baseline.decode("utf-8")
     report: dict[str, Any] = {
         "baseline_sha256": baseline_sha,
@@ -335,20 +353,11 @@ def run_editor_style_color_live_scenario(client: Any, *, fixture_path: Path) -> 
     if not report["resolve_source"]["unlocked"]:
         report["verdict"] = "blocked"
         report["verdict_reason"] = "style_color_source_unlock_failed"
-        report["restore"] = {
-            "byte_identical": True,
-            "sha256": baseline_sha,
-            "note": "manual_fixture_restore_cleanup_not_product_undo",
-        }
         return report
 
-    # Pixel before: wait for independent red paint (not scene-tree style fields).
     bounds_before, pixel_before = _wait_paint(client, expected_dominant="red", timeout=8.0)
     report["target_bounds"] = bounds_before
     report["pixel_before"] = pixel_before
-
-    # Product select attempt on the text glyph (expected: no style unlock).
-    report["product_select"] = _attempt_product_select(client, bounds_before)
 
     # Focusable control still resolves via focus_list (control-path sanity).
     focus_bounds = None
@@ -371,71 +380,340 @@ def run_editor_style_color_live_scenario(client: Any, *, fixture_path: Path) -> 
     if focus_bounds is not None:
         report["focus_control_select"] = _attempt_product_select(client, focus_bounds)
 
-    # Source patch via dedicated style contract (not coordinate spans).
-    staged_line = apply_text_color_patch(
-        target_line.encode("utf-8"),
-        target_analysis,
-        color=REQUESTED_COLOR,
-    ).decode("utf-8")
-    staged_text = baseline_text.replace(target_line, staged_line, 1)
-    if staged_text == baseline_text:
-        raise AssertionError("style colour patch produced no source change")
-    expected_text = _independent_expected_after_color_patch(baseline_text, color=REQUESTED_COLOR)
-    outside_ok = _outside_color_span_identical(baseline_text, staged_text)
-    report["source_patch"] = {
-        "changed": True,
-        "matches_independent_expected": staged_text == expected_text,
-        "outside_color_span_identical": outside_ok,
-        "source_color_after": _parse_color_from_target_line(staged_text, TARGET_ID),
-        "staged_sha256": hashlib.sha256(staged_text.encode("utf-8")).hexdigest(),
-    }
-    if not report["source_patch"]["matches_independent_expected"] or not outside_ok:
-        report["verdict"] = "inconclusive"
-        report["verdict_reason"] = "source_patch_form_or_span_mismatch"
+    # --- Product select on non-focusable text ---
+    report["product_select"] = _attempt_product_select(client, bounds_before)
+    try:
+        analysis_status = _wait_style_analysis(client, timeout=20.0)
+    except AssertionError as exc:
+        report["product_select_analysis_error"] = str(exc)
+        report["verdict"] = "blocked"
+        report["verdict_reason"] = "style_color_product_select_unlock_failed"
         return report
 
-    try:
-        atomic_write_file(fixture_path, staged_text.encode("utf-8"))
-        if fixture_path.read_text(encoding="utf-8") != staged_text:
-            raise AssertionError("atomic write did not publish staged style fixture bytes")
-        _require_ok(client.control("reload_script"), "style color reload")
-        # Give the reloaded script a moment, then re-show the fixture.
-        for _ in range(30):
-            if client.eval_expr(f'renpy.has_screen("{FIXTURE_SCREEN}")') is True:
-                break
-            time.sleep(0.1)
-        _show_fixture(client)
-        bounds_after, pixel_after = _wait_paint(client, expected_dominant="blue", timeout=10.0)
-        report["pixel_after"] = pixel_after
-        report["target_bounds_after"] = bounds_after
-        disk_color = _parse_color_from_target_line(
-            fixture_path.read_text(encoding="utf-8"),
-            TARGET_ID,
-        )
-        report["published_source_after_reload"] = {
-            "widget_id": TARGET_ID,
-            "bounds_after": bounds_after,
-            "source_color": disk_color,
-            "ok": disk_color == REQUESTED_COLOR,
-        }
-    finally:
-        # Cleanup only — not product undo evidence.
-        atomic_write_file(fixture_path, baseline)
-        try:
-            _require_ok(client.control("reload_script"), "style color restore reload")
-            _show_fixture(client)
-        except Exception as exc:  # noqa: BLE001
-            report["restore_reload_error"] = str(exc)
+    caps = analysis_status.get("current_capabilities") or {}
+    source_key = analysis_status.get("current_source_key") or {}
+    report["product_select_unlocked_style"] = bool(
+        analysis_status.get("selected_widget_id") == TARGET_ID
+        and source_key.get("statement_kind") == "text"
+        and source_key.get("style_mode") == TEXT_STYLE_COLOR_MODE_LITERAL
+        and caps.get("style_color") is True
+        and caps.get("style_color_preview") is True
+        and caps.get("style_color_commit") is True
+        and caps.get("style_color_undo") is True
+        and caps.get("style_color_attestation_rollback") is True
+    )
+    report["product_seam_probe"] = {
+        "measurement_source": "editor_task0_status.current_capabilities",
+        "selected_widget_id": analysis_status.get("selected_widget_id"),
+        "capabilities": caps,
+        "source_key": source_key,
+        "save_enabled": analysis_status.get("save_enabled"),
+        "history_length": analysis_status.get("history_length"),
+        "analysis_id": analysis_status.get("current_analysis_id"),
+        "measurement_method": ((report["product_select"].get("observation") or {}) or {}).get(
+            "measurement_method"
+        ),
+    }
+    report["product_preview_available"] = bool(caps.get("style_color_preview") is True)
+    report["product_commit_available"] = bool(caps.get("style_color_commit") is True)
+    report["product_undo_available"] = bool(caps.get("style_color_undo") is True)
+    report["refused_attestation_rollback_available"] = bool(
+        caps.get("style_color_attestation_rollback") is True
+    )
+    if not report["product_select_unlocked_style"]:
+        report["verdict"] = "blocked"
+        report["verdict_reason"] = "style_color_product_path_missing"
+        return report
 
-    restored = fixture_path.read_bytes()
-    report["restore"] = {
-        "sha256": hashlib.sha256(restored).hexdigest(),
-        "byte_identical": restored == baseline,
-        "note": "manual_fixture_restore_cleanup_not_product_undo",
+    generation0 = _source_generation(analysis_status)
+
+    # --- Preview without source write ---
+    pre_preview_bytes = fixture_path.read_bytes()
+    preview = _require_ok(
+        client.request("editor_task0_style_color", {"color": REQUESTED_COLOR}),
+        "style color preview",
+    )
+    preview_status = _wait_for_status(
+        client,
+        lambda status: bool(status.get("save_enabled"))
+        and str(status.get("style_color_input") or "").lower() == REQUESTED_COLOR,
+        timeout=8.0,
+        poll_name="style color preview dirty",
+    )
+    bounds_preview, pixel_preview = _wait_paint(client, expected_dominant="blue", timeout=10.0)
+    post_preview_bytes = fixture_path.read_bytes()
+    report["product_preview"] = {
+        "ok": preview.get("ok") is True,
+        "method": preview.get("method"),
+        "color": preview.get("color"),
+        "source_byte_identical": post_preview_bytes == pre_preview_bytes,
+        "source_sha256": _sha256_bytes(post_preview_bytes),
+        "pixel": pixel_preview,
+        "bounds": bounds_preview,
+        "save_enabled": preview_status.get("save_enabled"),
+    }
+    if not report["product_preview"]["source_byte_identical"]:
+        report["verdict"] = "blocked"
+        report["verdict_reason"] = "style_color_preview_wrote_source"
+        return report
+    if pixel_preview.get("dominant") != "blue":
+        report["verdict"] = "inconclusive"
+        report["verdict_reason"] = "style_color_preview_paint_unproven"
+        return report
+
+    # Reset is local preview history, distinct from transactional product undo.
+    reset = _require_ok(client.request("editor_task0_reset", {}), "style color preview reset")
+    reset_status = _wait_for_status(
+        client,
+        lambda status: not bool(status.get("save_enabled"))
+        and str(status.get("style_color_input") or "").lower() == BASELINE_COLOR,
+        timeout=8.0,
+        poll_name="style color preview reset clean",
+    )
+    reset_bounds, reset_pixel = _wait_paint(client, expected_dominant="red", timeout=10.0)
+    reset_bytes = fixture_path.read_bytes()
+    report["product_preview_reset"] = {
+        "ok": reset.get("ok") is True
+        and reset_bytes == baseline
+        and reset_pixel.get("dominant") == "red",
+        "source_byte_identical": reset_bytes == baseline,
+        "pixel": reset_pixel,
+        "bounds": reset_bounds,
+        "save_enabled": reset_status.get("save_enabled"),
+    }
+    if not report["product_preview_reset"]["ok"]:
+        report["verdict"] = "blocked"
+        report["verdict_reason"] = "style_color_preview_reset_failed"
+        return report
+
+    # Re-apply the requested preview before exercising commit rollback.
+    _require_ok(
+        client.request("editor_task0_style_color", {"color": REQUESTED_COLOR}),
+        "style color preview after reset",
+    )
+    _wait_for_status(
+        client,
+        lambda status: bool(status.get("save_enabled"))
+        and str(status.get("style_color_input") or "").lower() == REQUESTED_COLOR,
+        timeout=8.0,
+        poll_name="style color preview after reset dirty",
+    )
+    _wait_paint(client, expected_dominant="blue", timeout=10.0)
+
+    # --- Deliberate refused attestation rollback ---
+    _require_ok(
+        client.request("editor_task0_force_style_attestation_refusal", {}),
+        "force style attestation refusal",
+    )
+    refused_save = _require_ok(
+        client.click_element(id="rf_save", screen="_renforge_editor_overlay"),
+        "style color refused save",
+    )
+    refused_status = _wait_for_status(
+        client,
+        lambda status: (
+            not bool(status.get("save_in_progress"))
+            and status.get("status_text") in ("Reload failed", "Commit failed", "Reload handshake failed")
+        ),
+        timeout=60.0,
+        poll_name="style color refused attestation",
+    )
+    refused_bytes = fixture_path.read_bytes()
+    report["refused_attestation_rollback"] = {
+        "ok": refused_bytes == baseline,
+        "byte_identical": refused_bytes == baseline,
+        "sha256": _sha256_bytes(refused_bytes),
+        "save_request": refused_save,
+        "status_text": refused_status.get("status_text"),
+        "save_error": refused_status.get("save_error") or refused_status.get("save_last_error"),
+    }
+    if not report["refused_attestation_rollback"]["ok"]:
+        report["verdict"] = "blocked"
+        report["verdict_reason"] = "style_color_refused_attestation_did_not_rollback"
+        return report
+
+    # Resync runtime to rolled-back source for the successful product pass.
+    _require_ok(client.control("reload_script"), "post-refusal reload")
+    for _ in range(40):
+        if client.eval_expr(f'renpy.has_screen("{FIXTURE_SCREEN}")') is True:
+            break
+        time.sleep(0.1)
+    _show_fixture(client)
+    bounds_red, pixel_red = _wait_paint(client, expected_dominant="red", timeout=10.0)
+    report["post_refusal_paint"] = pixel_red
+    report["post_refusal_bounds"] = bounds_red
+
+    # Re-select and unlock again for the successful commit path.
+    report["product_select_retry"] = _attempt_product_select(client, bounds_red)
+    analysis_status = _wait_style_analysis(client, timeout=20.0)
+    generation1 = _source_generation(analysis_status)
+    _require_ok(
+        client.request("editor_task0_style_color", {"color": REQUESTED_COLOR}),
+        "style color preview before successful save",
+    )
+    _wait_for_status(
+        client,
+        lambda status: bool(status.get("save_enabled")),
+        timeout=8.0,
+        poll_name="style color ready to save",
+    )
+    bounds_preview2, pixel_preview2 = _wait_paint(client, expected_dominant="blue", timeout=10.0)
+    report["product_preview_before_commit"] = {
+        "pixel": pixel_preview2,
+        "bounds": bounds_preview2,
+        "source_byte_identical": fixture_path.read_bytes() == baseline,
     }
 
-    pixel_before = report.get("pixel_before") or {}
-    pixel_after = report.get("pixel_after") or {}
+    pre_save_text = fixture_path.read_text(encoding="utf-8")
+    save_request = _require_ok(
+        client.click_element(id="rf_save", screen="_renforge_editor_overlay"),
+        "style color product save",
+    )
+    save_status = _wait_for_status(
+        client,
+        lambda status: (
+            not bool(status.get("save_in_progress"))
+            and status.get("status_text") == "Reload committed"
+            and _source_generation(status) >= generation1 + 1
+        ),
+        timeout=60.0,
+        poll_name="style color save complete",
+    )
+    post_save_bytes = fixture_path.read_bytes()
+    post_save_text = post_save_bytes.decode("utf-8")
+    expected_text = _independent_expected_after_color_patch(pre_save_text, color=REQUESTED_COLOR)
+    outside_ok = _outside_color_span_identical(pre_save_text, post_save_text)
+    report["source_patch"] = {
+        "changed": post_save_text != pre_save_text,
+        "matches_independent_expected": post_save_text == expected_text,
+        "outside_color_span_identical": outside_ok,
+        "source_color_after": _parse_color_from_target_line(post_save_text, TARGET_ID),
+        "staged_sha256": _sha256_bytes(post_save_bytes),
+        "save_request": save_request,
+    }
+    report["product_commit"] = {
+        "ok": (
+            report["source_patch"]["matches_independent_expected"]
+            and report["source_patch"]["outside_color_span_identical"]
+            and report["source_patch"]["source_color_after"] == REQUESTED_COLOR
+            and save_status.get("status_text") == "Reload committed"
+        ),
+        "status_text": save_status.get("status_text"),
+        "script_generation": _source_generation(save_status),
+        "last_committed_transaction_id": save_status.get("last_committed_transaction_id"),
+    }
+
+    successor = _wait_for_status(
+        client,
+        lambda status: (
+            bool(status.get("current_analysis_id"))
+            and status.get("selected_widget_id") == TARGET_ID
+            and status.get("selected_lock_reason") in (None, "")
+            and (status.get("current_source_key") or {}).get("style_mode")
+            == TEXT_STYLE_COLOR_MODE_LITERAL
+            and (status.get("current_capabilities") or {}).get("style_color") is True
+        ),
+        timeout=15.0,
+        poll_name="style color post-save rebind",
+    )
+    bounds_after, pixel_after = _wait_paint(client, expected_dominant="blue", timeout=10.0)
+    report["pixel_after"] = pixel_after
+    report["target_bounds_after"] = bounds_after
+    report["published_source_after_reload"] = {
+        "widget_id": TARGET_ID,
+        "bounds_after": bounds_after,
+        "source_color": _parse_color_from_target_line(post_save_text, TARGET_ID),
+        "ok": _parse_color_from_target_line(post_save_text, TARGET_ID) == REQUESTED_COLOR,
+    }
+    report["rebinding"] = {
+        "ok": (
+            successor.get("selected_widget_id") == TARGET_ID
+            and successor.get("current_analysis_id")
+            not in (None, analysis_status.get("current_analysis_id"))
+            and (successor.get("current_source_key") or {}).get("statement_kind") == "text"
+            and (successor.get("current_source_key") or {}).get("style_mode")
+            == TEXT_STYLE_COLOR_MODE_LITERAL
+            and (successor.get("current_capabilities") or {}).get("style_color") is True
+        ),
+        "widget_id": successor.get("selected_widget_id"),
+        "analysis_id": successor.get("current_analysis_id"),
+        "previous_analysis_id": analysis_status.get("current_analysis_id"),
+        "source_key": successor.get("current_source_key"),
+        "capabilities": successor.get("current_capabilities"),
+    }
+
+    # --- Product undo ---
+    generation2 = _source_generation(successor)
+    undo_click = _require_ok(
+        client.click_element(id="rf_undo", screen="_renforge_editor_overlay"),
+        "style color product undo",
+    )
+    undo_status = _wait_for_status(
+        client,
+        lambda status: (
+            not bool(status.get("save_in_progress"))
+            and status.get("status_text") == "Reload committed"
+            and _source_generation(status) >= generation2 + 1
+        ),
+        timeout=60.0,
+        poll_name="style color product undo complete",
+    )
+    undo_bytes = fixture_path.read_bytes()
+    undo_text = undo_bytes.decode("utf-8")
+    bounds_undo, pixel_undo = _wait_paint(client, expected_dominant="red", timeout=10.0)
+    undo_rebind = _wait_for_status(
+        client,
+        lambda status: (
+            bool(status.get("current_analysis_id"))
+            and status.get("selected_widget_id") == TARGET_ID
+            and status.get("selected_lock_reason") in (None, "")
+            and (status.get("current_source_key") or {}).get("style_mode")
+            == TEXT_STYLE_COLOR_MODE_LITERAL
+            and (status.get("current_capabilities") or {}).get("style_color") is True
+        ),
+        timeout=15.0,
+        poll_name="style color post-undo rebind",
+    )
+    report["product_undo"] = {
+        "ok": (
+            undo_bytes == baseline
+            and _parse_color_from_target_line(undo_text, TARGET_ID) == BASELINE_COLOR
+            and pixel_undo.get("dominant") == "red"
+            and undo_rebind.get("selected_widget_id") == TARGET_ID
+            and undo_status.get("status_text") == "Reload committed"
+        ),
+        "byte_identical": undo_bytes == baseline,
+        "sha256": _sha256_bytes(undo_bytes),
+        "source_color": _parse_color_from_target_line(undo_text, TARGET_ID),
+        "pixel": pixel_undo,
+        "bounds": bounds_undo,
+        "click": undo_click,
+        "status_text": undo_status.get("status_text"),
+        "rebinding": {
+            "widget_id": undo_rebind.get("selected_widget_id"),
+            "analysis_id": undo_rebind.get("current_analysis_id"),
+            "capabilities": undo_rebind.get("current_capabilities"),
+        },
+        "note": "product_undo_transaction",
+    }
+
+    # Manual fixture restore is cleanup only if product undo already restored bytes.
+    restored = fixture_path.read_bytes()
+    if restored != baseline:
+        fixture_path.write_bytes(baseline)
+        restored = fixture_path.read_bytes()
+        report["restore"] = {
+            "sha256": _sha256_bytes(restored),
+            "byte_identical": restored == baseline,
+            "note": "manual_fixture_restore_cleanup_not_product_undo",
+        }
+    else:
+        report["restore"] = {
+            "sha256": _sha256_bytes(restored),
+            "byte_identical": True,
+            "note": "product_undo_restored_baseline",
+        }
+
     report["runtime_color_change_proven"] = (
         pixel_before.get("dominant") == "red"
         and pixel_after.get("dominant") == "blue"
@@ -444,54 +722,49 @@ def run_editor_style_color_live_scenario(client: Any, *, fixture_path: Path) -> 
         and int(pixel_before.get("paint_count") or 0) > 20
         and int(pixel_after.get("paint_count") or 0) > 20
     )
-    report["product_select_unlocked_style"] = bool(
-        report["product_select"].get("selected_widget_id") == TARGET_ID
-        and (report["product_select"].get("source_key") or {}).get("statement_kind") == "text"
-        and (report["product_select"].get("source_key") or {}).get("style_mode")
-        == TEXT_STYLE_COLOR_MODE_LITERAL
-        and (report["product_select"].get("capabilities") or {}).get("style_color") is True
-    )
-    # Measure advertised product seams from the status returned by the real
-    # production selection attempt. No style-specific command is inferred when
-    # the capability map does not advertise one.
-    capabilities = report["product_select"].get("capabilities") or {}
-    style_selected = report["product_select_unlocked_style"]
-    report["product_seam_probe"] = {
-        "measurement_source": "editor_task0_status.current_capabilities",
-        "selected_widget_id": report["product_select"].get("selected_widget_id"),
-        "capabilities": capabilities,
-        "save_enabled": report["product_select"].get("save_enabled"),
-        "history_length": report["product_select"].get("history_length"),
-        "pending_transaction_id": report["product_select"].get("pending_transaction_id"),
-    }
-    report["product_preview_available"] = bool(
-        style_selected and capabilities.get("style_color_preview") is True
-    )
-    report["product_commit_available"] = bool(
-        style_selected and capabilities.get("style_color_commit") is True
-    )
-    report["product_undo_available"] = bool(
-        style_selected and capabilities.get("style_color_undo") is True
-    )
-    report["refused_attestation_rollback_available"] = bool(
-        style_selected and capabilities.get("style_color_attestation_rollback") is True
-    )
 
-    if not report["runtime_color_change_proven"]:
-        report["verdict"] = "inconclusive"
-        report["verdict_reason"] = "pixel_color_change_unproven"
-    elif not (
-        report["source_patch"]["matches_independent_expected"]
-        and report["source_patch"]["outside_color_span_identical"]
-        and report["restore"]["byte_identical"]
-        and report["locks"]["inherited"]["matches_expected"]
-        and report["locks"]["expression"]["matches_expected"]
-    ):
-        report["verdict"] = "inconclusive"
-        report["verdict_reason"] = "source_or_lock_evidence_incomplete"
-    else:
-        # Source + independent pixel proven; product style path absent.
+    required = [
+        report["product_select_unlocked_style"],
+        report["product_preview"]["ok"] and report["product_preview"]["source_byte_identical"],
+        report["product_preview"]["pixel"].get("dominant") == "blue",
+        report["product_preview_reset"]["ok"],
+        report["refused_attestation_rollback"]["ok"],
+        report["product_commit"]["ok"],
+        report["runtime_color_change_proven"],
+        report["rebinding"]["ok"],
+        report["product_undo"]["ok"],
+        report["locks"]["inherited"]["matches_expected"],
+        report["locks"]["expression"]["matches_expected"],
+        report["restore"]["byte_identical"],
+    ]
+    if all(required):
+        report["verdict"] = "pass"
+        report["verdict_reason"] = None
+    elif not report["product_select_unlocked_style"]:
         report["verdict"] = "blocked"
         report["verdict_reason"] = "style_color_product_path_missing"
+    elif not report["refused_attestation_rollback"]["ok"]:
+        report["verdict"] = "blocked"
+        report["verdict_reason"] = "style_color_refused_attestation_did_not_rollback"
+    elif not report["product_commit"]["ok"]:
+        report["verdict"] = "blocked"
+        report["verdict_reason"] = "style_color_product_commit_failed"
+    elif not report["product_undo"]["ok"]:
+        report["verdict"] = "blocked"
+        report["verdict_reason"] = "style_color_product_undo_failed"
+    elif not report["runtime_color_change_proven"]:
+        report["verdict"] = "inconclusive"
+        report["verdict_reason"] = "pixel_color_change_unproven"
+    else:
+        report["verdict"] = "blocked"
+        report["verdict_reason"] = "style_color_product_evidence_incomplete"
 
+    # Keep generation0 referenced for diagnostics.
+    report["generations"] = {
+        "initial_analysis": generation0,
+        "pre_commit": generation1,
+        "post_commit": _source_generation(save_status),
+        "pre_undo": generation2,
+        "post_undo": _source_generation(undo_status),
+    }
     return report

--- a/src/renforge/editor_style_color_runner.py
+++ b/src/renforge/editor_style_color_runner.py
@@ -23,6 +23,8 @@ FIXTURE_SCREEN = "renforge_editor_style_fixture"
 TARGET_ID = "style_color_target"
 INHERITED_ID = "style_color_inherited"
 EXPR_ID = "style_color_expr"
+ALPHA_ID = "style_color_alpha"
+LOOP_ID = "style_color_loop"
 FOCUS_ID = "style_focus_control"
 BASELINE_COLOR = "#e22b2b"
 REQUESTED_COLOR = "#2457d6"
@@ -303,6 +305,52 @@ def _wait_style_analysis(client: Any, *, timeout: float = 20.0) -> dict[str, Any
     )
 
 
+def _runtime_target_probe(client: Any, *, label: str, widget_id: str) -> dict[str, Any]:
+    bounds = _scene_text_bounds(client, label=label)
+    if bounds is None:
+        return {"ok": False, "reason": "scene_bounds_missing", "widget_id": widget_id}
+    selection = _attempt_product_select(client, bounds)
+    try:
+        status = _wait_for_status(
+            client,
+            lambda item: (
+                item.get("selected_widget_id") == widget_id
+                and item.get("selected_lock_reason") != "ANALYZING"
+                and (
+                    bool(item.get("current_analysis_id"))
+                    or item.get("selected_lock_reason") not in (None, "")
+                )
+            ),
+            timeout=20.0,
+            poll_name=f"style runtime probe {widget_id}",
+        )
+    except AssertionError as exc:
+        final_status = client.request("editor_task0_status", {})
+        return {
+            "ok": False,
+            "reason": str(exc),
+            "widget_id": widget_id,
+            "selection": selection,
+            "final_status": {
+                "selected_widget_id": final_status.get("selected_widget_id"),
+                "selected_analysis_pending": final_status.get("selected_analysis_pending"),
+                "selected_lock_reason": final_status.get("selected_lock_reason"),
+                "current_analysis_id": final_status.get("current_analysis_id"),
+                "save_error": final_status.get("save_error"),
+                "status_text": final_status.get("status_text"),
+            },
+        }
+    return {
+        "ok": True,
+        "widget_id": widget_id,
+        "selection": selection,
+        "lock_reason": status.get("selected_lock_reason"),
+        "capabilities": status.get("current_capabilities") or {},
+        "source_key": status.get("current_source_key") or {},
+        "observation": selection.get("observation") or {},
+    }
+
+
 def _lock_probe(source_text: str, widget_id: str, expected_code: str) -> dict[str, Any]:
     line, _ = _target_line_with_offset(source_text, widget_id)
     parsed = analyze_text_color_style(line, expected_widget_id=widget_id)
@@ -335,6 +383,35 @@ def run_editor_style_color_live_scenario(client: Any, *, fixture_path: Path) -> 
     report["locks"] = {
         "inherited": _lock_probe(baseline_text, INHERITED_ID, "STYLE_COLOR_NOT_DIRECTLY_AUTHORED"),
         "expression": _lock_probe(baseline_text, EXPR_ID, "STYLE_COLOR_LITERAL_REQUIRED"),
+    }
+
+    alpha_probe = _runtime_target_probe(client, label="ALPHA", widget_id=ALPHA_ID)
+    alpha_observation = alpha_probe.get("observation") or {}
+    alpha_caps = alpha_probe.get("capabilities") or {}
+    report["runtime_alpha"] = {
+        **alpha_probe,
+        "ok": bool(
+            alpha_probe.get("ok")
+            and alpha_probe.get("lock_reason") in (None, "")
+            and alpha_caps.get("style_color") is True
+            and alpha_observation.get("style_color") == "#33669980"
+        ),
+    }
+
+    loop_probe = _runtime_target_probe(client, label="LOOP 1", widget_id=LOOP_ID)
+    loop_observation = loop_probe.get("observation") or {}
+    loop_runtime_key = loop_observation.get("runtime_key") or {}
+    loop_discriminator = loop_runtime_key.get("instance_discriminator") or {}
+    report["runtime_repeated_lock"] = {
+        **loop_probe,
+        "instance_discriminator": loop_discriminator,
+        "ok": bool(
+            loop_probe.get("ok")
+            and loop_probe.get("lock_reason")
+            in ("LOOP_INSTANCE_UNSUPPORTED", "MULTI_INSTANCE_UNSUPPORTED")
+            and (loop_probe.get("capabilities") or {}).get("style_color") is not True
+            and int(loop_discriminator.get("instance_count") or 0) >= 2
+        ),
     }
 
     target_line, _ = _target_line_with_offset(baseline_text, TARGET_ID)
@@ -735,6 +812,8 @@ def run_editor_style_color_live_scenario(client: Any, *, fixture_path: Path) -> 
         report["product_undo"]["ok"],
         report["locks"]["inherited"]["matches_expected"],
         report["locks"]["expression"]["matches_expected"],
+        report["runtime_alpha"]["ok"],
+        report["runtime_repeated_lock"]["ok"],
         report["restore"]["byte_identical"],
     ]
     if all(required):

--- a/tests/live_fixtures/renforge_editor_style_fixture.rpy
+++ b/tests/live_fixtures/renforge_editor_style_fixture.rpy
@@ -9,14 +9,26 @@ screen renforge_editor_style_fixture():
 
     add Solid("#0a0a12", xysize=(1280, 720))
 
-    # Unlocked target: pure hex string-literal color on single-line text.
-    text "STYLE" id "style_color_target" color "#e22b2b" size 96 xpos 240 ypos 220
+    # Unlocked target: pure hex string-literal color on single-line text. The
+    # parent offset forces selection geometry to be measured in screen space.
+    fixed:
+        xpos 120
+        ypos 80
+        text "STYLE" id "style_color_target" color "#e22b2b" size 96 xpos 120 ypos 140
 
     # Inherited / not directly authored color — must stay locked.
     text "INHERIT" id "style_color_inherited" size 40 xpos 240 ypos 420
 
     # Expression color — must stay locked.
     text "EXPR" id "style_color_expr" color renforge_style_expr_color size 40 xpos 240 ypos 500
+
+    # A non-opaque 8-digit literal must keep its runtime alpha channel.
+    text "ALPHA" id "style_color_alpha" color "#33669980" size 40 xpos 720 ypos 320
+
+    # screen.widgets retains only the final iteration. Cache-derived instance
+    # evidence must still keep the shared source statement locked.
+    for index in range(2):
+        text "LOOP [index]" id "style_color_loop" color "#e22b2b" size 40 xpos 720 ypos (420 + index * 60)
 
     # Non-text control present only for focus_list sanity (not a style target).
     textbutton "FOCUS" id "style_focus_control" xpos 900 ypos 80 action NullAction()

--- a/tests/test_editor_coordinator.py
+++ b/tests/test_editor_coordinator.py
@@ -2426,3 +2426,243 @@ def test_analyze_and_commit_textbutton_anchor_preserves_anchor_bytes(tmp_path: P
             )
     finally:
         coordinator.close()
+
+
+def _style_color_observation(*, script_generation: int = 20) -> dict[str, Any]:
+    observation = _base_observation(script_generation=script_generation)
+    runtime_key = observation["runtime_key"]
+    runtime_key["widget_id"] = "style_color_target"
+    runtime_key["ancestry"][-1]["type"] = "Text"
+    observation["measurement_method"] = "scene_tree_text"
+    observation["style_color"] = "#e22b2b"
+    observation["rect"] = [240, 220, 286, 112]
+    return observation
+
+
+def _send_editor_command(
+    sock: socket.socket,
+    auth: dict[str, Any],
+    *,
+    command: str,
+    payload: dict[str, Any],
+    request_id: str,
+) -> dict[str, Any]:
+    previous_timeout = sock.gettimeout()
+    sock.settimeout(max(float(previous_timeout or 0.0), _COMMIT_SOCKET_TIMEOUT_SECONDS))
+    try:
+        _send_json(
+            sock,
+            {
+                "protocol": "renforge-editor",
+                "version": 1,
+                "connection_id": auth["connection_id"],
+                "request_id": request_id,
+                "command": command,
+                "payload": payload,
+            },
+        )
+        return _recv_json(sock)
+    finally:
+        sock.settimeout(previous_timeout)
+
+
+@pytest.mark.parametrize(
+    ("baseline_color", "requested_color"),
+    [
+        ("#e22b2b", "#2457d6"),
+        ("#e2b", "#25d"),
+        ("#e22b2bff", "#2457d6ff"),
+    ],
+)
+def test_text_style_color_commit_and_product_undo_are_transactional(
+    tmp_path: Path,
+    baseline_color: str,
+    requested_color: str,
+) -> None:
+    root = tmp_path / "project_style_color"
+    game_dir = root / "game"
+    game_dir.mkdir(parents=True)
+    source = game_dir / "script.rpy"
+    baseline = (
+        "screen test_screen:\n"
+        f'    text "STYLE" id "style_color_target" color "{baseline_color}" size 96 xpos 240 ypos 220\n'
+    )
+    source.write_text(baseline, encoding="utf-8")
+    observation = _style_color_observation()
+    observation["style_color"] = baseline_color
+    probe = _Probe(
+        observe_reply={
+            **json.loads(json.dumps(observation)),
+            "frame_id": "independent-frame-style-color",
+            "object_id": "obj-independent-style-color",
+        }
+    )
+    coordinator = EditorCoordinator(RenpyProject(root), _make_sdk(tmp_path), attestation_timeout=2.0)
+    coordinator.attach_runtime_probe(probe)
+    endpoint = coordinator.start()
+    try:
+        with socket.create_connection((endpoint.host, endpoint.port), timeout=2.0) as sock:
+            auth = _auth(sock, endpoint)
+            analyzed = _analyze(sock, auth, observation, request_id="an-style-color")
+            assert analyzed["ok"] is True
+            result = analyzed["result"]
+            assert result["lock_reason"] is None
+            assert result["source_key"]["statement_kind"] == "text"
+            assert result["source_key"]["style_mode"] == "literal_hex"
+            assert result["source_key"]["style_color"] == baseline_color
+            assert result["capabilities"] == {
+                "move": False,
+                "resize": False,
+                "style_color": True,
+                "style_color_preview": True,
+                "style_color_commit": True,
+                "style_color_undo": True,
+                "style_color_attestation_rollback": True,
+            }
+
+            # A family mismatch must fail closed with a structured reply, never
+            # escape the coordinator boundary and leave the client hanging.
+            mismatched_color = "#25d" if len(baseline_color) != 4 else "#2457d6"
+            mismatched = _send_editor_command(
+                sock,
+                auth,
+                command="commit",
+                payload={
+                    "session_id": auth["session_id"],
+                    "intents": [
+                        {
+                            "analysis_id": result["analysis_id"],
+                            "source_key": result["source_key"],
+                            "color": mismatched_color,
+                        }
+                    ],
+                },
+                request_id="style-color-family-mismatch",
+            )
+            assert mismatched["ok"] is False
+            assert mismatched["error"]["code"] == "STYLE_COLOR_HEX_FAMILY_MISMATCH"
+            assert source.read_text(encoding="utf-8") == baseline
+
+            # The second independent observation sees the product preview.
+            probe.observe_reply["style_color"] = requested_color
+
+            committed = _send_editor_command(
+                sock,
+                auth,
+                command="commit",
+                payload={
+                    "session_id": auth["session_id"],
+                    "intents": [
+                        {
+                            "analysis_id": result["analysis_id"],
+                            "source_key": result["source_key"],
+                            "color": requested_color,
+                        }
+                    ],
+                },
+                request_id="co-style-color",
+            )
+            assert committed["ok"] is True
+            transaction_id = committed["result"]["transaction_id"]
+            assert source.read_text(encoding="utf-8") == baseline.replace(baseline_color, requested_color)
+
+            handshake = _send_editor_command(
+                sock,
+                auth,
+                command="reload_handshake",
+                payload={"transaction_id": transaction_id, "script_generation": 21},
+                request_id="hs-style-color",
+            )
+            assert handshake["ok"] is True
+            assert handshake["result"]["state"] == "committed"
+            assert probe.attest_calls[-1]["expected_targets"][0]["style_color"] == requested_color
+
+            undo = _send_editor_command(
+                sock,
+                auth,
+                command="undo_commit",
+                payload={"session_id": auth["session_id"], "transaction_id": transaction_id},
+                request_id="undo-style-color",
+            )
+            assert undo["ok"] is True
+            undo_transaction_id = undo["result"]["transaction_id"]
+            assert undo_transaction_id != transaction_id
+            assert source.read_text(encoding="utf-8") == baseline
+
+            undo_handshake = _send_editor_command(
+                sock,
+                auth,
+                command="reload_handshake",
+                payload={"transaction_id": undo_transaction_id, "script_generation": 22},
+                request_id="hs-undo-style-color",
+            )
+            assert undo_handshake["ok"] is True
+            assert undo_handshake["result"]["state"] == "committed"
+            assert probe.attest_calls[-1]["expected_targets"][0]["style_color"] == baseline_color
+            assert source.read_text(encoding="utf-8") == baseline
+    finally:
+        coordinator.close()
+
+
+def test_text_style_color_refused_attestation_restores_original_bytes(tmp_path: Path) -> None:
+    root = tmp_path / "project_style_color_refused"
+    game_dir = root / "game"
+    game_dir.mkdir(parents=True)
+    source = game_dir / "script.rpy"
+    baseline = (
+        "screen test_screen:\n"
+        '    text "STYLE" id "style_color_target" color "#e22b2b" size 96 xpos 240 ypos 220\n'
+    )
+    source.write_text(baseline, encoding="utf-8")
+    observation = _style_color_observation(script_generation=30)
+    probe = _Probe(
+        observe_reply={
+            **json.loads(json.dumps(observation)),
+            "frame_id": "independent-frame-style-refused",
+            "object_id": "obj-independent-style-refused",
+        },
+        attest_reply={"ok": False, "state": "refused"},
+    )
+    coordinator = EditorCoordinator(RenpyProject(root), _make_sdk(tmp_path), attestation_timeout=2.0)
+    coordinator.attach_runtime_probe(probe)
+    endpoint = coordinator.start()
+    try:
+        with socket.create_connection((endpoint.host, endpoint.port), timeout=2.0) as sock:
+            auth = _auth(sock, endpoint)
+            analyzed = _analyze(sock, auth, observation, request_id="an-style-refused")
+            assert analyzed["ok"] is True
+            result = analyzed["result"]
+            assert result["lock_reason"] is None
+            probe.observe_reply["style_color"] = "#2457d6"
+            committed = _send_editor_command(
+                sock,
+                auth,
+                command="commit",
+                payload={
+                    "session_id": auth["session_id"],
+                    "intents": [
+                        {
+                            "analysis_id": result["analysis_id"],
+                            "source_key": result["source_key"],
+                            "color": "#2457d6",
+                        }
+                    ],
+                },
+                request_id="co-style-refused",
+            )
+            assert committed["ok"] is True
+            transaction_id = committed["result"]["transaction_id"]
+            refused = _send_editor_command(
+                sock,
+                auth,
+                command="reload_handshake",
+                payload={"transaction_id": transaction_id, "script_generation": 31},
+                request_id="hs-style-refused",
+            )
+            assert refused["ok"] is False
+            assert refused["error"]["code"] == "ATTESTATION_FAILED"
+            assert source.read_text(encoding="utf-8") == baseline
+            status = _commit_status(sock, auth, transaction_id, request_id="st-style-refused")
+            assert status["result"]["state"] == "rolled_back"
+    finally:
+        coordinator.close()

--- a/tests/test_editor_style_color_live.py
+++ b/tests/test_editor_style_color_live.py
@@ -53,7 +53,7 @@ def _open_editor(session) -> None:
     pytest.fail("editor overlay never became active")
 
 
-def test_style_color_live_gate_is_blocked_with_source_and_pixel_proof(demo_copy: Path) -> None:
+def test_style_color_live_product_path_pass(demo_copy: Path) -> None:
     from renforge.bridge.launcher import launch_with_bridge
     from renforge.project import RenpyProject
     from renforge.sdk import get_or_install_sdk
@@ -88,11 +88,30 @@ def test_style_color_live_gate_is_blocked_with_source_and_pixel_proof(demo_copy:
     assert report["locks"]["inherited"]["matches_expected"] is True
     assert report["locks"]["expression"]["matches_expected"] is True
 
+    assert report["product_select_unlocked_style"] is True
+    assert report["product_preview_available"] is True
+    assert report["product_commit_available"] is True
+    assert report["product_undo_available"] is True
+    assert report["refused_attestation_rollback_available"] is True
+    assert report["product_seam_probe"]["measurement_source"] == (
+        "editor_task0_status.current_capabilities"
+    )
+
+    preview = report["product_preview"]
+    assert preview["ok"] is True
+    assert preview["source_byte_identical"] is True
+    assert preview["pixel"]["dominant"] == "blue"
+
+    refused = report["refused_attestation_rollback"]
+    assert refused["ok"] is True
+    assert refused["byte_identical"] is True
+
     patch = report["source_patch"]
     assert patch["changed"] is True
     assert patch["matches_independent_expected"] is True
     assert patch["outside_color_span_identical"] is True
     assert patch["source_color_after"] == "#2457d6"
+    assert report["product_commit"]["ok"] is True
 
     assert report["pixel_before"]["dominant"] == "red", report["pixel_before"]
     assert report["pixel_after"]["dominant"] == "blue", report["pixel_after"]
@@ -100,20 +119,16 @@ def test_style_color_live_gate_is_blocked_with_source_and_pixel_proof(demo_copy:
     assert report["pixel_after"]["bounds_from_scene_tree"] is True
     assert report["runtime_color_change_proven"] is True
     assert report["published_source_after_reload"]["ok"] is True
+    assert report["rebinding"]["ok"] is True
 
-    # Production path must remain disabled / unselected for non-focusable text.
-    assert report["product_select_unlocked_style"] is False
-    assert report["product_preview_available"] is False
-    assert report["product_commit_available"] is False
-    assert report["product_undo_available"] is False
-    assert report["product_seam_probe"]["measurement_source"] == (
-        "editor_task0_status.current_capabilities"
-    )
+    undo = report["product_undo"]
+    assert undo["ok"] is True
+    assert undo["byte_identical"] is True
+    assert undo["source_color"] == "#e22b2b"
+    assert undo["pixel"]["dominant"] == "red"
+    assert undo["note"] == "product_undo_transaction"
 
-    # Cleanup restore is not product undo.
     assert report["restore"]["byte_identical"] is True
-    assert report["restore"]["note"] == "manual_fixture_restore_cleanup_not_product_undo"
-
-    assert report["verdict"] == "blocked"
-    assert report["verdict_reason"] == "style_color_product_path_missing"
+    assert report["verdict"] == "pass"
+    assert report["verdict_reason"] is None
     assert TARGET_ID == "style_color_target"

--- a/tests/test_editor_style_color_live.py
+++ b/tests/test_editor_style_color_live.py
@@ -87,6 +87,10 @@ def test_style_color_live_product_path_pass(demo_copy: Path) -> None:
     assert report["resolve_source"]["color"] == "#e22b2b"
     assert report["locks"]["inherited"]["matches_expected"] is True
     assert report["locks"]["expression"]["matches_expected"] is True
+    assert report["runtime_alpha"]["ok"] is True, report["runtime_alpha"]
+    assert report["runtime_alpha"]["observation"]["style_color"] == "#33669980"
+    assert report["runtime_repeated_lock"]["ok"] is True
+    assert report["runtime_repeated_lock"]["instance_discriminator"]["instance_count"] >= 2
 
     assert report["product_select_unlocked_style"] is True
     assert report["product_preview_available"] is True

--- a/tests/test_editor_style_color_live.py
+++ b/tests/test_editor_style_color_live.py
@@ -102,6 +102,11 @@ def test_style_color_live_product_path_pass(demo_copy: Path) -> None:
     assert preview["source_byte_identical"] is True
     assert preview["pixel"]["dominant"] == "blue"
 
+    preview_reset = report["product_preview_reset"]
+    assert preview_reset["ok"] is True
+    assert preview_reset["source_byte_identical"] is True
+    assert preview_reset["pixel"]["dominant"] == "red"
+
     refused = report["refused_attestation_rollback"]
     assert refused["ok"] is True
     assert refused["byte_identical"] is True
@@ -127,6 +132,12 @@ def test_style_color_live_product_path_pass(demo_copy: Path) -> None:
     assert undo["source_color"] == "#e22b2b"
     assert undo["pixel"]["dominant"] == "red"
     assert undo["note"] == "product_undo_transaction"
+
+    generations = report["generations"]
+    assert generations["pre_commit"] >= generations["initial_analysis"]
+    assert generations["post_commit"] >= generations["pre_commit"] + 1
+    assert generations["pre_undo"] >= generations["post_commit"]
+    assert generations["post_undo"] >= generations["pre_undo"] + 1
 
     assert report["restore"]["byte_identical"] is True
     assert report["verdict"] == "pass"


### PR DESCRIPTION
## Summary

- add a source-safe `text` + literal hex `color` editing contract
- discover and select identified non-focusable text displayables in the in-game bridge
- preview colour without writing source, then shadow-validate and atomically commit
- reload, rebind by stable identity, attest the painted colour, and roll back on refusal
- undo committed colour edits through a second validated transaction
- keep inherited, expression-based, ambiguous, multiline, malformed, non-text, multi-instance, and stale targets locked

## Safety boundaries

- one adapter: `text`
- one property: `color`
- one physical source line
- directly authored `#rgb`, `#rrggbb`, or `#rrggbbaa` string literal only
- preserve the authored hex family and every byte outside the colour token
- live forced-attestation-refusal hook is registered only with `RENFORGE_STYLE_COLOR_LIVE=1`

## Validation

- `PYTHONPATH=src python -m pytest -q tests/test_editor_style_color_source.py tests/test_editor_coordinator.py` — `77 passed in 16.19s`
- `RENFORGE_STYLE_COLOR_LIVE=1 PYTHONPATH=src python -m pytest -q tests/test_editor_style_color_live.py` — `1 passed in 26.36s` on Ren'Py 8.5.3
- `PYTHONPATH=src python -m pytest -q` — `663 passed, 45 skipped in 34.51s`
- `python -m compileall -q src tests` — passed
- `git diff --check` — passed
- `cd ui && npm run build` — i18n green, TypeScript clean, Vite build passed

Closes #50
