### PR TITLE
fix(editor): report ATL ancestry as animated, not unknown (#51)

### DIFF
--- a/src/renforge/bridge/editor.rpy
+++ b/src/renforge/bridge/editor.rpy
@@ -261,6 +261,20 @@ init 1100 python:
         ]
     )
 
+    # Ancestry types that are locked for a known, specific reason rather than
+    # simply being unrecognised. `at <atl transform>` resolves to ATLTransform,
+    # which subclasses Transform but reports its own class name (issue #51):
+    # measured on 8.5.3, an active ATL resets show time on every
+    # `_widget_properties` preview and overwrites position overrides, so these
+    # targets stay locked — but the editor should say why.
+    _ATL_ANCESTRY_TYPES = set(["ATLTransform"])
+
+    def _renforge_editor_ancestry_lock_code(class_name):
+        """Lock code for an ancestry type outside the allowlist."""
+        if class_name in _ATL_ANCESTRY_TYPES:
+            return "ATL_ANIMATION_UNSUPPORTED"
+        return "UNKNOWN_ANCESTRY_TYPE"
+
     def _renforge_editor_state():
         state = _renforge_runtime_module.editor_v1
         if not hasattr(state, "initialized"):
@@ -1213,7 +1227,7 @@ init 1100 python:
         for index, node in enumerate(ancestry_nodes):
             class_name = getattr(getattr(node, "__class__", None), "__name__", "unknown")
             if class_name not in _ALLOWED_ANCESTRY_TYPES:
-                return None, "UNKNOWN_ANCESTRY_TYPE", None, None
+                return None, _renforge_editor_ancestry_lock_code(class_name), None, None
             # Size-compare against the focused widget (usually the Button), not
             # the named map entry which can resolve to a child Text.
             crop_state = _renforge_editor_crop_state(
@@ -1295,7 +1309,7 @@ init 1100 python:
                 return "UNKNOWN_ANCESTRY_TYPE"
             node_type = str(node.get("type") or "")
             if node_type not in _ALLOWED_ANCESTRY_TYPES:
-                return "UNKNOWN_ANCESTRY_TYPE"
+                return _renforge_editor_ancestry_lock_code(node_type)
             crop_state = str(node.get("crop_state") or "")
             if crop_state not in (
                 "none",
@@ -1512,7 +1526,7 @@ init 1100 python:
         for index, node in enumerate(ancestry_nodes):
             class_name = getattr(getattr(node, "__class__", None), "__name__", "unknown")
             if class_name not in _ALLOWED_ANCESTRY_TYPES:
-                return None, "UNKNOWN_ANCESTRY_TYPE", None
+                return None, _renforge_editor_ancestry_lock_code(class_name), None
             crop_state = _renforge_editor_crop_state(node, focus=None, target=widget)
             if crop_state not in (
                 "none",

--- a/tests/test_editor_animated_live.py
+++ b/tests/test_editor_animated_live.py
@@ -9,9 +9,11 @@ import pytest
 
 from renforge.editor_animated_runner import (
     FIXTURE_SCREEN,
+    _show_fixture,
     inject_editor_animated_resources,
     run_editor_animated_live_scenario,
 )
+from renforge.editor_live_common import wait_bounds
 
 pytestmark = pytest.mark.skipif(
     not os.environ.get("RENFORGE_ANIMATED_LIVE"),
@@ -75,3 +77,45 @@ def test_animated_element_editing_spike(demo_copy: Path) -> None:
     assert report["verdict"] == "blocked"
     assert report["reason_code"] in {"atl_position_override_conflict", "atl_time_reset"}
     assert "variants" in report
+
+
+def test_atl_ancestry_reports_its_own_lock_reason(demo_copy: Path) -> None:
+    """Issue #51: an ATL ancestor is locked as animated, not as an unknown type.
+
+    Both targets sit still on screen: `anim_style_target` animates alpha only and
+    `anim_static_transform` is a stationary wrapper, so the click point is stable.
+    `anim_pos_target` is deliberately not probed here — its ATL moves it between
+    the bounds read and the click.
+    """
+    from renforge.bridge.launcher import launch_with_bridge
+    from renforge.project import RenpyProject
+    from renforge.sdk import get_or_install_sdk
+
+    sdk = get_or_install_sdk("8.5.3", project_root=demo_copy)
+
+    def select_center(client, widget_id: str) -> dict:
+        bounds = wait_bounds(client, widget_id, fixture_screen=FIXTURE_SCREEN)
+        return client.request(
+            "editor_task0_select",
+            {
+                "x": bounds["x"] + bounds["width"] // 2,
+                "y": bounds["y"] + bounds["height"] // 2,
+            },
+        )
+
+    with launch_with_bridge(
+        sdk, RenpyProject(demo_copy), startup_timeout=120, editor=True
+    ) as session:
+        _open_editor(session)
+        _show_fixture(session.client)
+        animated = select_center(session.client, "anim_style_target")
+        stationary = select_center(session.client, "anim_static_transform")
+
+    # An active ATL stays locked, but says why.
+    assert animated.get("ok") is False
+    assert animated.get("lock_reason") == "ATL_ANIMATION_UNSUPPORTED"
+
+    # A stationary Transform wrapper keeps working: this lock must not widen.
+    assert stationary.get("ok") is True
+    assert stationary.get("lock_reason") is None
+    assert (stationary.get("selected") or {}).get("widget_id") == "anim_static_transform"


### PR DESCRIPTION
## What

An element carrying `at <atl transform>` was locked with `UNKNOWN_ANCESTRY_TYPE`.
The lock was correct; the reason was not.

`ATLTransform` subclasses `Transform`, but ancestry classification reads
`type(node).__name__`, so the exact name `ATLTransform` missed the allowlist and
fell into "unknown type". The editor told users their element had an
unrecognised ancestor when the real reason is that it is animated — precisely
the kind of reason the failed-gate UI (#52) was built to display.

Behaviour is unchanged: animated elements stay locked. Only the reason is now
accurate.

## Measured on Ren'Py 8.5.3

Probing the product selection path against the three fixture variants:

| Variant | Before | After |
| --- | --- | --- |
| `anim_pos_target` — ATL animating `xpos` | `UNKNOWN_ANCESTRY_TYPE` | `ATL_ANIMATION_UNSUPPORTED` |
| `anim_style_target` — ATL animating `alpha` | `UNKNOWN_ANCESTRY_TYPE` | `ATL_ANIMATION_UNSUPPORTED` |
| `anim_static_transform` — `Transform(zoom=1.0)` | selectable, no lock | selectable, no lock |

The stationary wrapper is the regression guard: this lock must not widen to
static transforms.

`test_atl_ancestry_reports_its_own_lock_reason` fails against the previous
behaviour (`assert 'UNKNOWN_ANCESTRY_TYPE' == 'ATL_ANIMATION_UNSUPPORTED'`) and
passes with the change. It probes only the two stationary targets, because
`anim_pos_target` moves between the bounds read and the click.

Full suite: `668 passed, 48 skipped`. `compileall` and `git diff --check` clean.

## Two findings for #51 and #70, out of scope here

**1. The existing animated live test cannot pass.**
`tests/test_editor_animated_live.py::test_animated_element_editing_spike` calls
`editor_task0_preview`, a command the bridge does not define — `git log -S` finds
no commit where it ever did. It fails identically on a clean `main`, and is
skipped by default, so CI never surfaced it. The measurements quoted in
`docs/superpowers/spikes/2026-08-02-animated-element-editing-result.md` cannot
have come from the command line that report gives.

**2. Animated elements are marginal in real Ren'Py UI.**
In the standard `screens.rpy` template: **4 of 120** interface elements carry an
`at`, and they are the three blinking skip-indicator triangles and the notify
frame — none of which anyone repositions by hand.

Together these suggest closing #51 as won't-do with the ratio as justification,
rather than spending an engine-level spike on it. That is a product call, not
one this PR makes.

Refs #51, #70

## Summary by Sourcery

Classer les ancêtres animés ATL avec une raison de verrouillage spécifique et activer un hit-testing précis pour les éléments transformés, en mettant à jour les tests et la documentation pour refléter le nouveau comportement.

Corrections de bugs :
- Reporter l’ascendance animée basée sur ATL comme ATL_ANIMATION_UNSUPPORTED plutôt que UNKNOWN_ANCESTRY_TYPE tout en préservant le comportement de verrouillage existant.

Améliorations :
- Introduire un hit-testing compatible avec les transformations, qui dérive et valide les quads transformés avant la sélection, en revenant à l’AABB uniquement pour les éléments non transformés et en verrouillant les cas ambigus avec TRANSFORM_GEOMETRY_UNPROVEN.

Documentation :
- Ajouter des critères produit et des rapports de résultats décrivant la sélection d’éléments pivotés, les invariants de géométrie et les conditions de déclenchement pour l’Issue #48.

Tests :
- Ajouter un test live garantissant que l’ascendance ATL rapporte sa propre raison de verrouillage sans provoquer de régression sur les transformations stationnaires.
- Mettre à jour les tests live de rotation et les attentes du runner afin d’exiger une sélection et un glisser réussis sur le chemin produit en utilisant le nouveau hit-testing basé sur les quads.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Classify ATL animated ancestors with a specific lock reason and enable precise hit-testing for transformed displayables, updating tests and documentation to reflect the new behavior.

Bug Fixes:
- Report ATL-based animated ancestry as ATL_ANIMATION_UNSUPPORTED instead of UNKNOWN_ANCESTRY_TYPE while preserving the existing lock behavior.

Enhancements:
- Introduce transform-aware hit-testing that derives and validates transformed quads before selection, falling back to AABB only for untransformed elements and locking ambiguous cases with TRANSFORM_GEOMETRY_UNPROVEN.

Documentation:
- Add product criteria and result reports documenting rotated element selection, geometry invariants, and gating conditions for Issue #48.

Tests:
- Add a live test ensuring ATL ancestry reports its own lock reason without regressing stationary transforms.
- Update rotation live tests and runner expectations to require successful product-path selection and dragging using the new quad-based hit-testing.

</details>