### PR TITLE
chore: add Glama release configuration

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+**
+!Dockerfile
+!pyproject.toml
+!glama.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM python:3.12-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1
+
+WORKDIR /tmp/renforge-build
+COPY pyproject.toml ./
+RUN RENFORGE_VERSION="$(python -c 'import pathlib, tomllib; print(tomllib.loads(pathlib.Path("pyproject.toml").read_text())["project"]["version"])')" \
+    && python -m pip install --no-cache-dir "renforge==${RENFORGE_VERSION}" \
+    && rm -rf /tmp/renforge-build
+
+RUN useradd --create-home --uid 10001 renforge \
+    && mkdir /workspace \
+    && chown renforge:renforge /workspace
+
+USER renforge
+WORKDIR /workspace
+
+ENTRYPOINT ["renforge"]
+CMD ["serve"]

--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": [
+    "alex-jordan547"
+  ],
+  "name": "RenForge MCP",
+  "description": "Inspect, launch, test, and visually edit Ren'Py projects through MCP, a CLI, and a web dashboard.",
+  "keywords": [
+    "renpy",
+    "visual-novel",
+    "game-development",
+    "live-editor",
+    "testing",
+    "mcp"
+  ]
+}


### PR DESCRIPTION
## Summary
- add Glama maintainer metadata for claiming the RenForge listing
- add a minimal non-root stdio container pinned to the package version in `pyproject.toml`
- restrict the Docker build context to release metadata only

## Verification
- `glama.json` validates against the official Glama schema
- Docker builds on ARM64 and AMD64
- both images report `renforge 0.7.0` and run as UID 10001
- AMD64 MCP smoke test initializes protocol `2025-06-18` and lists 54 tools

## Summary by Sourcery

Ajout des métadonnées de publication Glama et d’une image Docker minimale non-root pour l’interface CLI RenForge, limitée aux artefacts de publication.

Nouvelles fonctionnalités :
- Introduire une image Docker RenForge figée, construite à partir de la version du paquet définie dans `pyproject.toml`.
- Fournir les métadonnées de responsable Glama pour la fiche RenForge.

Améliorations :
- Exécuter l’image Docker en tant qu’utilisateur non-root avec un répertoire d’espace de travail dédié.
- Limiter le contexte de build Docker via `.dockerignore` aux seuls fichiers liés aux publications.

Déploiement :
- Ajouter un `Dockerfile` pour construire un conteneur de publication léger pour RenForge.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add Glama release metadata and a minimal non-root Docker image for the RenForge CLI, scoped to release artifacts.

New Features:
- Introduce a pinned RenForge Docker image built from the package version defined in pyproject.toml.
- Provide Glama maintainer metadata for the RenForge listing.

Enhancements:
- Run the Docker image as a non-root user with a dedicated workspace directory.
- Limit the Docker build context via .dockerignore to release-related files only.

Deployment:
- Add a Dockerfile for building a lightweight release container for RenForge.

</details>