### PR TITLE
fix(editor): dismiss dialogue screens immediately on jump

### DIFF
--- a/src/renforge/bridge/editor.rpy
+++ b/src/renforge/bridge/editor.rpy
@@ -4560,7 +4560,8 @@ init 1100 python:
     # Dialogue surfaces take required scope args (who/what). Jumping out of a
     # screen while they are still showing leaves them in the layer with an empty
     # scope; the next interact (often a `scene … with dissolve`) then dies with
-    # `TypeError: missing a required argument: 'who'`. Tear them down first.
+    # `TypeError: missing a required argument: 'who'`. Tear them down
+    # immediately so a hide transition cannot retain an empty-scope copy.
     _RF_JUMP_DISMISS_SCREENS = ("say", "nvl", "bubble", "choice")
 
     def _renforge_editor_jump_to(label):
@@ -4570,7 +4571,7 @@ init 1100 python:
         for name in _RF_JUMP_DISMISS_SCREENS:
             try:
                 if renpy.get_screen(name) is not None:
-                    renpy.hide_screen(name)
+                    renpy.hide_screen(name, immediately=True)
             except Exception:
                 pass
         renpy.jump(str(label))

--- a/tests/test_bridge_runtime.py
+++ b/tests/test_bridge_runtime.py
@@ -1281,6 +1281,60 @@ def test_editor_periodic_restores_handshake_after_saved_state(
         globs["_renforge_editor_stop_coordinator"]()
 
 
+def test_editor_jump_removes_dialogue_screens_before_control_transfer(
+    running_bridge, monkeypatch
+):
+    renpy = running_bridge.renpy
+    globs = running_bridge.globs
+    for name in (
+        "RENFORGE_EDITOR_HOST",
+        "RENFORGE_EDITOR_PORT",
+        "RENFORGE_EDITOR_TOKEN",
+        "RENFORGE_EDITOR_PROTOCOL",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+    active_screens = {"say", "quick_menu", "_renforge_editor_overlay"}
+    pending_hides = set()
+    hide_calls = []
+    renpy.config.after_load_callbacks = []
+    renpy.Displayable = object
+    renpy.Render = lambda width, height: types.SimpleNamespace(
+        width=width, height=height
+    )
+    renpy.IgnoreEvent = type("IgnoreEvent", (Exception,), {})
+    renpy.get_screen = lambda name: object() if name in active_screens else None
+    renpy.show_screen = lambda name, **_kwargs: active_screens.add(name)
+
+    def hide_screen(name, immediately=False, **_kwargs):
+        hide_calls.append((name, immediately))
+        if immediately:
+            active_screens.discard(name)
+        else:
+            pending_hides.add(name)
+
+    class JumpSignal(Exception):
+        pass
+
+    def jump(label):
+        if "say" in pending_hides:
+            raise TypeError("missing a required argument: 'who'")
+        raise JumpSignal(label)
+
+    renpy.hide_screen = hide_screen
+    renpy.jump = jump
+
+    exec(compile(_load_editor_body(), "editor.rpy", "exec"), globs)
+    try:
+        with pytest.raises(JumpSignal, match="village"):
+            globs["_renforge_editor_jump_to"]("village")
+
+        assert hide_calls == [("say", True)]
+        assert "say" not in active_screens
+    finally:
+        globs["_renforge_editor_stop_coordinator"]()
+
+
 def test_editor_exit_reverts_unsaved_previews_before_clearing_state(
     running_bridge, monkeypatch
 ):


### PR DESCRIPTION
## Summary
- Hide `say` / `nvl` / `bubble` / `choice` with `renpy.hide_screen(..., immediately=True)` before an editor jump.
- Add a regression test that reproduces the empty-scope `TypeError: missing a required argument: 'who'` when a hide transition is left pending.

## Motivation and related issue
Jumping while a dialogue screen is still showing can leave it on the layer with an empty scope. The next interact (often `scene … with dissolve`) then crashes.

This is the only follow-up from `feat/editor-ui-foundations` that was not in #80.

## Changes
- `_renforge_editor_jump_to` now tears dialogue screens down immediately so a hide transition cannot retain an empty-scope copy.
- `test_editor_jump_removes_dialogue_screens_before_control_transfer` asserts `hide_screen("say", immediately=True)` and that control transfer does not raise the `who` TypeError.

## Validation
- `.venv/bin/python -m pytest tests/test_bridge_runtime.py::test_editor_jump_removes_dialogue_screens_before_control_transfer tests/test_bridge_runtime.py::test_editor_periodic_finishes_pending_handshake_after_reload_slot_clears tests/test_bridge_runtime.py::test_editor_periodic_restores_handshake_after_saved_state -q`: 3 passed
- `python -m compileall src tests`: not re-run
- `python -m pytest -q`: not re-run (focused cases above)
- `npm --prefix ui run build`: not applicable
- Manual verification: original live crash was `TypeError: missing a required argument: 'who'` after jump; the unit test fails without `immediately=True` and passes with it

## User-facing changes
Jumping from the editor while dialogue is on screen no longer crashes the next interact.

## Internationalization
- [x] New user-visible copy uses i18n keys, or this PR adds no user-visible copy.
- [x] `npm --prefix ui run i18n:check` passes, or i18n is not applicable.

## Breaking changes
None

## Documentation
None required; comment on `_RF_JUMP_DISMISS_SCREENS` documents why the hide must be immediate.

## Reviewer notes
Cherry-picked from `46ce68d` onto current `main`. The test file conflict was resolved by keeping the handshake tests already on `main` and inserting the jump regression next to them.

## Final checklist
- [x] The PR is focused on one coherent change.
- [x] Tests were added or updated for behavior changes.
- [x] Generated `src/renforge/ui/static/` assets remain untracked; CI and release builds produce them.
- [x] No credentials, tokens, personal paths, or other secrets are included.
- [x] I understand the submitted code and can explain how it works.

## Summary by Sourcery

Garantir que les sauts initiés depuis l’éditeur ferment immédiatement les écrans de dialogue actifs afin d’éviter les crashs lors des interactions suivantes.

Bug Fixes:
- Empêcher un crash de type TypeError lors d’un saut depuis l’éditeur alors que des écrans de dialogue sont encore affichés, en les détruisant immédiatement avant le transfert de contrôle.

Tests:
- Ajouter un test de régression qui vérifie que les écrans de dialogue sont supprimés et qu’aucune TypeError n’est levée lors d’un saut depuis l’éditeur avec un dialogue actif.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure editor-initiated jumps dismiss active dialogue screens immediately to prevent crashes during subsequent interaction.

Bug Fixes:
- Prevent a TypeError crash when jumping from the editor while dialogue screens are still displayed by immediately tearing them down before control transfer.

Tests:
- Add a regression test that verifies dialogue screens are removed and no TypeError is raised when jumping from the editor with active dialogue.

</details>