### PR TITLE
fix: treat JSON null as unused exclusive MCP inputs

### DIFF
--- a/src/renforge/server.py
+++ b/src/renforge/server.py
@@ -926,7 +926,11 @@ def _register_tools(app: Any) -> None:
         )
 
     @_register_tool
-    def renforge_select_choice(project_path: str, text: str = "", index: int = -1) -> dict:
+    def renforge_select_choice(
+        project_path: str,
+        text: str | None = None,
+        index: int | None = None,
+    ) -> dict:
         """Select a menu choice by visible text (preferred) or by index."""
         return _log_tool_call(
             name="renforge_select_choice",
@@ -934,7 +938,10 @@ def _register_tools(app: Any) -> None:
             project_root=project_path,
             fn=live.select_choice,
             args=(project_path,),
-            kwargs={"text": text or None, "index": index if index >= 0 else None},
+            kwargs={
+                "text": text or None,
+                "index": index if isinstance(index, int) and index >= 0 else None,
+            },
         )
 
     @_register_tool

--- a/src/renforge/tool_definitions.py
+++ b/src/renforge/tool_definitions.py
@@ -415,8 +415,8 @@ TOOL_DEFINITIONS: dict[str, ToolDefinition] = {
         ),
         parameters={
             "project_path": "Project root of the running live session.",
-            "text": "Visible text to match; preferred over index.",
-            "index": "Zero-based choice index fallback when text is omitted.",
+            "text": "Visible text to match; preferred over index. Unused exclusive fields may be omitted or null.",
+            "index": "Zero-based choice index fallback when text is omitted or null.",
         },
     ),
     "renforge_list_ui_elements": ToolDefinition(
@@ -1097,6 +1097,26 @@ def _limits(minimum: int | float, maximum: int | float) -> dict[str, Any]:
     return {"minimum": minimum, "maximum": maximum}
 
 
+def _inactive(*names: str) -> dict[str, Any]:
+    """Allow schema-driven clients to serialize unused exclusive fields as JSON null."""
+    return {name: {"type": "null"} for name in names}
+
+
+def _exclusive_branches(
+    options: dict[str, dict[str, Any]],
+    extras: dict[str, dict[str, Any]] | None = None,
+) -> list[dict[str, Any]]:
+    extras = extras or {}
+    names = tuple(options)
+    branches: list[dict[str, Any]] = []
+    for name, schema in options.items():
+        properties = _inactive(*(other for other in names if other != name))
+        properties[name] = schema
+        properties.update(extras.get(name, {}))
+        branches.append({"required": [name], "properties": properties})
+    return branches
+
+
 def _scenario_step_schema(action: str) -> dict[str, Any]:
     payloads: dict[str, dict[str, Any]] = {
         "set": {"type": "object", "minProperties": 1},
@@ -1291,51 +1311,56 @@ _PARAMETER_SCHEMAS: dict[str, dict[str, dict[str, Any]]] = {
 
 _INPUT_SCHEMAS: dict[str, dict[str, Any]] = {
     "renforge_send_input": {
-        "oneOf": [
-            {"required": ["text"], "properties": {"text": {"type": "string"}}, "not": {"anyOf": [{"required": ["key"]}, {"required": ["scroll"]}]}},
-            {"required": ["key"], "properties": {"key": {"type": "string", "minLength": 1}, "submit": {"const": False}}, "not": {"anyOf": [{"required": ["text"]}, {"required": ["scroll"]}]}},
-            {"required": ["scroll"], "properties": {"scroll": _SCROLL_SCHEMA, "submit": {"const": False}}, "not": {"anyOf": [{"required": ["text"]}, {"required": ["key"]}]}},
-        ]
+        "oneOf": _exclusive_branches(
+            {
+                "text": {"type": "string"},
+                "key": {"type": "string", "minLength": 1},
+                "scroll": _SCROLL_SCHEMA,
+            },
+            extras={
+                "key": {"submit": {"const": False}},
+                "scroll": {"submit": {"const": False}},
+            },
+        )
     },
     "renforge_wait_until": {
-        "oneOf": [
-            {"required": ["label"], "properties": {"label": {"type": "string", "minLength": 1}}, "not": {"anyOf": [{"required": ["screen"]}, {"required": ["expr"]}]}},
-            {"required": ["screen"], "properties": {"screen": {"type": "string", "minLength": 1}}, "not": {"anyOf": [{"required": ["label"]}, {"required": ["expr"]}]}},
-            {"required": ["expr"], "properties": {"expr": {"type": "string", "minLength": 1}}, "not": {"anyOf": [{"required": ["label"]}, {"required": ["screen"]}]}},
-        ]
+        "oneOf": _exclusive_branches(
+            {
+                "label": {"type": "string", "minLength": 1},
+                "screen": {"type": "string", "minLength": 1},
+                "expr": {"type": "string", "minLength": 1},
+            }
+        )
     },
     "renforge_saves": {
         "oneOf": [
             {
-                "properties": {"action": {"const": "save"}},
+                "properties": {"action": {"const": "save"}, **_inactive("regexp")},
                 "required": ["action", "slot"],
-                "not": {"required": ["regexp"]},
             },
             {
-                "properties": {"action": {"const": "load"}},
+                "properties": {
+                    "action": {"const": "load"},
+                    **_inactive("extra_info", "regexp"),
+                },
                 "required": ["action", "slot"],
-                "not": {"anyOf": [{"required": ["extra_info"]}, {"required": ["regexp"]}]},
             },
             {
-                "properties": {"action": {"const": "list"}},
+                "properties": {
+                    "action": {"const": "list"},
+                    **_inactive("slot", "extra_info"),
+                },
                 "required": ["action"],
-                "not": {"anyOf": [{"required": ["slot"]}, {"required": ["extra_info"]}]},
             },
         ]
     },
     "renforge_select_choice": {
-        "oneOf": [
+        "oneOf": _exclusive_branches(
             {
-                "required": ["text"],
-                "properties": {"text": {"type": "string", "minLength": 1}},
-                "not": {"required": ["index"]},
-            },
-            {
-                "required": ["index"],
-                "properties": {"index": {"type": "integer", "minimum": 0}},
-                "not": {"required": ["text"]},
-            },
-        ]
+                "text": {"type": "string", "minLength": 1},
+                "index": {"type": "integer", "minimum": 0},
+            }
+        )
     },
 }
 

--- a/tests/test_tool_definitions.py
+++ b/tests/test_tool_definitions.py
@@ -102,15 +102,182 @@ def test_emitted_tool_schemas_encode_options_limits_and_required_relationships()
     assert scroll_object["additionalProperties"] is False
     assert scroll_object["properties"]["direction"]["enum"] == ["up", "down"]
     assert len(send_input["oneOf"]) == 3
+    assert send_input["oneOf"][0]["properties"]["key"] == {"type": "null"}
+    assert send_input["oneOf"][0]["properties"]["scroll"] == {"type": "null"}
+    assert "not" not in send_input["oneOf"][0]
 
     wait_schema = schemas["renforge_wait_until"]
     assert len(wait_schema["oneOf"]) == 3
+    assert wait_schema["oneOf"][0]["properties"]["screen"] == {"type": "null"}
+    assert wait_schema["oneOf"][0]["properties"]["expr"] == {"type": "null"}
     assert wait_schema["properties"]["timeout"]["maximum"] == 120
+
+    saves_schema = schemas["renforge_saves"]
+    assert saves_schema["oneOf"][0]["properties"]["regexp"] == {"type": "null"}
+    assert "not" not in saves_schema["oneOf"][0]
+
+    select_schema = schemas["renforge_select_choice"]
+    assert select_schema["oneOf"][0]["properties"]["index"] == {"type": "null"}
+    assert select_schema["oneOf"][1]["properties"]["text"] == {"type": "null"}
+    assert any(
+        item.get("type") == "null"
+        for item in select_schema["properties"]["index"].get("anyOf", [])
+    )
 
     scenario_steps = schemas["renforge_run_scenario"]["properties"]["steps"]
     assert len(scenario_steps["items"]["oneOf"]) == 14
     assert scenario_steps["items"]["oneOf"][0]["additionalProperties"] is False
     assert scenario_steps["items"]["oneOf"][0]["required"] == ["set"]
+
+
+def test_exclusive_input_schemas_accept_null_inactive_fields() -> None:
+    pytest.importorskip("fastmcp", reason="fastmcp not installed")
+    jsonschema = pytest.importorskip("jsonschema")
+
+    tools = asyncio.run(create_app().list_tools())
+    schemas = {
+        tool.name: tool.parameters
+        for tool in tools
+        if tool.name.startswith("renforge_")
+    }
+
+    valid = [
+        (
+            "renforge_send_input",
+            {"project_path": "/tmp/p", "text": "hello", "key": None, "scroll": None},
+        ),
+        (
+            "renforge_wait_until",
+            {"project_path": "/tmp/p", "label": "start", "screen": None, "expr": None},
+        ),
+        (
+            "renforge_saves",
+            {"project_path": "/tmp/p", "action": "save", "slot": "a", "regexp": None},
+        ),
+        (
+            "renforge_saves",
+            {"project_path": "/tmp/p", "action": "list", "slot": None, "extra_info": None},
+        ),
+        (
+            "renforge_select_choice",
+            {"project_path": "/tmp/p", "text": "Yes", "index": None},
+        ),
+        (
+            "renforge_select_choice",
+            {"project_path": "/tmp/p", "text": None, "index": 0},
+        ),
+    ]
+    invalid = [
+        (
+            "renforge_send_input",
+            {"project_path": "/tmp/p", "text": "hello", "key": "enter"},
+        ),
+        (
+            "renforge_wait_until",
+            {"project_path": "/tmp/p", "label": "start", "screen": "say"},
+        ),
+        (
+            "renforge_saves",
+            {"project_path": "/tmp/p", "action": "save", "slot": "a", "regexp": "branch"},
+        ),
+        (
+            "renforge_select_choice",
+            {"project_path": "/tmp/p", "text": "Yes", "index": 0},
+        ),
+    ]
+
+    for name, payload in valid:
+        jsonschema.validate(payload, schemas[name])
+    for name, payload in invalid:
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(payload, schemas[name])
+
+
+def test_null_exclusive_arguments_reach_tool_implementation(monkeypatch, tmp_path) -> None:
+    pytest.importorskip("fastmcp", reason="fastmcp not installed")
+    from fastmcp import Client
+    from renforge.tools import live
+
+    send_calls: list[dict] = []
+    wait_calls: list[dict] = []
+    save_calls: list[dict] = []
+    choice_calls: list[dict] = []
+    monkeypatch.setattr(
+        live,
+        "send_input",
+        lambda project_path, **kwargs: send_calls.append(kwargs) or {"ok": True},
+    )
+    monkeypatch.setattr(
+        live,
+        "wait_until",
+        lambda project_path, **kwargs: wait_calls.append(kwargs) or {"ok": True},
+    )
+    monkeypatch.setattr(
+        live,
+        "saves",
+        lambda project_path, action, **kwargs: save_calls.append({"action": action, **kwargs})
+        or {"ok": True},
+    )
+    monkeypatch.setattr(
+        live,
+        "select_choice",
+        lambda project_path, **kwargs: choice_calls.append(kwargs) or {"ok": True},
+    )
+
+    async def _call(name: str, payload: dict):
+        async with Client(create_app()) as client:
+            return await client.call_tool(name, payload, raise_on_error=False)
+
+    send = asyncio.run(
+        _call(
+            "renforge_send_input",
+            {
+                "project_path": str(tmp_path),
+                "text": "hello",
+                "key": None,
+                "scroll": None,
+            },
+        )
+    )
+    wait = asyncio.run(
+        _call(
+            "renforge_wait_until",
+            {
+                "project_path": str(tmp_path),
+                "label": "start",
+                "screen": None,
+                "expr": None,
+            },
+        )
+    )
+    saved = asyncio.run(
+        _call(
+            "renforge_saves",
+            {
+                "project_path": str(tmp_path),
+                "action": "save",
+                "slot": "a",
+                "regexp": None,
+            },
+        )
+    )
+    choice = asyncio.run(
+        _call(
+            "renforge_select_choice",
+            {"project_path": str(tmp_path), "text": "Yes", "index": None},
+        )
+    )
+
+    assert send.is_error is False
+    assert wait.is_error is False
+    assert saved.is_error is False
+    assert choice.is_error is False
+    assert send_calls == [{"text": "hello", "key": None, "scroll": None, "submit": False}]
+    assert wait_calls[0]["label"] == "start"
+    assert wait_calls[0]["screen"] is None
+    assert wait_calls[0]["expr"] is None
+    assert save_calls == [{"action": "save", "slot": "a", "extra_info": None, "regexp": None}]
+    assert choice_calls == [{"text": "Yes", "index": None}]
 
 
 def test_invalid_enum_is_rejected_before_tool_implementation(monkeypatch, tmp_path) -> None:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Address the Codex production review on #85: schema-driven clients that serialize unused mutually exclusive arguments as `null` were rejected by presence-based `oneOf` clauses, even though runtime already selects inputs with `value is not None`.

## Motivation and related issue

Codex review on #85 (`renforge_send_input`, also `renforge_wait_until`, `renforge_saves`, and `renforge_select_choice`):

> When a schema-driven client serializes optional arguments explicitly as `null`, a valid call such as `{text: "hello", key: null, scroll: null}` fails this `oneOf`.

This PR targets `fix/agent-safe-tool-definitions` so it can land into #85.

## Changes

- Express exclusive MCP inputs by constraining inactive fields to JSON `null` instead of `not: {required: [...]}`.
- Accept `null` for unused `renforge_select_choice` `text`/`index` arguments (they were previously `str`/`int` sentinels).
- Add schema and FastMCP regression tests for null inactive fields, while still rejecting two active values at once.

## Validation

- `python -m compileall src tests`: pending
- `python -m pytest -q`: pending
- `npm --prefix ui run build`: Not applicable (no UI change)
- Manual verification: pending JSON Schema validation of null exclusive payloads

## User-facing changes

Agents and other schema-driven MCP clients can now send unused exclusive parameters as `null` instead of omitting them.

## Internationalization

- [x] New user-visible copy uses i18n keys, or this PR adds no user-visible copy.
- [x] `npm --prefix ui run i18n:check` passes, or i18n is not applicable.

## Breaking changes

None. Omitting unused exclusive fields remains valid. Explicit `null` is now accepted as unused.

## Documentation

No docs change; tool JSON Schemas are the contract.

## Reviewer notes

Stacked on #85. Conflicting non-null exclusive values remain invalid.

## Final checklist

- [x] The PR is focused on one coherent change.
- [x] Tests were added or updated for behavior changes.
- [x] Generated `src/renforge/ui/static/` assets remain untracked; CI and release builds produce them.
- [x] No credentials, tokens, personal paths, or other secrets are included.
- [x] I understand the submitted code and can explain how it works.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c1144d26-032e-481d-a475-5fc506a35a40?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c1144d26-032e-481d-a475-5fc506a35a40&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

Autoriser les clients MCP pilotés par schéma à traiter `JSON null` comme un marqueur explicite pour les entrées d’outils mutuellement exclusives non utilisées, tout en préservant la validation de l’exclusivité.

Nouvelles fonctionnalités :
- Prise en charge de `JSON null` pour les paramètres mutuellement exclusifs non utilisés dans les schémas d’outils MCP de `renforge`, y compris les arguments `renforge_select_choice` text/index.

Corrections de bugs :
- Empêcher que des appels valides avec des valeurs `null` explicites dans des champs exclusifs inactifs soient rejetés par des clauses `oneOf` basées sur la présence.

Améliorations :
- Refactoriser les schémas JSON des entrées exclusives pour utiliser des branches générées avec des champs inactifs typés `null` au lieu de contraintes négatives sur `required`.
- Mettre à jour l’implémentation serveur de `renforge_select_choice` et les descriptions de paramètres pour les aligner avec des entrées exclusives text/index annulables.

Tests :
- Ajouter des tests de régression de schéma JSON garantissant que les champs inactifs à `null` sont acceptés et que plusieurs champs actifs restent invalides.
- Ajouter des tests d’intégration FastMCP vérifiant que les arguments exclusifs à `null` sont validés et parviennent aux implémentations d’outils avec les payloads attendus.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Allow schema-driven MCP clients to treat JSON null as an explicit marker for unused mutually exclusive tool inputs while preserving exclusivity validation.

New Features:
- Support JSON null for unused mutually exclusive parameters in renforge MCP tool schemas, including renforge_select_choice text/index arguments.

Bug Fixes:
- Prevent valid calls with explicit null values in inactive exclusive fields from being rejected by presence-based oneOf clauses.

Enhancements:
- Refactor exclusive input JSON Schemas to use generated branches with null-typed inactive fields instead of negative required constraints.
- Update renforge_select_choice server implementation and parameter descriptions to align with nullable exclusive text/index inputs.

Tests:
- Add JSON Schema regression tests ensuring null inactive fields are accepted and multiple active fields remain invalid.
- Add FastMCP integration tests verifying null exclusive arguments validate and reach tool implementations with the expected payloads.

</details>