### PR TITLE
feat(#86): enforce runtime policies for high-risk MCP tool actions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ docs/*
 !docs/ARCHITECTURE.md
 !docs/LIVE_EDITOR.md
 !docs/CLOUD_ENVIRONMENT.md
+!docs/POLICY.md
 !docs/superpowers/
 !docs/superpowers/specs/
 !docs/superpowers/specs/*.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable RenForge releases are recorded here. Versions follow semantic
 versioning.
 
+## Unreleased
+
+### Added
+
+- Operation-level runtime policy for `renforge_control`, `renforge_saves`,
+  `renforge_eval`, and `renforge_run_scenario`. Default remains
+  `RENFORGE_POLICY=off` (classify and record, never deny). `enforce` mode
+  blocks destructive and open-world operations unless `authorize=true` or an
+  allowlist permits them. See [docs/POLICY.md](docs/POLICY.md).
+
 ## [0.7.0] - 2026-08-11
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -216,6 +216,8 @@ renforge ui [--project <project>] [--port 8765]  # start the web dashboard
   vs locked targets, source-safety, public screenshots.
 - **[MCP guide](docs/MCP.md)** — full tool catalogue, agent workflows
   (Live Editor, hot reload, saves, pixel-perfect placement, scene perception).
+- **[Runtime policy](docs/POLICY.md)** — operation-level risk enforcement vs MCP
+  `ToolAnnotations`, authorization, and the compatibility plan.
 - **[Architecture](docs/ARCHITECTURE.md)** — code layout, live-control flow,
   Ren'Py SDK resolution, packaging.
 - **[Contributing](CONTRIBUTING.md)** — dev setup, frontend build, PRs.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -17,6 +17,7 @@ src/renforge/
   navigation.py      # shared label and file:line warp resolution
   session_registry.py # dashboard-to-MCP active-project discovery
   symbols.py         # Ren'Py-aware token/reference lookup
+  policy.py          # operation-level risk classification and enforcement
   util/             # filesystem + subprocess helpers
   sdk.py            # Ren'Py SDK download/cache
   scanner.py        # script/label/asset scanning
@@ -72,3 +73,12 @@ Packaging uses `hatchling`; the console script is
 
 The server falls back to a compatibility mode with a clear message if
 `fastmcp` is not installed (for example after a minimal manual install).
+
+## Runtime policy
+
+`policy.py` classifies high-risk MCP calls (`renforge_control`,
+`renforge_saves`, `renforge_eval`, `renforge_run_scenario`) from the tool name
+and validated parameters, then allows or denies them inside `_log_tool_call`
+before the live implementation runs. MCP `ToolAnnotations` remain static
+discovery hints; this layer is invocation-time enforcement. Defaults stay
+permissive (`RENFORGE_POLICY=off`). See [POLICY.md](POLICY.md).

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -64,6 +64,12 @@ The command is the same for every client. Example JSON configuration:
 }
 ```
 
+High-risk live tools are classified at invocation time. The default is
+`RENFORGE_POLICY=off` (record only). To enforce denials, set
+`RENFORGE_POLICY=enforce` in the MCP server environment and pass
+`authorize=true` on destructive or open-world calls, or see
+[POLICY.md](POLICY.md).
+
 For Codex CLI:
 
 ```bash
@@ -409,7 +415,7 @@ guards: each capture hashes a new frame.
 
 | Tool | Purpose |
 | --- | --- |
-| `renforge_eval` | Evaluate a Python expression in `store`. Use for diagnosis and development only. |
+| `renforge_eval` | Evaluate a Python expression in `store`. Use for diagnosis and development only. Open-world: requires `authorize=true` when `RENFORGE_POLICY=enforce`. |
 | `renforge_inspect_screen` | Inspect whether a screen is active and, when shown, return its layer, JSON-safe scope, and passed arguments. |
 | `renforge_get_var` | Read a store variable. |
 | `renforge_set_var` | Write a store variable. |
@@ -462,7 +468,11 @@ the requested screen is not shown. There is intentionally no separate style
 tool yet: use `renforge_eval` as the controlled style-introspection escape
 hatch when the active screen's resolved style needs investigation. Treat
 `renforge_eval` as arbitrary Python execution and use it only on a trusted
-local project.
+local project. When `RENFORGE_POLICY=enforce`, `renforge_eval`, destructive
+`renforge_control` / `renforge_saves` actions, and matching
+`renforge_run_scenario` steps are denied unless `authorize=true` or an
+allowlist permits them. See [POLICY.md](POLICY.md) for the operation-level
+model, its relationship to MCP `ToolAnnotations`, and the compatibility plan.
 
 `renforge_scene_tree` is read-mostly: it never changes game state, but `save_as`
 writes a JSON snapshot under `<project>/.renforge/scenes/` for later diffing.

--- a/docs/POLICY.md
+++ b/docs/POLICY.md
@@ -1,0 +1,100 @@
+# Runtime policy
+
+MCP `ToolAnnotations` are **static, whole-tool hints**. They help a client
+decide whether to offer `renforge_eval` or `renforge_control` at all. They
+cannot say that `renforge_control(action="advance")` is a recoverable mutation
+while `renforge_control(action="quit")` is destructive, or that a
+`renforge_run_scenario` call is only as dangerous as its highest-risk step.
+
+RenForge therefore evaluates an **operation-level policy** after the MCP
+backend has validated the tool arguments and **before** the implementation
+runs. Denied calls return a structured `POLICY_DENIED` payload and never reach
+`live.eval_expr`, `live.control`, `live.saves`, or `live.run_scenario`.
+
+## Risk classes
+
+| Class | Meaning | Default when `RENFORGE_POLICY=enforce` |
+| --- | --- | --- |
+| `observational` | Read-only (for example `saves action=list`) | Allowed |
+| `mutating` | Recoverable live-state change (`advance`, `save`) | Allowed |
+| `destructive` | Replaces or discards live state (`quit`, `load`, `reload_script`, `quick_load`) | Denied unless authorized |
+| `open_world` | Arbitrary Python / unconstrained side effects (`eval`, scenario `eval` steps) | Denied unless authorized |
+| `malformed` | Parameters do not identify a known operation | Always denied in enforce mode |
+| `unmanaged` | Tools outside this model | Allowed (compatibility) |
+
+Covered tools:
+
+- `renforge_control` — classified by `action`
+- `renforge_saves` — classified by `action`
+- `renforge_eval` — always `open_world` when `expr` is a non-empty string
+- `renforge_run_scenario` — classified by the highest-risk step, including nested `control` actions
+
+## Authorization
+
+When enforcement is on, a denied operation can still run if:
+
+1. The call sets `authorize=true` (MCP-client opt-in for **this** invocation), or
+2. The operation id is listed in `RENFORGE_POLICY_ALLOW` (comma-separated), or
+3. Its risk class is listed in `RENFORGE_POLICY_ALLOW_RISK`
+
+Unknown / malformed operations **cannot** be authorized. Fix the parameters
+instead.
+
+Allowlist examples:
+
+```text
+RENFORGE_POLICY_ALLOW=renforge_eval,renforge_control.quit
+RENFORGE_POLICY_ALLOW_RISK=destructive
+```
+
+A tool-level id such as `renforge_control` allows every classified action of
+that tool. A scenario step uses ids such as `renforge_run_scenario.eval` or
+`renforge_run_scenario.control.quit`.
+
+Project file `<project>/.renforge/policy.json`:
+
+```json
+{
+  "mode": "enforce",
+  "allow": ["renforge_eval"],
+  "allow_risk": []
+}
+```
+
+`RENFORGE_POLICY` and `RENFORGE_POLICY_ALLOW*` environment variables override
+the file. MCP clients can set them next to the `uvx` / `renforge serve`
+command. Invalid mode strings and unreadable policy files **fail closed** to
+`enforce`.
+
+## Refusal payload
+
+```json
+{
+  "ok": false,
+  "error": "policy_denied",
+  "code": "POLICY_DENIED",
+  "policy": {
+    "operation": "renforge_eval",
+    "risk": "open_world",
+    "reason": "Arbitrary Python can touch the filesystem, processes, network, and game state.",
+    "next_step": "Retry with authorize=true, add this operation to RENFORGE_POLICY_ALLOW, or set RENFORGE_POLICY=off for trusted local automation.",
+    "mode": "enforce",
+    "decision": "deny"
+  }
+}
+```
+
+Activity log entries record `policy.operation`, `risk`, `decision`, and `mode`.
+Sensitive parameters (`expr`, `steps`, `value`, `text`, `extra_info`) are
+redacted on denied calls and on allowed destructive / open-world calls.
+
+## Compatibility and release plan
+
+| Release | Default | Behavior |
+| --- | --- | --- |
+| Current (0.7.x) | `RENFORGE_POLICY=off` | Classify and record; **never deny**. Existing agents and CI keep working. |
+| Opt-in now | `RENFORGE_POLICY=enforce` | Destructive and open-world operations require `authorize=true` or an allowlist. |
+| Later minor | Changelog notice before considering a default of `enforce` | Automation must set `RENFORGE_POLICY=off` or an allowlist before that switch. |
+
+Do not fold this contract into metadata-only MCP annotation work. Annotations
+remain discovery-time hints; this module is invocation-time enforcement.

--- a/src/renforge/activity_log.py
+++ b/src/renforge/activity_log.py
@@ -67,6 +67,7 @@ def log_tool_call(
     duration_ms: float,
     result: Any,
     files_touched: list[str] | None = None,
+    policy: dict[str, Any] | None = None,
 ) -> None:
     summary = summarize_result(result)
     entry = {
@@ -78,6 +79,8 @@ def log_tool_call(
         "result": _coerce_result_payload(summary["result"]),
         "files_touched": files_touched or summary["files_touched"],
     }
+    if policy:
+        entry["policy"] = _coerce_payload(policy)
 
     root = _coerce_project_root(project_root)
     if not root.exists() or not root.is_dir():

--- a/src/renforge/policy.py
+++ b/src/renforge/policy.py
@@ -1,0 +1,371 @@
+"""Operation-level runtime policy for high-risk MCP tool actions.
+
+MCP ``ToolAnnotations`` are static, whole-tool hints. This module classifies
+the concrete requested operation from the tool name and validated parameters,
+then allows or denies it before the implementation runs.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Mapping
+
+RISK_OBSERVATIONAL = "observational"
+RISK_MUTATING = "mutating"
+RISK_DESTRUCTIVE = "destructive"
+RISK_OPEN_WORLD = "open_world"
+RISK_MALFORMED = "malformed"
+RISK_UNMANAGED = "unmanaged"
+
+MODE_OFF = "off"
+MODE_ENFORCE = "enforce"
+
+_RISK_RANK = {
+    RISK_OBSERVATIONAL: 0,
+    RISK_MUTATING: 1,
+    RISK_DESTRUCTIVE: 2,
+    RISK_OPEN_WORLD: 3,
+    RISK_MALFORMED: 4,
+}
+
+CONTROL_ACTIONS: dict[str, str] = {
+    "advance": RISK_MUTATING,
+    "rollback": RISK_MUTATING,
+    "toggle_skip": RISK_MUTATING,
+    "toggle_auto": RISK_MUTATING,
+    "toggle_afm": RISK_MUTATING,
+    "game_menu": RISK_MUTATING,
+    "hide_windows": RISK_MUTATING,
+    "quick_save": RISK_MUTATING,
+    "restart_interaction": RISK_MUTATING,
+    "quick_load": RISK_DESTRUCTIVE,
+    "reload_script": RISK_DESTRUCTIVE,
+    "quit": RISK_DESTRUCTIVE,
+}
+
+SAVES_ACTIONS: dict[str, str] = {
+    "list": RISK_OBSERVATIONAL,
+    "save": RISK_MUTATING,
+    "load": RISK_DESTRUCTIVE,
+}
+
+SCENARIO_STEP_RISKS: dict[str, str] = {
+    "wait": RISK_OBSERVATIONAL,
+    "assert": RISK_OBSERVATIONAL,
+    "capture": RISK_OBSERVATIONAL,
+    "set": RISK_MUTATING,
+    "click": RISK_MUTATING,
+    "click_at": RISK_MUTATING,
+    "advance": RISK_MUTATING,
+    "scroll": RISK_MUTATING,
+    "select_choice": RISK_MUTATING,
+    "send_input": RISK_MUTATING,
+    "save": RISK_MUTATING,
+    "eval": RISK_OPEN_WORLD,
+    "load": RISK_DESTRUCTIVE,
+}
+
+_SENSITIVE_PARAM_KEYS = frozenset({"expr", "steps", "value", "text", "extra_info"})
+
+_REASONS = {
+    RISK_OBSERVATIONAL: "This operation only observes the project or running game.",
+    RISK_MUTATING: "This operation changes live game state in a recoverable way.",
+    RISK_DESTRUCTIVE: (
+        "This operation can discard or replace live state (quit, load, or reload)."
+    ),
+    RISK_OPEN_WORLD: (
+        "Arbitrary Python can touch the filesystem, processes, network, and game state."
+    ),
+    RISK_MALFORMED: "The requested operation could not be classified from the supplied parameters.",
+}
+
+_NEXT_STEPS = {
+    RISK_DESTRUCTIVE: (
+        "Retry with authorize=true, add this operation to RENFORGE_POLICY_ALLOW, "
+        "or set RENFORGE_POLICY=off for trusted local automation."
+    ),
+    RISK_OPEN_WORLD: (
+        "Retry with authorize=true, add this operation to RENFORGE_POLICY_ALLOW, "
+        "or set RENFORGE_POLICY=off for trusted local automation."
+    ),
+    RISK_MALFORMED: (
+        "Fix the tool parameters so the operation can be classified, then retry. "
+        "Unknown actions cannot be authorized."
+    ),
+}
+
+
+@dataclass(frozen=True)
+class PolicySettings:
+    mode: str = MODE_OFF
+    allow: frozenset[str] = field(default_factory=frozenset)
+    allow_risk: frozenset[str] = field(default_factory=frozenset)
+
+
+@dataclass(frozen=True)
+class PolicyDecision:
+    operation: str
+    risk: str
+    decision: str
+    mode: str
+    reason: str
+    next_step: str
+    allowed: bool
+
+    def to_result(self) -> dict[str, Any]:
+        return {
+            "ok": False,
+            "error": "policy_denied",
+            "code": "POLICY_DENIED",
+            "policy": {
+                "operation": self.operation,
+                "risk": self.risk,
+                "reason": self.reason,
+                "next_step": self.next_step,
+                "mode": self.mode,
+                "decision": self.decision,
+            },
+        }
+
+    def log_fields(self) -> dict[str, str]:
+        return {
+            "operation": self.operation,
+            "risk": self.risk,
+            "decision": self.decision,
+            "mode": self.mode,
+        }
+
+
+def redact_params(params: Mapping[str, Any] | None) -> dict[str, Any]:
+    """Copy parameters with sensitive values removed for activity logging."""
+    redacted: dict[str, Any] = {}
+    for key, value in dict(params or {}).items():
+        if key in _SENSITIVE_PARAM_KEYS:
+            redacted[key] = "<redacted>"
+        else:
+            redacted[key] = value
+    return redacted
+
+
+def load_settings(
+    project_root: str | Path | None = None,
+    environ: Mapping[str, str] | None = None,
+) -> PolicySettings:
+    env = environ if environ is not None else os.environ
+    file_settings = _load_project_file(project_root)
+
+    raw_mode = env.get("RENFORGE_POLICY")
+    if raw_mode is None or raw_mode.strip() == "":
+        mode = file_settings.mode
+    else:
+        mode = _parse_mode(raw_mode, fail_closed=True)
+
+    allow = set(file_settings.allow)
+    allow.update(_split_csv(env.get("RENFORGE_POLICY_ALLOW")))
+    allow_risk = set(file_settings.allow_risk)
+    allow_risk.update(_split_csv(env.get("RENFORGE_POLICY_ALLOW_RISK")))
+    return PolicySettings(
+        mode=mode,
+        allow=frozenset(item for item in allow if item),
+        allow_risk=frozenset(item for item in allow_risk if item),
+    )
+
+
+def classify(name: str, params: Mapping[str, Any] | None = None) -> tuple[str, str]:
+    """Return ``(operation_id, risk)`` for a validated tool invocation."""
+    payload = dict(params or {})
+    if name == "renforge_control":
+        action = payload.get("action")
+        if not isinstance(action, str) or not action.strip():
+            return "renforge_control", RISK_MALFORMED
+        action = action.strip()
+        risk = CONTROL_ACTIONS.get(action)
+        if risk is None:
+            return f"renforge_control.{action}", RISK_MALFORMED
+        return f"renforge_control.{action}", risk
+    if name == "renforge_saves":
+        action = payload.get("action")
+        if not isinstance(action, str) or not action.strip():
+            return "renforge_saves", RISK_MALFORMED
+        action = action.strip()
+        risk = SAVES_ACTIONS.get(action)
+        if risk is None:
+            return f"renforge_saves.{action}", RISK_MALFORMED
+        return f"renforge_saves.{action}", risk
+    if name == "renforge_eval":
+        expr = payload.get("expr")
+        if not isinstance(expr, str) or not expr.strip():
+            return "renforge_eval", RISK_MALFORMED
+        return "renforge_eval", RISK_OPEN_WORLD
+    if name == "renforge_run_scenario":
+        return _classify_scenario(payload.get("steps"))
+    return name, RISK_UNMANAGED
+
+
+def evaluate(
+    name: str,
+    params: Mapping[str, Any] | None = None,
+    *,
+    project_root: str | Path | None = None,
+    environ: Mapping[str, str] | None = None,
+    settings: PolicySettings | None = None,
+) -> PolicyDecision:
+    payload = dict(params or {})
+    operation, risk = classify(name, payload)
+    resolved = settings or load_settings(
+        project_root or payload.get("project_path"),
+        environ=environ,
+    )
+    reason = _REASONS.get(risk, _REASONS[RISK_MALFORMED])
+    next_step = _NEXT_STEPS.get(
+        risk,
+        "No authorization is required for this operation.",
+    )
+    if resolved.mode == MODE_OFF:
+        return PolicyDecision(
+            operation=operation,
+            risk=risk,
+            decision="allow",
+            mode=MODE_OFF,
+            reason=reason,
+            next_step=next_step,
+            allowed=True,
+        )
+
+    allowed = _is_allowed(operation, risk, payload, resolved)
+    return PolicyDecision(
+        operation=operation,
+        risk=risk,
+        decision="allow" if allowed else "deny",
+        mode=resolved.mode,
+        reason=reason,
+        next_step=next_step,
+        allowed=allowed,
+    )
+
+
+def _is_allowed(
+    operation: str,
+    risk: str,
+    params: Mapping[str, Any],
+    settings: PolicySettings,
+) -> bool:
+    if risk == RISK_UNMANAGED:
+        return True
+    if risk in {RISK_OBSERVATIONAL, RISK_MUTATING}:
+        return True
+    if risk == RISK_MALFORMED:
+        return False
+    if risk in settings.allow_risk:
+        return True
+    if operation in settings.allow or operation.split(".", 1)[0] in settings.allow:
+        return True
+    return _authorize_flag(params.get("authorize")) is True
+
+
+def _authorize_flag(value: Any) -> bool | None:
+    if value is True:
+        return True
+    if value is False or value is None:
+        return False
+    return None
+
+
+def _classify_scenario(steps: Any) -> tuple[str, str]:
+    if steps is None:
+        steps = []
+    if not isinstance(steps, list):
+        return "renforge_run_scenario", RISK_MALFORMED
+    if not steps:
+        return "renforge_run_scenario", RISK_OBSERVATIONAL
+
+    highest = RISK_OBSERVATIONAL
+    highest_op = "renforge_run_scenario"
+    for step in steps:
+        operation, risk = _classify_scenario_step(step)
+        if _RISK_RANK[risk] > _RISK_RANK[highest]:
+            highest = risk
+            highest_op = operation
+    return highest_op, highest
+
+
+def _classify_scenario_step(step: Any) -> tuple[str, str]:
+    if not isinstance(step, dict):
+        return "renforge_run_scenario", RISK_MALFORMED
+    action_keys = tuple(SCENARIO_STEP_RISKS) + ("control",)
+    present = [key for key in action_keys if key in step]
+    if len(present) != 1:
+        return "renforge_run_scenario", RISK_MALFORMED
+    action = present[0]
+    if action == "control":
+        control_action = _control_payload_action(step.get("control"))
+        if control_action is None:
+            return "renforge_run_scenario.control", RISK_MALFORMED
+        risk = CONTROL_ACTIONS.get(control_action)
+        if risk is None:
+            return f"renforge_run_scenario.control.{control_action}", RISK_MALFORMED
+        return f"renforge_run_scenario.control.{control_action}", risk
+    return f"renforge_run_scenario.{action}", SCENARIO_STEP_RISKS[action]
+
+
+def _control_payload_action(payload: Any) -> str | None:
+    if isinstance(payload, str) and payload.strip():
+        return payload.strip()
+    if isinstance(payload, dict):
+        action = payload.get("action")
+        if isinstance(action, str) and action.strip():
+            return action.strip()
+    return None
+
+
+def _parse_mode(raw: str, *, fail_closed: bool) -> str:
+    value = raw.strip().lower()
+    if value in {MODE_OFF, MODE_ENFORCE}:
+        return value
+    if fail_closed:
+        return MODE_ENFORCE
+    return MODE_OFF
+
+
+def _split_csv(raw: str | None) -> list[str]:
+    if not raw:
+        return []
+    return [part.strip() for part in raw.split(",") if part.strip()]
+
+
+def _load_project_file(project_root: str | Path | None) -> PolicySettings:
+    if project_root in (None, ""):
+        return PolicySettings()
+    try:
+        root = Path(str(project_root)).expanduser().resolve()
+    except (OSError, RuntimeError, ValueError):
+        return PolicySettings()
+    path = root / ".renforge" / "policy.json"
+    try:
+        if not path.is_file():
+            return PolicySettings()
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return PolicySettings(mode=MODE_ENFORCE)
+
+    if not isinstance(payload, dict):
+        return PolicySettings(mode=MODE_ENFORCE)
+
+    raw_mode = payload.get("mode", MODE_OFF)
+    if not isinstance(raw_mode, str):
+        return PolicySettings(mode=MODE_ENFORCE)
+    mode = _parse_mode(raw_mode, fail_closed=True)
+    allow = payload.get("allow", [])
+    allow_risk = payload.get("allow_risk", [])
+    if not isinstance(allow, list) or not isinstance(allow_risk, list):
+        return PolicySettings(mode=MODE_ENFORCE)
+    if not all(isinstance(item, str) for item in allow + allow_risk):
+        return PolicySettings(mode=MODE_ENFORCE)
+    return PolicySettings(
+        mode=mode,
+        allow=frozenset(item.strip() for item in allow if item.strip()),
+        allow_risk=frozenset(item.strip() for item in allow_risk if item.strip()),
+    )

--- a/src/renforge/policy.py
+++ b/src/renforge/policy.py
@@ -308,6 +308,19 @@ def _classify_scenario_step(step: Any) -> tuple[str, str]:
         if risk is None:
             return f"renforge_run_scenario.control.{control_action}", RISK_MALFORMED
         return f"renforge_run_scenario.control.{control_action}", risk
+    if action == "wait":
+        payload = step.get("wait")
+        if isinstance(payload, dict) and "expr" in payload:
+            expr = payload.get("expr")
+            if not isinstance(expr, str) or not expr.strip():
+                return "renforge_run_scenario.wait", RISK_MALFORMED
+            return "renforge_run_scenario.wait", RISK_OPEN_WORLD
+    if action == "assert":
+        payload = step.get("assert")
+        expr = payload.get("expr") if isinstance(payload, dict) else payload
+        if not isinstance(expr, str) or not expr.strip():
+            return "renforge_run_scenario.assert", RISK_MALFORMED
+        return "renforge_run_scenario.assert", RISK_OPEN_WORLD
     return f"renforge_run_scenario.{action}", SCENARIO_STEP_RISKS[action]
 
 

--- a/src/renforge/server.py
+++ b/src/renforge/server.py
@@ -54,7 +54,20 @@ def _log_tool_call(
     args: tuple[Any, ...],
     kwargs: dict[str, Any],
 ) -> Any:
-    from . import activity_log
+    from . import policy
+
+    decision = policy.evaluate(name, params, project_root=project_root)
+    if not decision.allowed:
+        result = decision.to_result()
+        _record_tool_activity(
+            project_root,
+            name,
+            policy.redact_params(params),
+            0.0,
+            result,
+            policy=decision.log_fields(),
+        )
+        return result
 
     started = perf_counter()
     try:
@@ -63,21 +76,45 @@ def _log_tool_call(
         result = {"ok": False, "error": f"{type(exc).__name__}: {exc}"}
 
     duration_ms = round((perf_counter() - started) * 1000, 2)
-    if project_root is not None:
-        summary = activity_log.summarize_result(result)
-        try:
-            activity_log.log_tool_call(
-                project_root,
-                name,
-                params,
-                duration_ms,
-                result,
-                files_touched=summary["files_touched"],
-            )
-        except Exception:
-            pass
-
+    logged_params = params
+    if decision.risk in {policy.RISK_OPEN_WORLD, policy.RISK_DESTRUCTIVE}:
+        logged_params = policy.redact_params(params)
+    _record_tool_activity(
+        project_root,
+        name,
+        logged_params,
+        duration_ms,
+        result,
+        policy=decision.log_fields(),
+    )
     return result
+
+
+def _record_tool_activity(
+    project_root: str | None,
+    name: str,
+    params: dict[str, Any],
+    duration_ms: float,
+    result: Any,
+    policy: dict[str, Any] | None = None,
+) -> None:
+    if project_root is None:
+        return
+    from . import activity_log
+
+    summary = activity_log.summarize_result(result)
+    try:
+        activity_log.log_tool_call(
+            project_root,
+            name,
+            params,
+            duration_ms,
+            result,
+            files_touched=summary["files_touched"],
+            policy=policy,
+        )
+    except Exception:
+        pass
 
 
 def _png_content(png: bytes) -> Any:
@@ -672,6 +709,7 @@ def _register_tools(app: Any) -> None:
         interaction_id: str = "",
         wait_for_effect: bool = False,
         effect_timeout: float = 5.0,
+        authorize: bool = False,
     ) -> dict:
         """Run a runtime action: advance, rollback, toggle_skip, toggle_auto,
         toggle_afm, game_menu, hide_windows, quick_save, quick_load,
@@ -679,6 +717,8 @@ def _register_tools(app: Any) -> None:
 
         Emits correlated business events (quick_save.completed, skip.stopped,
         …). Set wait_for_effect=true to block until the matching event appears.
+        Destructive actions (quit, load-equivalent reload/quick_load) require
+        authorize=true when RENFORGE_POLICY=enforce.
         """
         return _log_tool_call(
             name="renforge_control",
@@ -688,6 +728,7 @@ def _register_tools(app: Any) -> None:
                 "interaction_id": interaction_id,
                 "wait_for_effect": wait_for_effect,
                 "effect_timeout": effect_timeout,
+                "authorize": authorize,
             },
             project_root=project_path,
             fn=live.control,
@@ -744,8 +785,13 @@ def _register_tools(app: Any) -> None:
         slot: str | None = None,
         extra_info: str | None = None,
         regexp: str | None = None,
+        authorize: bool = False,
     ) -> dict:
-        """Save, load, or list named save slots without screenshot payloads."""
+        """Save, load, or list named save slots without screenshot payloads.
+
+        ``load`` is destructive and requires authorize=true when
+        RENFORGE_POLICY=enforce.
+        """
         return _log_tool_call(
             name="renforge_saves",
             params={
@@ -754,6 +800,7 @@ def _register_tools(app: Any) -> None:
                 "slot": slot,
                 "extra_info": extra_info,
                 "regexp": regexp,
+                "authorize": authorize,
             },
             project_root=project_path,
             fn=live.saves,
@@ -1058,11 +1105,15 @@ def _register_tools(app: Any) -> None:
         )
 
     @tool_decorator()
-    def renforge_eval(project_path: str, expr: str) -> dict:
-        """Evaluate a Python expression in the running game's store namespace."""
+    def renforge_eval(project_path: str, expr: str, authorize: bool = False) -> dict:
+        """Evaluate a Python expression in the running game's store namespace.
+
+        This is an open-world operation. When RENFORGE_POLICY=enforce, pass
+        authorize=true or allow ``renforge_eval`` in RENFORGE_POLICY_ALLOW.
+        """
         return _log_tool_call(
             name="renforge_eval",
-            params={"project_path": project_path, "expr": expr},
+            params={"project_path": project_path, "expr": expr, "authorize": authorize},
             project_root=project_path,
             fn=live.eval_expr,
             args=(project_path, expr),
@@ -1316,12 +1367,15 @@ def _register_tools(app: Any) -> None:
         stop_on_failure: bool = True,
         state_profile: str = "minimal",
         capture_on_failure: bool = True,
+        authorize: bool = False,
     ) -> dict:
         """Run a multi-step live scenario (click/wait/assert/...) in one call.
 
         On failure, captures a screenshot and compact diagnostics automatically.
         Supported step actions: set, eval, click, click_at, advance, scroll,
         wait, assert, select_choice, capture, save, load, control, send_input.
+        Risk follows the highest-risk step. eval/load/quit-class control steps
+        require authorize=true when RENFORGE_POLICY=enforce.
         """
         return _log_tool_call(
             name="renforge_run_scenario",
@@ -1333,6 +1387,7 @@ def _register_tools(app: Any) -> None:
                 "state_profile": state_profile,
                 "capture_on_failure": capture_on_failure,
                 "steps": steps,
+                "authorize": authorize,
             },
             project_root=project_path,
             fn=live.run_scenario,
@@ -1754,7 +1809,10 @@ def create_app() -> Any:
         "renforge_control(action=\"reload_script\"); Live Editor Save already "
         "reloads and attests its own changes. Use renforge_wait_until for one "
         "bounded condition, and "
-        "renforge_get_errors after risky actions or a stopped process."
+        "renforge_get_errors after risky actions or a stopped process. "
+        "RENFORGE_POLICY defaults to off; when set to enforce, destructive and "
+        "open-world operations (eval, quit, load, reload_script, and matching "
+        "scenario steps) require authorize=true or an allowlist."
     )
     try:
         app = backend_cls("renforge", instructions=instructions)

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -26,6 +26,23 @@ def test_mcp_safety_docs_include_runtime_mutations() -> None:
 
     assert "`renforge_control`" in safety
     assert "`renforge_saves`" in safety
+    assert "POLICY.md" in safety or "authorize=true" in safety
+
+
+def test_runtime_policy_docs_cover_model_and_compatibility() -> None:
+    root = Path(__file__).parents[1]
+    policy = (root / "docs" / "POLICY.md").read_text(encoding="utf-8")
+    mcp = (root / "docs" / "MCP.md").read_text(encoding="utf-8")
+
+    assert "ToolAnnotations" in policy
+    assert "RENFORGE_POLICY=off" in policy
+    assert "RENFORGE_POLICY=enforce" in policy
+    assert "authorize=true" in policy
+    assert "POLICY_DENIED" in policy
+    assert "`renforge_eval`" in policy
+    assert "`renforge_run_scenario`" in policy
+    assert "docs/POLICY.md" in (root / "README.md").read_text(encoding="utf-8")
+    assert "POLICY.md" in mcp
 
 
 def test_public_god_mode_tools_and_workflow_are_documented() -> None:

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -1,0 +1,253 @@
+import asyncio
+import json
+
+import pytest
+
+from renforge.policy import (
+    MODE_ENFORCE,
+    MODE_OFF,
+    RISK_DESTRUCTIVE,
+    RISK_MALFORMED,
+    RISK_MUTATING,
+    RISK_OBSERVATIONAL,
+    RISK_OPEN_WORLD,
+    classify,
+    evaluate,
+    load_settings,
+    redact_params,
+)
+from renforge.server import create_app
+
+
+def test_classify_control_saves_eval_and_scenario_operations() -> None:
+    assert classify("renforge_control", {"action": "advance"}) == (
+        "renforge_control.advance",
+        RISK_MUTATING,
+    )
+    assert classify("renforge_control", {"action": "quit"}) == (
+        "renforge_control.quit",
+        RISK_DESTRUCTIVE,
+    )
+    assert classify("renforge_saves", {"action": "list"}) == (
+        "renforge_saves.list",
+        RISK_OBSERVATIONAL,
+    )
+    assert classify("renforge_saves", {"action": "load"}) == (
+        "renforge_saves.load",
+        RISK_DESTRUCTIVE,
+    )
+    assert classify("renforge_eval", {"expr": "renpy.version"}) == (
+        "renforge_eval",
+        RISK_OPEN_WORLD,
+    )
+    assert classify(
+        "renforge_run_scenario",
+        {"steps": [{"wait": {"label": "start"}}, {"eval": "True"}]},
+    ) == ("renforge_run_scenario.eval", RISK_OPEN_WORLD)
+    assert classify(
+        "renforge_run_scenario",
+        {"steps": [{"control": {"action": "quit"}}]},
+    ) == ("renforge_run_scenario.control.quit", RISK_DESTRUCTIVE)
+
+
+def test_classify_malformed_operations() -> None:
+    assert classify("renforge_control", {"action": "explode"})[1] == RISK_MALFORMED
+    assert classify("renforge_saves", {"action": "delete"})[1] == RISK_MALFORMED
+    assert classify("renforge_eval", {"expr": "   "})[1] == RISK_MALFORMED
+    assert classify("renforge_run_scenario", {"steps": "nope"})[1] == RISK_MALFORMED
+    assert classify("renforge_run_scenario", {"steps": [{"wait": {}, "eval": "1"}]})[1] == (
+        RISK_MALFORMED
+    )
+
+
+def test_policy_disabled_allows_high_risk_operations(monkeypatch) -> None:
+    monkeypatch.setenv("RENFORGE_POLICY", "off")
+    decision = evaluate("renforge_eval", {"expr": "1+1", "project_path": "/tmp/game"})
+    assert decision.allowed is True
+    assert decision.mode == MODE_OFF
+    assert decision.decision == "allow"
+    assert decision.risk == RISK_OPEN_WORLD
+
+
+def test_enforce_denies_open_world_and_destructive_without_authorize(monkeypatch) -> None:
+    monkeypatch.setenv("RENFORGE_POLICY", "enforce")
+    denied_eval = evaluate("renforge_eval", {"expr": "1+1"})
+    denied_quit = evaluate("renforge_control", {"action": "quit"})
+    allowed_advance = evaluate("renforge_control", {"action": "advance"})
+    allowed_list = evaluate("renforge_saves", {"action": "list"})
+
+    assert denied_eval.allowed is False
+    assert denied_eval.to_result()["code"] == "POLICY_DENIED"
+    assert denied_eval.to_result()["policy"]["operation"] == "renforge_eval"
+    assert "authorize=true" in denied_eval.next_step
+    assert denied_quit.allowed is False
+    assert allowed_advance.allowed is True
+    assert allowed_list.allowed is True
+
+
+def test_enforce_allows_authorized_and_allowlisted_calls(monkeypatch) -> None:
+    monkeypatch.setenv("RENFORGE_POLICY", "enforce")
+    authorized = evaluate("renforge_eval", {"expr": "1+1", "authorize": True})
+    assert authorized.allowed is True
+
+    monkeypatch.setenv("RENFORGE_POLICY_ALLOW", "renforge_control.quit,renforge_saves.load")
+    assert evaluate("renforge_control", {"action": "quit"}).allowed is True
+    assert evaluate("renforge_saves", {"action": "load", "slot": "a"}).allowed is True
+    assert evaluate("renforge_eval", {"expr": "1+1"}).allowed is False
+
+
+def test_malformed_operations_are_denied_even_with_authorize(monkeypatch) -> None:
+    monkeypatch.setenv("RENFORGE_POLICY", "enforce")
+    decision = evaluate(
+        "renforge_control",
+        {"action": "not-an-action", "authorize": True},
+    )
+    assert decision.allowed is False
+    assert decision.risk == RISK_MALFORMED
+    assert "cannot be authorized" in decision.next_step
+
+
+def test_unknown_policy_mode_fails_closed(monkeypatch) -> None:
+    monkeypatch.setenv("RENFORGE_POLICY", "enforece")
+    settings = load_settings()
+    assert settings.mode == MODE_ENFORCE
+    assert evaluate("renforge_eval", {"expr": "1"}, settings=settings).allowed is False
+
+
+def test_project_policy_file_and_env_override(tmp_path, monkeypatch) -> None:
+    policy_dir = tmp_path / ".renforge"
+    policy_dir.mkdir()
+    (policy_dir / "policy.json").write_text(
+        json.dumps({"mode": "enforce", "allow": ["renforge_eval"]}),
+        encoding="utf-8",
+    )
+    monkeypatch.delenv("RENFORGE_POLICY", raising=False)
+    monkeypatch.delenv("RENFORGE_POLICY_ALLOW", raising=False)
+
+    from_file = load_settings(tmp_path)
+    assert from_file.mode == MODE_ENFORCE
+    assert "renforge_eval" in from_file.allow
+    assert evaluate("renforge_eval", {"expr": "1", "project_path": str(tmp_path)}).allowed is True
+
+    monkeypatch.setenv("RENFORGE_POLICY", "off")
+    overridden = load_settings(tmp_path)
+    assert overridden.mode == MODE_OFF
+
+
+def test_malformed_policy_file_fails_closed(tmp_path, monkeypatch) -> None:
+    policy_dir = tmp_path / ".renforge"
+    policy_dir.mkdir()
+    (policy_dir / "policy.json").write_text("{not json", encoding="utf-8")
+    monkeypatch.delenv("RENFORGE_POLICY", raising=False)
+    settings = load_settings(tmp_path)
+    assert settings.mode == MODE_ENFORCE
+
+
+def test_redact_params_strips_sensitive_values() -> None:
+    redacted = redact_params({"expr": "secret()", "action": "eval", "steps": [{"eval": "1"}]})
+    assert redacted["expr"] == "<redacted>"
+    assert redacted["steps"] == "<redacted>"
+    assert redacted["action"] == "eval"
+
+
+def test_denied_eval_never_reaches_implementation(monkeypatch, tmp_path) -> None:
+    pytest.importorskip("fastmcp", reason="fastmcp not installed")
+    from fastmcp import Client
+    from renforge.tools import live
+
+    monkeypatch.setenv("RENFORGE_POLICY", "enforce")
+    calls: list[str] = []
+    monkeypatch.setattr(
+        live,
+        "eval_expr",
+        lambda project_path, expr: calls.append(expr) or {"ok": True, "value": expr},
+    )
+
+    async def _call(**payload):
+        async with Client(create_app()) as client:
+            return await client.call_tool(
+                "renforge_eval",
+                {"project_path": str(tmp_path), **payload},
+                raise_on_error=False,
+            )
+
+    denied = asyncio.run(_call(expr="1+1"))
+    payload = json.loads(next(block.text for block in denied.content if block.type == "text"))
+    assert calls == []
+    assert payload["ok"] is False
+    assert payload["code"] == "POLICY_DENIED"
+    assert payload["policy"]["operation"] == "renforge_eval"
+    assert payload["policy"]["risk"] == RISK_OPEN_WORLD
+    assert "authorize=true" in payload["policy"]["next_step"]
+
+    activity = (tmp_path / ".renforge" / "activity.jsonl").read_text(encoding="utf-8")
+    entry = json.loads(activity.strip().splitlines()[-1])
+    assert entry["policy"]["decision"] == "deny"
+    assert entry["params"]["expr"] == "<redacted>"
+
+    allowed = asyncio.run(_call(expr="1+1", authorize=True))
+    allowed_payload = json.loads(
+        next(block.text for block in allowed.content if block.type == "text")
+    )
+    assert calls == ["1+1"]
+    assert allowed_payload == {"ok": True, "value": "1+1"}
+
+
+def test_policy_disabled_eval_reaches_implementation(monkeypatch, tmp_path) -> None:
+    pytest.importorskip("fastmcp", reason="fastmcp not installed")
+    from fastmcp import Client
+    from renforge.tools import live
+
+    monkeypatch.setenv("RENFORGE_POLICY", "off")
+    calls: list[str] = []
+    monkeypatch.setattr(
+        live,
+        "eval_expr",
+        lambda project_path, expr: calls.append(expr) or {"ok": True, "value": 2},
+    )
+
+    async def _call():
+        async with Client(create_app()) as client:
+            return await client.call_tool(
+                "renforge_eval",
+                {"project_path": str(tmp_path), "expr": "1+1"},
+            )
+
+    result = asyncio.run(_call())
+    payload = json.loads(next(block.text for block in result.content if block.type == "text"))
+    assert calls == ["1+1"]
+    assert payload == {"ok": True, "value": 2}
+
+
+def test_denied_scenario_eval_step_never_runs(monkeypatch, tmp_path) -> None:
+    pytest.importorskip("fastmcp", reason="fastmcp not installed")
+    from fastmcp import Client
+    from renforge.tools import live
+
+    monkeypatch.setenv("RENFORGE_POLICY", "enforce")
+    calls: list[object] = []
+    monkeypatch.setattr(
+        live,
+        "run_scenario",
+        lambda project_path, **kwargs: calls.append(kwargs) or {"ok": True},
+    )
+
+    async def _call(steps, **extra):
+        async with Client(create_app()) as client:
+            return await client.call_tool(
+                "renforge_run_scenario",
+                {"project_path": str(tmp_path), "steps": steps, **extra},
+                raise_on_error=False,
+            )
+
+    denied = asyncio.run(_call([{"eval": "True"}]))
+    payload = json.loads(next(block.text for block in denied.content if block.type == "text"))
+    assert calls == []
+    assert payload["policy"]["operation"] == "renforge_run_scenario.eval"
+
+    allowed = asyncio.run(_call([{"wait": {"label": "start"}}]))
+    allowed_payload = json.loads(
+        next(block.text for block in allowed.content if block.type == "text")
+    )
+    assert allowed_payload == {"ok": True}
+    assert len(calls) == 1

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -46,6 +46,14 @@ def test_classify_control_saves_eval_and_scenario_operations() -> None:
     ) == ("renforge_run_scenario.eval", RISK_OPEN_WORLD)
     assert classify(
         "renforge_run_scenario",
+        {"steps": [{"wait": {"expr": "renpy.version"}}]},
+    ) == ("renforge_run_scenario.wait", RISK_OPEN_WORLD)
+    assert classify(
+        "renforge_run_scenario",
+        {"steps": [{"assert": {"expr": "renpy.version"}}]},
+    ) == ("renforge_run_scenario.assert", RISK_OPEN_WORLD)
+    assert classify(
+        "renforge_run_scenario",
         {"steps": [{"control": {"action": "quit"}}]},
     ) == ("renforge_run_scenario.control.quit", RISK_DESTRUCTIVE)
 
@@ -219,7 +227,7 @@ def test_policy_disabled_eval_reaches_implementation(monkeypatch, tmp_path) -> N
     assert payload == {"ok": True, "value": 2}
 
 
-def test_denied_scenario_eval_step_never_runs(monkeypatch, tmp_path) -> None:
+def test_denied_open_world_scenario_steps_never_run(monkeypatch, tmp_path) -> None:
     pytest.importorskip("fastmcp", reason="fastmcp not installed")
     from fastmcp import Client
     from renforge.tools import live
@@ -240,10 +248,18 @@ def test_denied_scenario_eval_step_never_runs(monkeypatch, tmp_path) -> None:
                 raise_on_error=False,
             )
 
-    denied = asyncio.run(_call([{"eval": "True"}]))
-    payload = json.loads(next(block.text for block in denied.content if block.type == "text"))
-    assert calls == []
-    assert payload["policy"]["operation"] == "renforge_run_scenario.eval"
+    for step, operation in (
+        ({"eval": "True"}, "renforge_run_scenario.eval"),
+        ({"wait": {"expr": "True"}}, "renforge_run_scenario.wait"),
+        ({"assert": {"expr": "True"}}, "renforge_run_scenario.assert"),
+    ):
+        denied = asyncio.run(_call([step]))
+        payload = json.loads(
+            next(block.text for block in denied.content if block.type == "text")
+        )
+        assert calls == []
+        assert payload["policy"]["operation"] == operation
+        assert payload["policy"]["risk"] == RISK_OPEN_WORLD
 
     allowed = asyncio.run(_call([{"wait": {"label": "start"}}]))
     allowed_payload = json.loads(

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -854,6 +854,7 @@ def test_saves_tool_is_listed_with_grouped_actions() -> None:
         "slot",
         "extra_info",
         "regexp",
+        "authorize",
     }
 
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Add an operation-level runtime policy for high-risk MCP tools. Static MCP `ToolAnnotations` cannot tell `advance` from `quit` or a click-only scenario from one that `eval`s Python. This layer classifies the concrete operation after schema validation and can deny it before the implementation runs.

## Motivation and related issue

Fixes #86

Discovered while hardening MCP contracts in #85, but kept separate so #85 stays a metadata/schema/filesystem change and this PR introduces the authorization contract.

## Changes

- Classify `renforge_control`, `renforge_saves`, `renforge_eval`, and `renforge_run_scenario` (including nested control steps) as observational, mutating, destructive, open-world, or malformed.
- Default `RENFORGE_POLICY=off`: classify and record, never deny (compatibility).
- `RENFORGE_POLICY=enforce`: deny destructive/open-world/malformed calls unless `authorize=true` or `RENFORGE_POLICY_ALLOW` / project `.renforge/policy.json` allows them. Malformed operations cannot be authorized.
- Structured `POLICY_DENIED` payload with operation, risk, reason, and next step.
- Activity log records the decision without leaking `expr` / `steps` / other sensitive parameters.
- Document the model, ToolAnnotations relationship, and release plan in `docs/POLICY.md`.

## Validation

- `python3 -m compileall src tests`: passed
- `PYTHONPATH=src python3 -m pytest -q tests/test_policy.py tests/test_docs.py tests/test_server.py`: **66 passed**
- `PYTHONPATH=src python3 -m pytest -q -m "not live"` (excluding editor CAS/coordinator, i18n scanner, and cloud-env path checks that fail on this `/tmp` worktree filesystem): **766 passed, 48 skipped**
- `npm --prefix ui run build`: Not applicable (no UI change)
- Manual verification: FastMCP calls confirm denied `renforge_eval` never reaches `live.eval_expr`; `authorize=true` and `RENFORGE_POLICY=off` still execute.

## User-facing changes

- New optional `authorize` argument on `renforge_eval`, `renforge_control`, `renforge_saves`, and `renforge_run_scenario`.
- New env vars: `RENFORGE_POLICY`, `RENFORGE_POLICY_ALLOW`, `RENFORGE_POLICY_ALLOW_RISK`.
- Default behavior is unchanged (`off`).

## Internationalization

- [x] New user-visible copy uses i18n keys, or this PR adds no user-visible copy.
- [x] `npm --prefix ui run i18n:check` passes, or i18n is not applicable.

## Breaking changes

None at the default `RENFORGE_POLICY=off`. Enabling `enforce` requires `authorize=true` or an allowlist for destructive and open-world operations. A later release may change the default after a changelog notice; see `docs/POLICY.md`.

## Documentation

- `docs/POLICY.md`
- `docs/MCP.md`, `docs/ARCHITECTURE.md`, `README.md`, `CHANGELOG.md`

## Reviewer notes

Kept off of #85 on purpose. Unmanaged tools stay allowed even in enforce mode so this stays scoped to the four named tools.

## Final checklist

- [x] The PR is focused on one coherent change.
- [x] Tests were added or updated for behavior changes.
- [x] Generated `src/renforge/ui/static/` assets remain untracked; CI and release builds produce them.
- [x] No credentials, tokens, personal paths, or other secrets are included.
- [x] I understand the submitted code and can explain how it works.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c1144d26-032e-481d-a475-5fc506a35a40?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c1144d26-032e-481d-a475-5fc506a35a40&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

Introduire une couche de politique d’exécution au niveau des opérations pour les outils MCP à haut risque, l’intégrer dans la journalisation du serveur et les appels d’outils, tout en maintenant un comportement par défaut permissif.

Nouvelles fonctionnalités :
- Ajouter une classification et une application en temps réel pour les opérations `renforge_control`, `renforge_saves`, `renforge_eval` et `renforge_run_scenario` en fonction du niveau de risque.
- Introduire un indicateur d’autorisation sur les outils à haut risque et la configuration d’environnement/projet (`RENFORGE_POLICY`, `RENFORGE_POLICY_ALLOW`, `RENFORGE_POLICY_ALLOW_RISK`) pour contrôler les actions destructrices et en monde ouvert.
- Retourner des charges utiles d’erreur structurées `POLICY_DENIED` pour les invocations d’outils bloquées et exposer les métadonnées de politique dans les journaux d’activité.

Améliorations :
- Étendre la journalisation des activités côté serveur pour inclure les décisions de politique et occulter les paramètres sensibles pour les opérations destructrices et en monde ouvert.
- Refactoriser les outils côté serveur pour centraliser l’enregistrement des activités via `_record_tool_activity` et intégrer l’occultation des paramètres basée sur le risque.

Documentation :
- Ajouter `docs/POLICY.md` décrivant le modèle de politique d’exécution, la configuration, l’autorisation et le plan de compatibilité, et y faire référence depuis la documentation MCP, l’architecture et le README.
- Mettre à jour la documentation MCP pour indiquer que `renforge_eval` et les outils associés sont soumis à l’application de la politique d’exécution et clarifier leurs caractéristiques de risque.
- Documenter le nouveau comportement de politique d’exécution dans le CHANGELOG sous une section « unreleased ».

Tests :
- Ajouter des tests unitaires et d’intégration pour la classification de politique, le chargement de configuration, le comportement d’application, l’occultation, les chemins de refus, et la couverture documentaire du nouveau modèle de politique d’exécution.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an operation-level runtime policy layer for high-risk MCP tools and wire it into server logging and tool calls while keeping default behavior permissive.

New Features:
- Add runtime classification and enforcement for renforge_control, renforge_saves, renforge_eval, and renforge_run_scenario operations based on risk level.
- Introduce an authorize flag on high-risk tools and environment/project configuration (RENFORGE_POLICY, RENFORGE_POLICY_ALLOW, RENFORGE_POLICY_ALLOW_RISK) to control destructive and open-world actions.
- Return structured POLICY_DENIED error payloads for blocked tool invocations and surface policy metadata in activity logs.

Enhancements:
- Extend server-side activity logging to include policy decisions and redact sensitive parameters for destructive and open-world operations.
- Refactor server tooling to centralize activity recording via _record_tool_activity and integrate risk-aware parameter redaction.

Documentation:
- Add docs/POLICY.md describing the runtime policy model, configuration, authorization, and compatibility plan, and reference it from MCP, architecture, and README documentation.
- Update MCP documentation to mark renforge_eval and related tools as subject to runtime policy enforcement and clarify their risk characteristics.
- Record the new runtime policy behavior in the CHANGELOG under an unreleased section.

Tests:
- Add unit and integration tests for policy classification, configuration loading, enforcement behavior, redaction, denial paths, and documentation coverage for the new runtime policy model.

</details>

Nouvelles fonctionnalités :
- Ajouter la classification et l’application de la politique d’exécution pour `renforge_control`, `renforge_saves`, `renforge_eval` et `renforge_run_scenario` en fonction du risque propre à chaque opération.
- Introduire un indicateur `authorize` et une configuration d’environnement / de projet pour permettre ou interdire les opérations destructrices et « open-world » lorsque `RENFORGE_POLICY=enforce`.
- Retourner des charges d’erreur structurées `POLICY_DENIED` pour les opérations bloquées et journaliser les métadonnées de politique associées aux activités des outils.

Améliorations :
- Rendre anonymes (ou masquer) les paramètres sensibles dans le journal d’activité pour les opérations destructrices et « open-world » afin d’éviter la fuite de charges utiles à haut risque.
- Étendre la journalisation côté serveur pour inclure les décisions de politique pour chaque appel d’outil, sans modifier le comportement par défaut lorsque `RENFORGE_POLICY=off`.

Documentation :
- Ajouter `docs/POLICY.md` décrivant le modèle de politique d’exécution, la configuration et le plan de compatibilité, et le référencer depuis les guides MCP, d’architecture et le `README`.
- Mettre à jour la documentation MCP pour indiquer que `renforge_eval` et les outils associés sont soumis à l’application de la politique d’exécution et clarifier leurs caractéristiques de risque.
- Consigner le nouveau comportement de la politique d’exécution dans le `CHANGELOG` sous une section « unreleased ».

Tests :
- Ajouter des tests unitaires et d’intégration pour la classification de politique, le chargement de la configuration, le comportement d’application, la réduction (redaction) des logs et les chemins de refus pour `renforge_eval` et `renforge_run_scenario`.
- Étendre les tests de documentation pour s’assurer que les documents de politique d’exécution sont présents et couvrent `ToolAnnotations`, les modes, l’autorisation et `POLICY_DENIED`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduire une couche de politique d’exécution au niveau des opérations pour les outils MCP à haut risque, l’intégrer dans la journalisation du serveur et les appels d’outils, tout en maintenant un comportement par défaut permissif.

Nouvelles fonctionnalités :
- Ajouter une classification et une application en temps réel pour les opérations `renforge_control`, `renforge_saves`, `renforge_eval` et `renforge_run_scenario` en fonction du niveau de risque.
- Introduire un indicateur d’autorisation sur les outils à haut risque et la configuration d’environnement/projet (`RENFORGE_POLICY`, `RENFORGE_POLICY_ALLOW`, `RENFORGE_POLICY_ALLOW_RISK`) pour contrôler les actions destructrices et en monde ouvert.
- Retourner des charges utiles d’erreur structurées `POLICY_DENIED` pour les invocations d’outils bloquées et exposer les métadonnées de politique dans les journaux d’activité.

Améliorations :
- Étendre la journalisation des activités côté serveur pour inclure les décisions de politique et occulter les paramètres sensibles pour les opérations destructrices et en monde ouvert.
- Refactoriser les outils côté serveur pour centraliser l’enregistrement des activités via `_record_tool_activity` et intégrer l’occultation des paramètres basée sur le risque.

Documentation :
- Ajouter `docs/POLICY.md` décrivant le modèle de politique d’exécution, la configuration, l’autorisation et le plan de compatibilité, et y faire référence depuis la documentation MCP, l’architecture et le README.
- Mettre à jour la documentation MCP pour indiquer que `renforge_eval` et les outils associés sont soumis à l’application de la politique d’exécution et clarifier leurs caractéristiques de risque.
- Documenter le nouveau comportement de politique d’exécution dans le CHANGELOG sous une section « unreleased ».

Tests :
- Ajouter des tests unitaires et d’intégration pour la classification de politique, le chargement de configuration, le comportement d’application, l’occultation, les chemins de refus, et la couverture documentaire du nouveau modèle de politique d’exécution.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an operation-level runtime policy layer for high-risk MCP tools and wire it into server logging and tool calls while keeping default behavior permissive.

New Features:
- Add runtime classification and enforcement for renforge_control, renforge_saves, renforge_eval, and renforge_run_scenario operations based on risk level.
- Introduce an authorize flag on high-risk tools and environment/project configuration (RENFORGE_POLICY, RENFORGE_POLICY_ALLOW, RENFORGE_POLICY_ALLOW_RISK) to control destructive and open-world actions.
- Return structured POLICY_DENIED error payloads for blocked tool invocations and surface policy metadata in activity logs.

Enhancements:
- Extend server-side activity logging to include policy decisions and redact sensitive parameters for destructive and open-world operations.
- Refactor server tooling to centralize activity recording via _record_tool_activity and integrate risk-aware parameter redaction.

Documentation:
- Add docs/POLICY.md describing the runtime policy model, configuration, authorization, and compatibility plan, and reference it from MCP, architecture, and README documentation.
- Update MCP documentation to mark renforge_eval and related tools as subject to runtime policy enforcement and clarify their risk characteristics.
- Record the new runtime policy behavior in the CHANGELOG under an unreleased section.

Tests:
- Add unit and integration tests for policy classification, configuration loading, enforcement behavior, redaction, denial paths, and documentation coverage for the new runtime policy model.

</details>

</details>