### PR TITLE
docs(#87): snapshot modular MCP registration and close the stacked refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ versioning.
   blocks destructive and open-world operations unless `authorize=true` or an
   allowlist permits them. See [docs/POLICY.md](docs/POLICY.md).
 
+### Changed
+
+- MCP tool registration is split into domain modules under
+  `src/renforge/tool_registration/`. `server.py` only bootstraps the app;
+  wrappers, contract metadata, and fail-closed registration live next to each
+  other by domain. The public 54-tool MCP API is unchanged.
+
 ## [0.7.0] - 2026-08-11
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,6 +49,30 @@ for local testing by running `npm run build` from `ui/`.
 - If you touch the frontend, run `npm run build`; generated static assets must be
   left uncommitted.
 
+## Adding or changing an MCP tool
+
+The public MCP API is a versioned tool contract (currently 54 tools). Keep
+registration, wrappers, and metadata in sync so names and schemas cannot
+drift silently.
+
+1. Add or update the `ToolDefinition` in `src/renforge/tool_definitions.py`
+   (description, annotations, parameter docs, and JSON Schema constraints).
+2. Add or update the wrapper in the matching domain module under
+   `src/renforge/tool_registration/` and include the name in that module's
+   `TOOL_NAMES`.
+3. Implement behavior in `src/renforge/tools/` (or an existing helper), not in
+   `server.py`.
+4. Update `tests/test_server.py` (`EXPECTED_TOOLS`) when adding a tool.
+5. Refresh `tests/snapshots/mcp_public_tool_contract.json` when the emitted
+   contract changes, then run:
+
+```bash
+python -m pytest -q tests/test_tool_definitions.py tests/test_tool_registration.py tests/test_server.py
+```
+
+Do not mutate shared wrapper `__annotations__` as a registration side effect;
+`ToolRegistrar` clones wrappers before applying MCP metadata.
+
 ## Locale and i18n integration
 
 - Canonical UI copy lives in `ui/src/i18n/locales/en.json`.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -5,7 +5,19 @@
 ```
 src/renforge/
   cli.py            # argparse entrypoint (inspect / serve / ui)
-  server.py         # MCP app bootstrap + fallback + tool registration
+  server.py         # MCP app bootstrap + FastMCP/fallback; delegates tool registration
+  tool_definitions.py # canonical 54-tool public contract (names, schemas, annotations)
+  tool_schema.py    # shared JSON Schema fragments used by the contract catalog
+  tool_registration/
+    registry.py     # backend-aware ToolRegistrar; clones wrappers before annotating
+    wrappers.py     # shared context, activity logging, PNG content helper
+    project_analysis.py  # info, inspect, scan, lint, references
+    lifecycle.py    # launch, jump, new_game, stop
+    runtime_state.py # game state, eval, vars, wait, errors
+    interaction.py  # control, input, saves, choices, clicks
+    inspection.py   # screenshots, scene tree, measure
+    scenarios.py    # run_scenario, autopilot
+    content_build.py # assets, translations, builds, docs
   bridge/           # in-game .rpy bridge, launcher, and client
   tools/
     live.py         # running-game control (launch, eval, screenshot, ...)
@@ -31,6 +43,21 @@ build into `src/renforge/ui/static/`. CI/release regenerates this directory
 with `npm --prefix ui ci && npm --prefix ui run build`, then validates bundled
 assets before packaging. Generated static files stay ignored in source checkouts
 and are included in wheel/sdist artifacts so PyPI and `uvx` users never need Node.
+
+## MCP tool registration
+
+`server.py` only constructs the FastMCP (or compatibility) app and calls
+`tool_registration.register_all_tools`. Each domain module owns a disjoint
+`TOOL_NAMES` tuple and the corresponding wrapper bodies. `ToolRegistrar`
+looks up the matching `ToolDefinition`, clones the wrapper so registration
+never mutates shared `__annotations__` or `__doc__`, then applies description,
+`ToolAnnotations`, and JSON Schema metadata. Registration is fail-closed:
+unknown names, parameter drift, duplicate registrations, and backends that
+cannot accept required metadata raise instead of shipping a partial catalog.
+
+The public 54-tool contract is snapshotted in
+`tests/snapshots/mcp_public_tool_contract.json`. Intentional API changes must
+update that file; accidental ones fail CI.
 
 ## Live control flow
 

--- a/tests/snapshots/mcp_public_tool_contract.json
+++ b/tests/snapshots/mcp_public_tool_contract.json
@@ -1,0 +1,3775 @@
+{
+  "renforge_advance": {
+    "annotations": {
+      "destructiveHint": true,
+      "idempotentHint": false,
+      "openWorldHint": true,
+      "readOnlyHint": false
+    },
+    "description": "Advance one dialogue event from the currently active queue. Prefer `renforge_control(action=\"advance\")` only when you intentionally need control-command consistency with other navigation actions.",
+    "parameters": {
+      "additionalProperties": false,
+      "properties": {
+        "project_path": {
+          "description": "Project root of the running live session.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "project_path"
+      ],
+      "type": "object"
+    }
+  },
+  "renforge_assets": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true
+    },
+    "description": "Run static asset validation and return missing/orphaned image or audio references. Useful before build and before submitting translation/build changes.",
+    "parameters": {
+      "additionalProperties": false,
+      "properties": {
+        "project_path": {
+          "description": "Project root to inspect.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "project_path"
+      ],
+      "type": "object"
+    }
+  },
+  "renforge_autopilot": {
+    "annotations": {
+      "destructiveHint": true,
+      "idempotentHint": false,
+      "openWorldHint": true,
+      "readOnlyHint": false
+    },
+    "description": "Auto-play branches by stopping any current manual session and launching a fresh session for every replay. It writes incremental progress to `.renforge/autopilot.json` and may download/cache the required SDK. Best for broad checks; not deterministic and potentially expensive.",
+    "parameters": {
+      "additionalProperties": false,
+      "properties": {
+        "max_runs": {
+          "default": 16,
+          "description": "Maximum scenario runs before stopping.",
+          "type": "integer"
+        },
+        "max_steps": {
+          "default": 60,
+          "description": "Maximum steps per run.",
+          "type": "integer"
+        },
+        "project_path": {
+          "description": "Project root for the live session.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "project_path"
+      ],
+      "type": "object"
+    }
+  },
+  "renforge_capture_screenshot": {
+    "annotations": {
+      "destructiveHint": true,
+      "idempotentHint": false,
+      "openWorldHint": false,
+      "readOnlyHint": false
+    },
+    "description": "Persist the current frame under `.renforge/captures/` and return the output path plus hash. This writes disk and may overwrite an existing name.",
+    "parameters": {
+      "additionalProperties": false,
+      "properties": {
+        "crop_height": {
+          "default": 0,
+          "description": "Crop height; 0 disables cropping in Y.",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "crop_width": {
+          "default": 0,
+          "description": "Crop width; 0 disables cropping in X.",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "crop_x": {
+          "default": 0,
+          "description": "Crop origin x in logical coordinates.",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "crop_y": {
+          "default": 0,
+          "description": "Crop origin y in logical coordinates.",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "crosshair_x": {
+          "default": -1,
+          "description": "Crosshair x coordinate; both x/y must be set together.",
+          "minimum": -1,
+          "type": "integer"
+        },
+        "crosshair_y": {
+          "default": -1,
+          "description": "Crosshair y coordinate; both x/y must be set together.",
+          "minimum": -1,
+          "type": "integer"
+        },
+        "grid": {
+          "default": 0,
+          "description": "Guide overlay grid spacing in pixels.",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "height": {
+          "default": 0,
+          "description": "Target capture height.",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "name": {
+          "default": "capture",
+          "description": "Capture base filename (letters, digits, dot, dash, underscore).",
+          "not": {
+            "enum": [
+              ".",
+              ".."
+            ]
+          },
+          "pattern": "^[A-Za-z0-9_.-]{1,80}$",
+          "type": "string"
+        },
+        "project_path": {
+          "description": "Project root with active live session.",
+          "type": "string"
+        },
+        "rulers": {
+          "default": false,
+          "description": "Draw rulers along frame edges for measurement.",
+          "type": "boolean"
+        },
+        "scale": {
+          "default": 1.0,
+          "description": "Scale factor applied after crop/resize.",
+          "maximum": 16.0,
+          "minimum": 0.1,
+          "type": "number"
+        },
+        "width": {
+          "default": 0,
+          "description": "Target capture width.",
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "project_path"
+      ],
+      "type": "object"
+    }
+  },
+  "renforge_click_at": {
+    "annotations": {
+      "destructiveHint": true,
+      "idempotentHint": false,
+      "openWorldHint": true,
+      "readOnlyHint": false
+    },
+    "description": "Click a coordinate in screenshot or logical space. Use semantic click first (`renforge_click_element`) and fall back when text/id selectors are unavailable. Combine with coordinate space and frame/state guards.",
+    "parameters": {
+      "additionalProperties": false,
+      "properties": {
+        "coordinate_space": {
+          "default": "logical",
+          "description": "`logical` (default) or `screenshot` coordinates.",
+          "enum": [
+            "logical",
+            "screenshot"
+          ],
+          "type": "string"
+        },
+        "expected_frame_id": {
+          "default": "",
+          "description": "Frame id that must match for safety checks.",
+          "type": "string"
+        },
+        "expected_state": {
+          "anyOf": [
+            {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Optional expected runtime state dictionary before click."
+        },
+        "project_path": {
+          "description": "Project root with active live session.",
+          "type": "string"
+        },
+        "x": {
+          "description": "Horizontal coordinate in selected coordinate space.",
+          "type": "number"
+        },
+        "y": {
+          "description": "Vertical coordinate in selected coordinate space.",
+          "type": "number"
+        }
+      },
+      "required": [
+        "project_path",
+        "x",
+        "y"
+      ],
+      "type": "object"
+    }
+  },
+  "renforge_click_element": {
+    "annotations": {
+      "destructiveHint": true,
+      "idempotentHint": false,
+      "openWorldHint": true,
+      "readOnlyHint": false
+    },
+    "description": "Click a semantic UI element by text/id/screen (preferred). Falls back safely through fresh frame guards and returns focus hints when another element captures the hit test. Use `renforge_click_at` only as coordinate fallback.",
+    "parameters": {
+      "additionalProperties": false,
+      "properties": {
+        "effect_timeout": {
+          "default": 5.0,
+          "description": "How long to wait when `wait_for_effect` is true.",
+          "type": "number"
+        },
+        "element_id": {
+          "default": "",
+          "description": "Exact control id override when text is unstable.",
+          "type": "string"
+        },
+        "exact": {
+          "default": false,
+          "description": "Enable strict text matching.",
+          "type": "boolean"
+        },
+        "expected_frame_id": {
+          "default": "",
+          "description": "Optional frame id from a recent scene/listing call; when supplied it rejects a stale frame.",
+          "type": "string"
+        },
+        "interaction_id": {
+          "default": "",
+          "description": "Optional interaction correlation id for logs/troubleshooting.",
+          "type": "string"
+        },
+        "project_path": {
+          "description": "Project root with active live session.",
+          "type": "string"
+        },
+        "screen": {
+          "default": "",
+          "description": "Optional screen name filter to scope semantic lookup.",
+          "type": "string"
+        },
+        "text": {
+          "default": "",
+          "description": "Preferred visible text matcher for the target control.",
+          "type": "string"
+        },
+        "wait_for_effect": {
+          "default": false,
+          "description": "Wait for a visual effect/state update before returning.",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "project_path"
+      ],
+      "type": "object"
+    }
+  },
+  "renforge_context": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true
+    },
+    "description": "Return the same full payload as `renforge_info`, including active project discovery, dashboard/runtime hints, and RenForge version. This is an alias, not a reduced view.",
+    "parameters": {
+      "additionalProperties": false,
+      "properties": {},
+      "type": "object"
+    }
+  },
+  "renforge_control": {
+    "annotations": {
+      "destructiveHint": true,
+      "idempotentHint": false,
+      "openWorldHint": true,
+      "readOnlyHint": false
+    },
+    "description": "Run a runtime control action (`advance`, `rollback`, `toggle_skip`, `toggle_auto`, `toggle_afm`, `game_menu`, `hide_windows`, `quick_save`, `quick_load`, `reload_script`, `restart_interaction`, `quit`). Use `quick_load` with care: it replaces live state. `quit` stops the active game session. `renforge_advance` is a narrower alternative for pure advance actions. Destructive actions require `authorize=true` when `RENFORGE_POLICY=enforce`.",
+    "parameters": {
+      "additionalProperties": false,
+      "properties": {
+        "action": {
+          "description": "Control verb name to execute.",
+          "enum": [
+            "advance",
+            "rollback",
+            "toggle_skip",
+            "toggle_auto",
+            "toggle_afm",
+            "game_menu",
+            "hide_windows",
+            "quick_save",
+            "quick_load",
+            "reload_script",
+            "restart_interaction",
+            "quit"
+          ],
+          "type": "string"
+        },
+        "authorize": {
+          "default": false,
+          "description": "Explicitly authorize destructive actions when `RENFORGE_POLICY=enforce`; ignored for lower-risk actions.",
+          "type": "boolean"
+        },
+        "effect_timeout": {
+          "default": 5.0,
+          "description": "Maximum seconds to wait when `wait_for_effect` is enabled.",
+          "type": "number"
+        },
+        "interaction_id": {
+          "default": "",
+          "description": "Optional interaction correlation id used for safety checks and logs.",
+          "type": "string"
+        },
+        "project_path": {
+          "description": "Project root with running live session.",
+          "type": "string"
+        },
+        "wait_for_effect": {
+          "default": false,
+          "description": "Wait until bridge reports visible state effect before returning.",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "project_path",
+        "action"
+      ],
+      "type": "object"
+    }
+  },
+  "renforge_diff_screenshots": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true
+    },
+    "description": "Diff two PNG frames and return whether pixels changed plus the minimal changed rectangle. Use for regression checks between pre/post actions.",
+    "parameters": {
+      "additionalProperties": false,
+      "properties": {
+        "after_path": {
+          "default": "",
+          "description": "Path to comparison PNG; omit to compare against current live frame.",
+          "type": "string"
+        },
+        "before_path": {
+          "description": "Path to baseline PNG file.",
+          "type": "string"
+        },
+        "project_path": {
+          "description": "Project root used for path resolution of before/after images.",
+          "type": "string"
+        },
+        "threshold": {
+          "default": 0,
+          "description": "Pixel-difference threshold; higher values reduce sensitivity.",
+          "maximum": 255,
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "project_path",
+        "before_path"
+      ],
+      "type": "object"
+    }
+  },
+  "renforge_distribute": {
+    "annotations": {
+      "destructiveHint": true,
+      "idempotentHint": false,
+      "openWorldHint": true,
+      "readOnlyHint": false
+    },
+    "description": "Build desktop distribution packages and write them to destination. This executes packaging toolchains and may download and cache the SDK; it can be slow or destructive when output paths are reused.",
+    "parameters": {
+      "additionalProperties": false,
+      "properties": {
+        "destination": {
+          "default": "",
+          "description": "Optional output directory override.",
+          "type": "string"
+        },
+        "package": {
+          "default": "",
+          "description": "Package target (for example `pc`, `mac`, `linux`).",
+          "type": "string"
+        },
+        "project_path": {
+          "description": "Project root to package.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "project_path"
+      ],
+      "type": "object"
+    }
+  },
+  "renforge_estimate_translation": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true
+    },
+    "description": "Estimate geometric translation between two images for visual text alignment workflows. This is file-only and read-only.",
+    "parameters": {
+      "additionalProperties": false,
+      "properties": {
+        "after_path": {
+          "description": "Path to comparison image.",
+          "type": "string"
+        },
+        "before_path": {
+          "description": "Path to baseline image.",
+          "type": "string"
+        },
+        "max_shift": {
+          "default": 64,
+          "description": "Maximum per-axis shift considered during matching.",
+          "maximum": 256,
+          "minimum": 0,
+          "type": "integer"
+        },
+        "region_height": {
+          "default": 0,
+          "description": "Optional crop region height.",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "region_width": {
+          "default": 0,
+          "description": "Optional crop region width.",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "region_x": {
+          "default": 0,
+          "description": "Optional crop region X origin.",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "region_y": {
+          "default": 0,
+          "description": "Optional crop region Y origin.",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "threshold": {
+          "default": 16,
+          "description": "Similarity threshold for matching pixels.",
+          "maximum": 255,
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "before_path",
+        "after_path"
+      ],
+      "type": "object"
+    }
+  },
+  "renforge_eval": {
+    "annotations": {
+      "destructiveHint": true,
+      "idempotentHint": false,
+      "openWorldHint": true,
+      "readOnlyHint": false
+    },
+    "description": "Evaluate an arbitrary Python expression in the running store namespace. This may call project functions and mutate runtime state or access the filesystem, start processes, and use the network with the game process's permissions. Prefer `renforge_get_var` for plain reads and use this only for controlled diagnostics. Pass `authorize=true` when `RENFORGE_POLICY=enforce`, unless this operation is allowlisted.",
+    "parameters": {
+      "additionalProperties": false,
+      "properties": {
+        "authorize": {
+          "default": false,
+          "description": "Explicitly authorize this open-world expression when `RENFORGE_POLICY=enforce`.",
+          "type": "boolean"
+        },
+        "expr": {
+          "description": "Python expression to evaluate in the store namespace.",
+          "type": "string"
+        },
+        "project_path": {
+          "description": "Project root with active live session.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "project_path",
+        "expr"
+      ],
+      "type": "object"
+    }
+  },
+  "renforge_export_dialogue": {
+    "annotations": {
+      "destructiveHint": true,
+      "idempotentHint": false,
+      "openWorldHint": true,
+      "readOnlyHint": false
+    },
+    "description": "Export dialogue for translators or external tooling. This may download and cache the SDK, then writes and overwrites `dialogue.txt` at the project root.",
+    "parameters": {
+      "additionalProperties": false,
+      "properties": {
+        "language": {
+          "default": "None",
+          "description": "Optional language variant to export.",
+          "type": "string"
+        },
+        "project_path": {
+          "description": "Project root whose dialogue should be exported.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "project_path"
+      ],
+      "type": "object"
+    }
+  },
+  "renforge_find_image_on_screen": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true
+    },
+    "description": "Find a template image on the current frame and return matches with bounds in screenshot coordinates. Use this to close the control loop after screenshot capture and click fallback.",
+    "parameters": {
+      "additionalProperties": false,
+      "properties": {
+        "max_matches": {
+          "default": 20,
+          "description": "Maximum number of matches to return.",
+          "maximum": 100,
+          "minimum": 1,
+          "type": "integer"
+        },
+        "project_path": {
+          "description": "Project root with active live session.",
+          "type": "string"
+        },
+        "region_height": {
+          "default": 0,
+          "description": "Optional region height; set width/height together.",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "region_width": {
+          "default": 0,
+          "description": "Optional region width; set width/height together.",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "region_x": {
+          "default": 0,
+          "description": "Optional region x origin to limit search area.",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "region_y": {
+          "default": 0,
+          "description": "Optional region y origin to limit search area.",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "template_path": {
+          "description": "Template image path relative to project or absolute.",
+          "type": "string"
+        },
+        "threshold": {
+          "default": 0.92,
+          "description": "Match confidence threshold.",
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "type": "number"
+        }
+      },
+      "required": [
+        "project_path",
+        "template_path"
+      ],
+      "type": "object"
+    }
+  },
+  "renforge_find_references": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true
+    },
+    "description": "Find symbol definitions and references across scripts and templates with the same pagination controls as scan. Useful before editing or renaming project identifiers.",
+    "parameters": {
+      "additionalProperties": false,
+      "properties": {
+        "file_glob": {
+          "default": "",
+          "description": "Optional glob filter limiting candidate files.",
+          "type": "string"
+        },
+        "limit": {
+          "default": 200,
+          "description": "Maximum results to return; keep this bounded for large codebases.",
+          "maximum": 1000,
+          "minimum": 1,
+          "type": "integer"
+        },
+        "offset": {
+          "default": 0,
+          "description": "Zero-based pagination offset for matches.",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "project_path": {
+          "description": "Project root where symbol references should be resolved.",
+          "type": "string"
+        },
+        "symbol": {
+          "description": "Symbol name to resolve (for example label, define, or python identifier).",
+          "pattern": "^[A-Za-z_][A-Za-z0-9_]*$",
+          "type": "string"
+        }
+      },
+      "required": [
+        "project_path",
+        "symbol"
+      ],
+      "type": "object"
+    }
+  },
+  "renforge_game_state": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true
+    },
+    "description": "Read full live state for debugging and monitoring. Use this before/after interactions to verify state deltas without changing variables directly. Request optional sections such as `metrics` and `audio`.",
+    "parameters": {
+      "additionalProperties": false,
+      "properties": {
+        "include": {
+          "anyOf": [
+            {
+              "items": {
+                "enum": [
+                  "metrics",
+                  "audio"
+                ],
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Optional sections to include in addition to default state (for example metrics, audio).",
+          "items": {
+            "enum": [
+              "metrics",
+              "audio"
+            ],
+            "type": "string"
+          }
+        },
+        "project_path": {
+          "description": "Project root with an active live session.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "project_path"
+      ],
+      "type": "object"
+    }
+  },
+  "renforge_game_state_compact": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true
+    },
+    "description": "Read bounded live state with explicit variable limits and payload caps for large sessions. Use this in loops and scripts to keep responses predictable.",
+    "parameters": {
+      "additionalProperties": false,
+      "properties": {
+        "max_depth": {
+          "default": 3,
+          "description": "Maximum object nesting depth to serialize, from 0 through 20.",
+          "maximum": 20,
+          "minimum": 0,
+          "type": "integer"
+        },
+        "max_items": {
+          "default": 50,
+          "description": "Maximum variable count before trimming, from 1 through 10000.",
+          "maximum": 10000,
+          "minimum": 1,
+          "type": "integer"
+        },
+        "max_output_bytes": {
+          "default": 8192,
+          "description": "Payload cap in bytes, from 64 through 2000000.",
+          "maximum": 2000000,
+          "minimum": 64,
+          "type": "integer"
+        },
+        "project_path": {
+          "description": "Project root with an active live session.",
+          "type": "string"
+        },
+        "state_profile": {
+          "default": "interaction",
+          "description": "Compact shape policy: `minimal`, `interaction`, `debug`, or `full`.",
+          "enum": [
+            "minimal",
+            "interaction",
+            "debug",
+            "full"
+          ],
+          "type": "string"
+        },
+        "variable_names": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Restrict output to these variable names."
+        },
+        "variable_prefix": {
+          "default": "",
+          "description": "Filter variable names by this prefix.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "project_path"
+      ],
+      "type": "object"
+    }
+  },
+  "renforge_generate_translations": {
+    "annotations": {
+      "destructiveHint": true,
+      "idempotentHint": false,
+      "openWorldHint": true,
+      "readOnlyHint": false
+    },
+    "description": "Generate or update translation files under `game/tl/<language>/`. This may download and cache the SDK before writing output. It writes files, so treat it as destructive when run against production trees and prefer checking stats first.",
+    "parameters": {
+      "additionalProperties": false,
+      "properties": {
+        "language": {
+          "description": "Language code/name to generate.",
+          "type": "string"
+        },
+        "project_path": {
+          "description": "Project root to write translation files for.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "project_path",
+        "language"
+      ],
+      "type": "object"
+    }
+  },
+  "renforge_get_displayable_bounds": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true
+    },
+    "description": "Read placement bounds for a rendered displayable tag by tag name. Use this to diagnose layout changes or anchor calculations before moving elements.",
+    "parameters": {
+      "additionalProperties": false,
+      "properties": {
+        "layer": {
+          "default": "",
+          "description": "Optional Ren'Py layer override.",
+          "type": "string"
+        },
+        "project_path": {
+          "description": "Project root with active live session.",
+          "type": "string"
+        },
+        "tag": {
+          "description": "Displayable tag name to resolve.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "project_path",
+        "tag"
+      ],
+      "type": "object"
+    }
+  },
+  "renforge_get_doc": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": true,
+      "readOnlyHint": false
+    },
+    "description": "Read a single Ren'Py documentation topic. For discovery, run `renforge_search_docs` and `renforge_list_docs` first to avoid guessing IDs. This may download and cache the SDK before resolving doc content.",
+    "parameters": {
+      "additionalProperties": false,
+      "properties": {
+        "topic": {
+          "description": "Topic identifier or slug in the doc catalog.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "topic"
+      ],
+      "type": "object"
+    }
+  },
+  "renforge_get_errors": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true
+    },
+    "description": "Read recent runtime and bridge errors. Run this after risky actions or after a stop to confirm the game did not crash with hidden diagnostics.",
+    "parameters": {
+      "additionalProperties": false,
+      "properties": {
+        "project_path": {
+          "description": "Project root; this can still read bounded crash files after the runtime stops.",
+          "type": "string"
+        },
+        "since": {
+          "default": 0,
+          "description": "Exclusive cursor for paginating older logs/diagnostics.",
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "project_path"
+      ],
+      "type": "object"
+    }
+  },
+  "renforge_get_ui_element_bounds": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true
+    },
+    "description": "Resolve semantic element bounds without clicking. Use this after list output to verify target geometry before any pointer action.",
+    "parameters": {
+      "additionalProperties": false,
+      "properties": {
+        "element_id": {
+          "default": "",
+          "description": "Element id matcher for a precise target.",
+          "type": "string"
+        },
+        "exact": {
+          "default": false,
+          "description": "Require exact text matching.",
+          "type": "boolean"
+        },
+        "expected_frame_id": {
+          "default": "",
+          "description": "Optional frame guard token for freshness.",
+          "type": "string"
+        },
+        "project_path": {
+          "description": "Project root with active live session.",
+          "type": "string"
+        },
+        "screen": {
+          "default": "",
+          "description": "Optional screen filter for targeted lookup.",
+          "type": "string"
+        },
+        "text": {
+          "default": "",
+          "description": "Text matcher for the element.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "project_path"
+      ],
+      "type": "object"
+    }
+  },
+  "renforge_get_var": {
+    "annotations": {
+      "destructiveHint": true,
+      "idempotentHint": false,
+      "openWorldHint": true,
+      "readOnlyHint": false
+    },
+    "description": "Read one named variable from the live store. JSON-safe values are returned as-is; other objects are replaced by a type label without calling conversion hooks such as `__repr__`. Resolving the name can still run a store property getter. Prefer this over `renforge_eval` when you only need a named lookup.",
+    "parameters": {
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "description": "Variable name to read.",
+          "type": "string"
+        },
+        "project_path": {
+          "description": "Project root with active live session.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "project_path",
+        "name"
+      ],
+      "type": "object"
+    }
+  },
+  "renforge_hit_test": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true
+    },
+    "description": "Inspect which interactive nodes sit under a coordinate. Use this when click targets look stale or overlays may absorb events, and prefer semantic selectors once ambiguity is resolved.",
+    "parameters": {
+      "additionalProperties": false,
+      "properties": {
+        "coordinate_space": {
+          "default": "logical",
+          "description": "Coordinate system for the test point (`logical` or `screenshot`).",
+          "enum": [
+            "logical",
+            "screenshot"
+          ],
+          "type": "string"
+        },
+        "project_path": {
+          "description": "Project root with active live session.",
+          "type": "string"
+        },
+        "x": {
+          "description": "X coordinate for hit testing.",
+          "type": "number"
+        },
+        "y": {
+          "description": "Y coordinate for hit testing.",
+          "type": "number"
+        }
+      },
+      "required": [
+        "project_path",
+        "x",
+        "y"
+      ],
+      "type": "object"
+    }
+  },
+  "renforge_hover_element": {
+    "annotations": {
+      "destructiveHint": true,
+      "idempotentHint": false,
+      "openWorldHint": true,
+      "readOnlyHint": false
+    },
+    "description": "Move cursor over a semantic control by text/id/screen. Prefer this before click when checking hover states or tooltips.",
+    "parameters": {
+      "additionalProperties": false,
+      "properties": {
+        "element_id": {
+          "default": "",
+          "description": "Element id matcher for precise targeting.",
+          "type": "string"
+        },
+        "exact": {
+          "default": false,
+          "description": "Require exact text match.",
+          "type": "boolean"
+        },
+        "expected_frame_id": {
+          "default": "",
+          "description": "Frame id expected from recent scene/listing calls.",
+          "type": "string"
+        },
+        "project_path": {
+          "description": "Project root with active live session.",
+          "type": "string"
+        },
+        "screen": {
+          "default": "",
+          "description": "Screen filter for ambiguous UI states.",
+          "type": "string"
+        },
+        "text": {
+          "default": "",
+          "description": "Text matcher for the control to hover.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "project_path"
+      ],
+      "type": "object"
+    }
+  },
+  "renforge_info": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true
+    },
+    "description": "Call this first. It returns the active project target (dashboard, \"serve_default\" or cwd), plus local runtime hints and RenForge version. Use this to determine the project path you should pass to project-scoped tools.",
+    "parameters": {
+      "additionalProperties": false,
+      "properties": {},
+      "type": "object"
+    }
+  },
+  "renforge_inspect_image": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true
+    },
+    "description": "Inspect a local image file and optionally crop/zoom it before returning PNG bytes. Use this for artifact review without launching the game.",
+    "parameters": {
+      "additionalProperties": false,
+      "properties": {
+        "crop_height": {
+          "default": 0,
+          "description": "Optional crop height in pixels; 0 keeps full height.",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "crop_width": {
+          "default": 0,
+          "description": "Optional crop width in pixels; 0 keeps full width.",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "crop_x": {
+          "default": 0,
+          "description": "Pixel offset from left for the crop rectangle origin.",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "crop_y": {
+          "default": 0,
+          "description": "Pixel offset from top for the crop rectangle origin.",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "image_path": {
+          "description": "Local image path to load and inspect.",
+          "type": "string"
+        },
+        "scale": {
+          "default": 1.0,
+          "description": "Scale multiplier applied after crop; > 1 zooms in, < 1 zooms out.",
+          "maximum": 16.0,
+          "minimum": 0.1,
+          "type": "number"
+        }
+      },
+      "required": [
+        "image_path"
+      ],
+      "type": "object"
+    }
+  },
+  "renforge_inspect_project": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true
+    },
+    "description": "Read-only static analysis of a Ren'Py project: scan metadata and file structure without starting the game engine. Use this for safe project triage before runtime actions.",
+    "parameters": {
+      "additionalProperties": false,
+      "properties": {
+        "project_path": {
+          "description": "Absolute or relative Ren'Py project root containing `game/`.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "project_path"
+      ],
+      "type": "object"
+    }
+  },
+  "renforge_inspect_screen": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true
+    },
+    "description": "Inspect a named active screen, including layer, scope and arguments. Useful for branch verification before choosing click or hover selectors.",
+    "parameters": {
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "description": "Screen name to inspect in the live bridge state.",
+          "type": "string"
+        },
+        "project_path": {
+          "description": "Project root with active game session.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "project_path",
+        "name"
+      ],
+      "type": "object"
+    }
+  },
+  "renforge_jump": {
+    "annotations": {
+      "destructiveHint": true,
+      "idempotentHint": false,
+      "openWorldHint": true,
+      "readOnlyHint": false
+    },
+    "description": "Restart into a specific label/file position and keep interacting in a fresh game session. If needed, this may download and cache the required SDK before restart. Use for deterministic positioning before scripted checks.",
+    "parameters": {
+      "additionalProperties": false,
+      "properties": {
+        "project_path": {
+          "description": "Project root containing the target game.",
+          "type": "string"
+        },
+        "target": {
+          "description": "Label name or `file:line` destination for relaunch.",
+          "type": "string"
+        },
+        "version": {
+          "default": "stable",
+          "description": "Runtime version to use when restarting at target.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "project_path",
+        "target"
+      ],
+      "type": "object"
+    }
+  },
+  "renforge_languages": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true
+    },
+    "description": "List translation languages currently present under `game/tl/`. Use this before generating or exporting localized files.",
+    "parameters": {
+      "additionalProperties": false,
+      "properties": {
+        "project_path": {
+          "description": "Project root for translation inventory.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "project_path"
+      ],
+      "type": "object"
+    }
+  },
+  "renforge_launch": {
+    "annotations": {
+      "destructiveHint": true,
+      "idempotentHint": false,
+      "openWorldHint": true,
+      "readOnlyHint": false
+    },
+    "description": "Start or attach a running game session with Live Editor enabled by default (pass editor=false for non-editor runtime launch). Launch starts the background startup flow, usually returning while startup is still in progress; poll `renforge_launch_status` and capture with `renforge_screenshot` before interaction. It may download/cache the selected SDK, inject session-owned `.rpy` files and editor assets under `game/`, and publish authenticated ownership/bridge metadata under `.renforge/control/`. `renforge_stop` removes only owned session artifacts.",
+    "parameters": {
+      "additionalProperties": false,
+      "properties": {
+        "audio": {
+          "default": "auto",
+          "description": "Audio strategy: `auto`, `native`, `dummy`, or `none`; both `dummy` and `none` use SDL dummy audio.",
+          "enum": [
+            "auto",
+            "native",
+            "dummy",
+            "none"
+          ],
+          "type": "string"
+        },
+        "cleanup_on_stop": {
+          "default": true,
+          "description": "When true, stop removes only the temporary save directory created by `savedir=temporary`; arbitrary save directories and existing saves are not deleted.",
+          "type": "boolean"
+        },
+        "display": {
+          "default": "auto",
+          "description": "Display strategy: `auto`, `native`, `xvfb`, or `external`. The accepted token `none` returns an error because Ren'Py requires a display surface.",
+          "enum": [
+            "auto",
+            "native",
+            "xvfb",
+            "external",
+            "none"
+          ],
+          "type": "string"
+        },
+        "editor": {
+          "default": true,
+          "description": "Enable/disable live editor injection; default True for interactive work.",
+          "type": "boolean"
+        },
+        "persistent": {
+          "default": "existing",
+          "description": "Persistent mode: `existing` preserves current persistent data and `empty` removes it in the isolated session; `copy` and `fixture` currently set an environment marker only and do not copy or load fixture data.",
+          "enum": [
+            "existing",
+            "empty",
+            "copy",
+            "fixture"
+          ],
+          "type": "string"
+        },
+        "project_path": {
+          "description": "Project root passed to the launcher and runtime bridge.",
+          "type": "string"
+        },
+        "savedir": {
+          "default": "",
+          "description": "Optional save directory override. `temporary` creates an isolated temporary directory; any other non-default value is an arbitrary save directory path that is created if missing and is never removed by stop.",
+          "type": "string"
+        },
+        "timeout": {
+          "default": 0,
+          "description": "Ren'Py background startup deadline in seconds (0 uses the launcher default). This does not control the MCP response wait; poll `renforge_launch_status` after a `starting` result.",
+          "minimum": 0,
+          "type": "number"
+        },
+        "version": {
+          "default": "stable",
+          "description": "Launcher version selector, either `stable` or an explicit semantic version (for example `8.5.3`).",
+          "type": "string"
+        },
+        "warp": {
+          "default": "",
+          "description": "Optional Ren'Py `file.rpy:line` startup target; this launch tool does not resolve label names.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "project_path"
+      ],
+      "type": "object"
+    }
+  },
+  "renforge_launch_status": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true
+    },
+    "description": "Poll launch progress and return `idle`, `starting`, `ready`, `failed`, `closing`, or `closed`. Use after any launch start when the first call has not returned an immediate ready state.",
+    "parameters": {
+      "additionalProperties": false,
+      "properties": {
+        "project_path": {
+          "description": "Project root currently being launched or running.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "project_path"
+      ],
+      "type": "object"
+    }
+  },
+  "renforge_list_choices": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true
+    },
+    "description": "List on-screen menu choices with index and text ordering. Call before `renforge_select_choice` to pick valid entries for the current menu state.",
+    "parameters": {
+      "additionalProperties": false,
+      "properties": {
+        "project_path": {
+          "description": "Project root of the running live session.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "project_path"
+      ],
+      "type": "object"
+    }
+  },
+  "renforge_list_docs": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": true,
+      "readOnlyHint": false
+    },
+    "description": "List available Ren'Py documentation topics. Use this as the discovery step before any topic-specific docs read. This may download and cache the SDK if docs are not already available.",
+    "parameters": {
+      "additionalProperties": false,
+      "properties": {},
+      "type": "object"
+    }
+  },
+  "renforge_list_ui_elements": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true
+    },
+    "description": "List focusable UI elements with bounds and element metadata. Use this first for semantic interaction planning; it is narrower than a full scene readout and aligned to click/hover workflows.",
+    "parameters": {
+      "additionalProperties": false,
+      "properties": {
+        "element_type": {
+          "default": "",
+          "description": "Optional element type/class filter (for example button, label).",
+          "type": "string"
+        },
+        "project_path": {
+          "description": "Project root with active live session.",
+          "type": "string"
+        },
+        "screen": {
+          "default": "",
+          "description": "Optional active screen filter.",
+          "type": "string"
+        },
+        "text": {
+          "default": "",
+          "description": "Optional text filter to narrow focusable candidates.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "project_path"
+      ],
+      "type": "object"
+    }
+  },
+  "renforge_measure": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true
+    },
+    "description": "Measure geometry between scene nodes without visual inspection. `contrast` samples the live frame and reports a WCAG ratio. Use this to detect layout drift after positional edits.",
+    "parameters": {
+      "additionalProperties": false,
+      "properties": {
+        "action": {
+          "description": "One of `align`, `gap`, `distribute`, `center`, `overlap`, `fit`, or `contrast`.",
+          "enum": [
+            "align",
+            "gap",
+            "distribute",
+            "center",
+            "overlap",
+            "fit",
+            "contrast"
+          ],
+          "type": "string"
+        },
+        "project_path": {
+          "description": "Project root with active live session.",
+          "type": "string"
+        },
+        "targets": {
+          "description": "Scene node `id` strings or literal bounds objects `{\"x\": number, \"y\": number, \"width\": number, \"height\": number}`.",
+          "items": {},
+          "type": "array"
+        },
+        "tolerance": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Optional tolerance; adds a pass verdict (for contrast, the minimum WCAG ratio)."
+        },
+        "within": {
+          "default": null,
+          "description": "Optional scene node id or literal `{x,y,width,height}` bounds used as the containing region.",
+          "title": "Within"
+        }
+      },
+      "required": [
+        "project_path",
+        "action",
+        "targets"
+      ],
+      "type": "object"
+    }
+  },
+  "renforge_new_game": {
+    "annotations": {
+      "destructiveHint": true,
+      "idempotentHint": false,
+      "openWorldHint": true,
+      "readOnlyHint": false
+    },
+    "description": "Restart at `start` and begin a new story progression. This may download and cache the required SDK before the fresh launch. Prefer this for clean scenario entry rather than reusing unstable runtime state.",
+    "parameters": {
+      "additionalProperties": false,
+      "properties": {
+        "project_path": {
+          "description": "Project root containing the game to restart.",
+          "type": "string"
+        },
+        "version": {
+          "default": "stable",
+          "description": "Runtime version used for the fresh launch.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "project_path"
+      ],
+      "type": "object"
+    }
+  },
+  "renforge_parse_lint": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true
+    },
+    "description": "Parse existing Ren'Py lint output text and return normalized diagnostics. This does not run Ren'Py, does not execute code, and does not touch the runtime.",
+    "parameters": {
+      "additionalProperties": false,
+      "properties": {
+        "text": {
+          "description": "Existing Ren'Py lint output text to parse.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "text"
+      ],
+      "type": "object"
+    }
+  },
+  "renforge_poll_events": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true
+    },
+    "description": "Read queued runtime events since a stream index. Use this for deterministic event-driven debugging instead of polling live UI repeatedly.",
+    "parameters": {
+      "additionalProperties": false,
+      "properties": {
+        "project_path": {
+          "description": "Project root with active live session.",
+          "type": "string"
+        },
+        "since": {
+          "default": 0,
+          "description": "Exclusive cursor position for pagination of event history.",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "project_path"
+      ],
+      "type": "object"
+    }
+  },
+  "renforge_position_element": {
+    "annotations": {
+      "destructiveHint": true,
+      "idempotentHint": false,
+      "openWorldHint": true,
+      "readOnlyHint": false
+    },
+    "description": "Reposition a shown image tag live and return new logical bounds. This mutates runtime placement only; after converging with scene/measure tools, write the final values into the `.rpy` source.",
+    "parameters": {
+      "additionalProperties": false,
+      "properties": {
+        "layer": {
+          "default": "",
+          "description": "Optional Ren'Py layer override.",
+          "type": "string"
+        },
+        "project_path": {
+          "description": "Project root with active live session.",
+          "type": "string"
+        },
+        "rotate": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Rotation in degrees."
+        },
+        "tag": {
+          "description": "Displayable tag to reposition.",
+          "type": "string"
+        },
+        "xalign": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Alternative x alignment offset."
+        },
+        "xanchor": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Anchor point for x placement (0..1)."
+        },
+        "xoffset": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Relative x offset in pixels."
+        },
+        "xpos": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "X position: an integer is absolute logical pixels; a float is a screen fraction (for example 0.5)."
+        },
+        "yalign": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Alternative y alignment offset."
+        },
+        "yanchor": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Anchor point for y placement (0..1)."
+        },
+        "yoffset": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Relative y offset in pixels."
+        },
+        "ypos": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Y position: an integer is absolute logical pixels; a float is a screen fraction (for example 0.5)."
+        },
+        "zoom": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Scale factor for the displayable."
+        }
+      },
+      "required": [
+        "project_path",
+        "tag"
+      ],
+      "type": "object"
+    }
+  },
+  "renforge_run_scenario": {
+    "annotations": {
+      "destructiveHint": true,
+      "idempotentHint": false,
+      "openWorldHint": true,
+      "readOnlyHint": false
+    },
+    "description": "Run a scripted scenario pipeline of multiple interaction steps in one call and return grouped diagnostics. `eval`, `assert`, and expression-based `wait` steps execute arbitrary Python that may mutate state, access the filesystem, start processes, or use the network. Validate expectations and review capture output on failure. Destructive or open-world steps require `authorize=true` when `RENFORGE_POLICY=enforce`.",
+    "parameters": {
+      "additionalProperties": false,
+      "properties": {
+        "authorize": {
+          "default": false,
+          "description": "Explicitly authorize a destructive or open-world step when `RENFORGE_POLICY=enforce`.",
+          "type": "boolean"
+        },
+        "capture_on_failure": {
+          "default": true,
+          "description": "Capture diagnostics (including image) when step evaluation fails.",
+          "type": "boolean"
+        },
+        "name": {
+          "default": "scenario",
+          "description": "Scenario name used for logs and output grouping.",
+          "type": "string"
+        },
+        "project_path": {
+          "description": "Project root of the live session.",
+          "type": "string"
+        },
+        "state_profile": {
+          "default": "minimal",
+          "description": "Compact state profile used for captures: `minimal`, `interaction`, `debug`, or `full`.",
+          "enum": [
+            "minimal",
+            "interaction",
+            "debug",
+            "full"
+          ],
+          "type": "string"
+        },
+        "steps": {
+          "description": "Ordered action objects. Supported actions: `set`, `eval`, `click`, `click_at`, `advance`, `scroll`, `wait`, `assert`, `select_choice`, `capture`, `save`, `load`, `control`, and `send_input`.",
+          "items": {
+            "oneOf": [
+              {
+                "additionalProperties": false,
+                "properties": {
+                  "set": {
+                    "minProperties": 1,
+                    "type": "object"
+                  },
+                  "step_timeout": {
+                    "minimum": 0,
+                    "type": "number"
+                  },
+                  "timeout": {
+                    "minimum": 0,
+                    "type": "number"
+                  }
+                },
+                "required": [
+                  "set"
+                ],
+                "type": "object"
+              },
+              {
+                "additionalProperties": false,
+                "properties": {
+                  "eval": {
+                    "oneOf": [
+                      {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      {
+                        "additionalProperties": false,
+                        "properties": {
+                          "expr": {
+                            "minLength": 1,
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "expr"
+                        ],
+                        "type": "object"
+                      }
+                    ]
+                  },
+                  "step_timeout": {
+                    "minimum": 0,
+                    "type": "number"
+                  },
+                  "timeout": {
+                    "minimum": 0,
+                    "type": "number"
+                  }
+                },
+                "required": [
+                  "eval"
+                ],
+                "type": "object"
+              },
+              {
+                "additionalProperties": false,
+                "properties": {
+                  "click": {
+                    "oneOf": [
+                      {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      {
+                        "additionalProperties": false,
+                        "anyOf": [
+                          {
+                            "properties": {
+                              "text": {
+                                "minLength": 1,
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "text"
+                            ]
+                          },
+                          {
+                            "properties": {
+                              "id": {
+                                "minLength": 1,
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "id"
+                            ]
+                          },
+                          {
+                            "properties": {
+                              "target": {
+                                "minLength": 1,
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "target"
+                            ]
+                          },
+                          {
+                            "properties": {
+                              "element_id": {
+                                "minLength": 1,
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "element_id"
+                            ]
+                          }
+                        ],
+                        "properties": {
+                          "element_id": {
+                            "anyOf": [
+                              {
+                                "minLength": 1,
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "exact": {
+                            "anyOf": [
+                              {
+                                "type": "boolean"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "expected_frame_id": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "id": {
+                            "anyOf": [
+                              {
+                                "minLength": 1,
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "screen": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "target": {
+                            "anyOf": [
+                              {
+                                "minLength": 1,
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "text": {
+                            "anyOf": [
+                              {
+                                "minLength": 1,
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          }
+                        },
+                        "type": "object"
+                      }
+                    ]
+                  },
+                  "step_timeout": {
+                    "minimum": 0,
+                    "type": "number"
+                  },
+                  "timeout": {
+                    "minimum": 0,
+                    "type": "number"
+                  }
+                },
+                "required": [
+                  "click"
+                ],
+                "type": "object"
+              },
+              {
+                "additionalProperties": false,
+                "properties": {
+                  "click_at": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "coordinate_space": {
+                        "enum": [
+                          "logical",
+                          "screenshot"
+                        ],
+                        "type": "string"
+                      },
+                      "expected_frame_id": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "x": {
+                        "type": "number"
+                      },
+                      "y": {
+                        "type": "number"
+                      }
+                    },
+                    "required": [
+                      "x",
+                      "y"
+                    ],
+                    "type": "object"
+                  },
+                  "step_timeout": {
+                    "minimum": 0,
+                    "type": "number"
+                  },
+                  "timeout": {
+                    "minimum": 0,
+                    "type": "number"
+                  }
+                },
+                "required": [
+                  "click_at"
+                ],
+                "type": "object"
+              },
+              {
+                "additionalProperties": false,
+                "properties": {
+                  "advance": {
+                    "oneOf": [
+                      {
+                        "type": "null"
+                      },
+                      {
+                        "minimum": 1,
+                        "type": "integer"
+                      },
+                      {
+                        "additionalProperties": false,
+                        "properties": {
+                          "count": {
+                            "minimum": 1,
+                            "type": "integer"
+                          }
+                        },
+                        "type": "object"
+                      }
+                    ]
+                  },
+                  "step_timeout": {
+                    "minimum": 0,
+                    "type": "number"
+                  },
+                  "timeout": {
+                    "minimum": 0,
+                    "type": "number"
+                  }
+                },
+                "required": [
+                  "advance"
+                ],
+                "type": "object"
+              },
+              {
+                "additionalProperties": false,
+                "properties": {
+                  "scroll": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "amount": {
+                        "minimum": 1,
+                        "type": "integer"
+                      },
+                      "direction": {
+                        "enum": [
+                          "up",
+                          "down"
+                        ],
+                        "type": "string"
+                      },
+                      "x": {
+                        "type": "number"
+                      },
+                      "y": {
+                        "type": "number"
+                      }
+                    },
+                    "required": [
+                      "x",
+                      "y",
+                      "direction"
+                    ],
+                    "type": "object"
+                  },
+                  "step_timeout": {
+                    "minimum": 0,
+                    "type": "number"
+                  },
+                  "timeout": {
+                    "minimum": 0,
+                    "type": "number"
+                  }
+                },
+                "required": [
+                  "scroll"
+                ],
+                "type": "object"
+              },
+              {
+                "additionalProperties": false,
+                "properties": {
+                  "step_timeout": {
+                    "minimum": 0,
+                    "type": "number"
+                  },
+                  "timeout": {
+                    "minimum": 0,
+                    "type": "number"
+                  },
+                  "wait": {
+                    "additionalProperties": false,
+                    "oneOf": [
+                      {
+                        "properties": {
+                          "expr": {
+                            "type": "null"
+                          },
+                          "label": {
+                            "minLength": 1,
+                            "type": "string"
+                          },
+                          "screen": {
+                            "type": "null"
+                          }
+                        },
+                        "required": [
+                          "label"
+                        ]
+                      },
+                      {
+                        "properties": {
+                          "expr": {
+                            "type": "null"
+                          },
+                          "label": {
+                            "type": "null"
+                          },
+                          "screen": {
+                            "minLength": 1,
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "screen"
+                        ]
+                      },
+                      {
+                        "properties": {
+                          "expr": {
+                            "minLength": 1,
+                            "type": "string"
+                          },
+                          "label": {
+                            "type": "null"
+                          },
+                          "screen": {
+                            "type": "null"
+                          }
+                        },
+                        "required": [
+                          "expr"
+                        ]
+                      }
+                    ],
+                    "properties": {
+                      "expr": {
+                        "anyOf": [
+                          {
+                            "minLength": 1,
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "include": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "interval": {
+                        "minimum": 0,
+                        "type": "number"
+                      },
+                      "label": {
+                        "anyOf": [
+                          {
+                            "minLength": 1,
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "screen": {
+                        "anyOf": [
+                          {
+                            "minLength": 1,
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "state_profile": {
+                        "enum": [
+                          "minimal",
+                          "interaction",
+                          "debug",
+                          "full"
+                        ],
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  }
+                },
+                "required": [
+                  "wait"
+                ],
+                "type": "object"
+              },
+              {
+                "additionalProperties": false,
+                "properties": {
+                  "assert": {
+                    "oneOf": [
+                      {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      {
+                        "additionalProperties": false,
+                        "properties": {
+                          "equals": {},
+                          "expr": {
+                            "minLength": 1,
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "expr"
+                        ],
+                        "type": "object"
+                      }
+                    ]
+                  },
+                  "step_timeout": {
+                    "minimum": 0,
+                    "type": "number"
+                  },
+                  "timeout": {
+                    "minimum": 0,
+                    "type": "number"
+                  }
+                },
+                "required": [
+                  "assert"
+                ],
+                "type": "object"
+              },
+              {
+                "additionalProperties": false,
+                "properties": {
+                  "select_choice": {
+                    "oneOf": [
+                      {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      {
+                        "additionalProperties": false,
+                        "oneOf": [
+                          {
+                            "properties": {
+                              "index": {
+                                "anyOf": [
+                                  {
+                                    "type": "null"
+                                  },
+                                  {
+                                    "const": -1
+                                  }
+                                ]
+                              },
+                              "text": {
+                                "minLength": 1,
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "text"
+                            ]
+                          },
+                          {
+                            "properties": {
+                              "index": {
+                                "minimum": 0,
+                                "type": "integer"
+                              },
+                              "text": {
+                                "anyOf": [
+                                  {
+                                    "type": "null"
+                                  },
+                                  {
+                                    "const": ""
+                                  }
+                                ]
+                              }
+                            },
+                            "required": [
+                              "index"
+                            ]
+                          }
+                        ],
+                        "properties": {
+                          "index": {
+                            "anyOf": [
+                              {
+                                "minimum": 0,
+                                "type": "integer"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "text": {
+                            "anyOf": [
+                              {
+                                "minLength": 1,
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          }
+                        },
+                        "type": "object"
+                      }
+                    ]
+                  },
+                  "step_timeout": {
+                    "minimum": 0,
+                    "type": "number"
+                  },
+                  "timeout": {
+                    "minimum": 0,
+                    "type": "number"
+                  }
+                },
+                "required": [
+                  "select_choice"
+                ],
+                "type": "object"
+              },
+              {
+                "additionalProperties": false,
+                "properties": {
+                  "capture": {
+                    "oneOf": [
+                      {
+                        "not": {
+                          "enum": [
+                            ".",
+                            ".."
+                          ]
+                        },
+                        "pattern": "^[A-Za-z0-9_.-]{1,80}$",
+                        "type": "string"
+                      },
+                      {
+                        "additionalProperties": false,
+                        "properties": {
+                          "name": {
+                            "not": {
+                              "enum": [
+                                ".",
+                                ".."
+                              ]
+                            },
+                            "pattern": "^[A-Za-z0-9_.-]{1,80}$",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      }
+                    ]
+                  },
+                  "step_timeout": {
+                    "minimum": 0,
+                    "type": "number"
+                  },
+                  "timeout": {
+                    "minimum": 0,
+                    "type": "number"
+                  }
+                },
+                "required": [
+                  "capture"
+                ],
+                "type": "object"
+              },
+              {
+                "additionalProperties": false,
+                "properties": {
+                  "save": {
+                    "oneOf": [
+                      {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      {
+                        "additionalProperties": false,
+                        "properties": {
+                          "slot": {
+                            "minLength": 1,
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "slot"
+                        ],
+                        "type": "object"
+                      }
+                    ]
+                  },
+                  "step_timeout": {
+                    "minimum": 0,
+                    "type": "number"
+                  },
+                  "timeout": {
+                    "minimum": 0,
+                    "type": "number"
+                  }
+                },
+                "required": [
+                  "save"
+                ],
+                "type": "object"
+              },
+              {
+                "additionalProperties": false,
+                "properties": {
+                  "load": {
+                    "oneOf": [
+                      {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      {
+                        "additionalProperties": false,
+                        "properties": {
+                          "slot": {
+                            "minLength": 1,
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "slot"
+                        ],
+                        "type": "object"
+                      }
+                    ]
+                  },
+                  "step_timeout": {
+                    "minimum": 0,
+                    "type": "number"
+                  },
+                  "timeout": {
+                    "minimum": 0,
+                    "type": "number"
+                  }
+                },
+                "required": [
+                  "load"
+                ],
+                "type": "object"
+              },
+              {
+                "additionalProperties": false,
+                "properties": {
+                  "control": {
+                    "oneOf": [
+                      {
+                        "enum": [
+                          "advance",
+                          "rollback",
+                          "toggle_skip",
+                          "toggle_auto",
+                          "toggle_afm",
+                          "game_menu",
+                          "hide_windows",
+                          "quick_save",
+                          "quick_load",
+                          "reload_script",
+                          "restart_interaction",
+                          "quit"
+                        ],
+                        "type": "string"
+                      },
+                      {
+                        "additionalProperties": false,
+                        "properties": {
+                          "action": {
+                            "enum": [
+                              "advance",
+                              "rollback",
+                              "toggle_skip",
+                              "toggle_auto",
+                              "toggle_afm",
+                              "game_menu",
+                              "hide_windows",
+                              "quick_save",
+                              "quick_load",
+                              "reload_script",
+                              "restart_interaction",
+                              "quit"
+                            ],
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "action"
+                        ],
+                        "type": "object"
+                      }
+                    ]
+                  },
+                  "step_timeout": {
+                    "minimum": 0,
+                    "type": "number"
+                  },
+                  "timeout": {
+                    "minimum": 0,
+                    "type": "number"
+                  }
+                },
+                "required": [
+                  "control"
+                ],
+                "type": "object"
+              },
+              {
+                "additionalProperties": false,
+                "properties": {
+                  "send_input": {
+                    "additionalProperties": false,
+                    "oneOf": [
+                      {
+                        "properties": {
+                          "key": {
+                            "type": "null"
+                          },
+                          "scroll": {
+                            "type": "null"
+                          },
+                          "text": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "text"
+                        ]
+                      },
+                      {
+                        "properties": {
+                          "key": {
+                            "minLength": 1,
+                            "type": "string"
+                          },
+                          "scroll": {
+                            "type": "null"
+                          },
+                          "submit": {
+                            "const": false
+                          },
+                          "text": {
+                            "type": "null"
+                          }
+                        },
+                        "required": [
+                          "key"
+                        ]
+                      },
+                      {
+                        "properties": {
+                          "key": {
+                            "type": "null"
+                          },
+                          "scroll": {
+                            "additionalProperties": false,
+                            "properties": {
+                              "amount": {
+                                "minimum": 1,
+                                "type": "integer"
+                              },
+                              "direction": {
+                                "enum": [
+                                  "up",
+                                  "down"
+                                ],
+                                "type": "string"
+                              },
+                              "x": {
+                                "type": "number"
+                              },
+                              "y": {
+                                "type": "number"
+                              }
+                            },
+                            "required": [
+                              "x",
+                              "y",
+                              "direction"
+                            ],
+                            "type": "object"
+                          },
+                          "submit": {
+                            "const": false
+                          },
+                          "text": {
+                            "type": "null"
+                          }
+                        },
+                        "required": [
+                          "scroll"
+                        ]
+                      }
+                    ],
+                    "properties": {
+                      "key": {
+                        "anyOf": [
+                          {
+                            "minLength": 1,
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "scroll": {
+                        "anyOf": [
+                          {
+                            "additionalProperties": false,
+                            "properties": {
+                              "amount": {
+                                "minimum": 1,
+                                "type": "integer"
+                              },
+                              "direction": {
+                                "enum": [
+                                  "up",
+                                  "down"
+                                ],
+                                "type": "string"
+                              },
+                              "x": {
+                                "type": "number"
+                              },
+                              "y": {
+                                "type": "number"
+                              }
+                            },
+                            "required": [
+                              "x",
+                              "y",
+                              "direction"
+                            ],
+                            "type": "object"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "submit": {
+                        "type": "boolean"
+                      },
+                      "text": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "step_timeout": {
+                    "minimum": 0,
+                    "type": "number"
+                  },
+                  "timeout": {
+                    "minimum": 0,
+                    "type": "number"
+                  }
+                },
+                "required": [
+                  "send_input"
+                ],
+                "type": "object"
+              }
+            ]
+          },
+          "type": "array"
+        },
+        "stop_on_failure": {
+          "default": true,
+          "description": "Abort remaining steps when one step fails.",
+          "type": "boolean"
+        },
+        "timeout": {
+          "default": 30.0,
+          "description": "Total finite wall-time budget from 0 through 600 seconds.",
+          "maximum": 600,
+          "minimum": 0,
+          "type": "number"
+        }
+      },
+      "required": [
+        "project_path",
+        "steps"
+      ],
+      "type": "object"
+    }
+  },
+  "renforge_saves": {
+    "annotations": {
+      "destructiveHint": true,
+      "idempotentHint": false,
+      "openWorldHint": true,
+      "readOnlyHint": false
+    },
+    "description": "List, load, or save named slots in a single command family. `list` is read-only; `load` replaces live state and `save` can overwrite the chosen slot. Verify slot names before mutating gameplay progress. `load` requires `authorize=true` when `RENFORGE_POLICY=enforce`.",
+    "parameters": {
+      "additionalProperties": false,
+      "oneOf": [
+        {
+          "properties": {
+            "action": {
+              "const": "save"
+            },
+            "regexp": {
+              "type": "null"
+            },
+            "slot": {
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          "required": [
+            "action",
+            "slot"
+          ]
+        },
+        {
+          "properties": {
+            "action": {
+              "const": "load"
+            },
+            "extra_info": {
+              "type": "null"
+            },
+            "regexp": {
+              "type": "null"
+            },
+            "slot": {
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          "required": [
+            "action",
+            "slot"
+          ]
+        },
+        {
+          "properties": {
+            "action": {
+              "const": "list"
+            },
+            "extra_info": {
+              "type": "null"
+            },
+            "slot": {
+              "type": "null"
+            }
+          },
+          "required": [
+            "action"
+          ]
+        }
+      ],
+      "properties": {
+        "action": {
+          "description": "One of `list`, `load`, or `save`.",
+          "enum": [
+            "save",
+            "load",
+            "list"
+          ],
+          "type": "string"
+        },
+        "authorize": {
+          "default": false,
+          "description": "Explicitly authorize `load` when `RENFORGE_POLICY=enforce`; ignored for list/save.",
+          "type": "boolean"
+        },
+        "extra_info": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Optional save metadata for save actions."
+        },
+        "project_path": {
+          "description": "Project root of the running live game.",
+          "type": "string"
+        },
+        "regexp": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Optional regex filter for list only, selecting matching slots."
+        },
+        "slot": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Slot label used by save/load actions."
+        }
+      },
+      "required": [
+        "project_path",
+        "action"
+      ],
+      "type": "object"
+    }
+  },
+  "renforge_scan_project": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true
+    },
+    "description": "Search project scripts with bounded output. Use `sections`, `file_glob`, and `symbol` for focused indexing, then paginate with `offset` and `limit` for stable batches.",
+    "parameters": {
+      "additionalProperties": false,
+      "properties": {
+        "file_glob": {
+          "default": "",
+          "description": "Optional filename glob filter for targeted scan files.",
+          "type": "string"
+        },
+        "limit": {
+          "default": 200,
+          "description": "Maximum items per page. Keep values bounded to avoid large payloads.",
+          "maximum": 1000,
+          "minimum": 1,
+          "type": "integer"
+        },
+        "offset": {
+          "default": 0,
+          "description": "Zero-based pagination offset for scan results.",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "project_path": {
+          "description": "Project root to index for static analysis.",
+          "type": "string"
+        },
+        "sections": {
+          "anyOf": [
+            {
+              "items": {
+                "enum": [
+                  "files",
+                  "variables",
+                  "graph",
+                  "labels",
+                  "jumps",
+                  "calls",
+                  "menus",
+                  "characters",
+                  "images",
+                  "unresolved_targets"
+                ],
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Optional sections: `files`, `variables`, `graph`, `labels`, `jumps`, `calls`, `menus`, `characters`, `images`, and `unresolved_targets`.",
+          "items": {
+            "enum": [
+              "files",
+              "variables",
+              "graph",
+              "labels",
+              "jumps",
+              "calls",
+              "menus",
+              "characters",
+              "images",
+              "unresolved_targets"
+            ],
+            "type": "string"
+          }
+        },
+        "symbol": {
+          "default": "",
+          "description": "Filter matches for this symbol; empty keeps section-wide scan.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "project_path"
+      ],
+      "type": "object"
+    }
+  },
+  "renforge_scene_tree": {
+    "annotations": {
+      "destructiveHint": true,
+      "idempotentHint": false,
+      "openWorldHint": false,
+      "readOnlyHint": false
+    },
+    "description": "Read the full scene graph (logical scene data). Unlike `renforge_list_ui_elements` this is broad and includes non-focusable nodes, so use it for full-tree inspection when semantic selectors are ambiguous. `save_as` or `diff_against` may create `.renforge/scenes/`; `save_as` writes and overwrites the named JSON snapshot. Omit both options for read-only inspection.",
+    "parameters": {
+      "additionalProperties": false,
+      "properties": {
+        "detail": {
+          "default": "semantic",
+          "description": "Detail granularity (`semantic`, `layout`, or `raw`) for scene nodes.",
+          "enum": [
+            "semantic",
+            "layout",
+            "raw"
+          ],
+          "type": "string"
+        },
+        "diff_against": {
+          "default": "",
+          "description": "Optional snapshot name for diff context; compare against existing `.renforge/scenes/<name>.json` entry.",
+          "pattern": "^$|^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$",
+          "type": "string"
+        },
+        "format": {
+          "default": "json",
+          "description": "Return format (`json` or `wireframe`).",
+          "enum": [
+            "json",
+            "wireframe"
+          ],
+          "type": "string"
+        },
+        "ids": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Optional element id filters."
+        },
+        "include": {
+          "anyOf": [
+            {
+              "items": {
+                "enum": [
+                  "color",
+                  "style",
+                  "overflow"
+                ],
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Optional expensive node properties: `color`, `style`, and `overflow`.",
+          "items": {
+            "enum": [
+              "color",
+              "style",
+              "overflow"
+            ],
+            "type": "string"
+          }
+        },
+        "layers": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Optional layer filters."
+        },
+        "max_items": {
+          "default": 50,
+          "description": "Maximum total nodes, from 1 through 10000.",
+          "maximum": 10000,
+          "minimum": 1,
+          "type": "integer"
+        },
+        "max_output_bytes": {
+          "default": 65536,
+          "description": "Payload cap, from 64 through 2000000 bytes.",
+          "maximum": 2000000,
+          "minimum": 64,
+          "type": "integer"
+        },
+        "max_output_depth": {
+          "default": 6,
+          "description": "Maximum traversal depth before truncation, from 0 through 20.",
+          "maximum": 20,
+          "minimum": 0,
+          "type": "integer"
+        },
+        "project_path": {
+          "description": "Project root with active live session.",
+          "type": "string"
+        },
+        "save_as": {
+          "default": "",
+          "description": "Optional snapshot name saved under `.renforge/scenes/<name>.json`; reusing a name overwrites it.",
+          "pattern": "^$|^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$",
+          "type": "string"
+        },
+        "screen": {
+          "default": "",
+          "description": "Optional active screen filter.",
+          "type": "string"
+        },
+        "types": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Optional node type filters."
+        }
+      },
+      "required": [
+        "project_path"
+      ],
+      "type": "object"
+    }
+  },
+  "renforge_screenshot": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true
+    },
+    "description": "Capture the current live frame and return an in-memory image response (no persistent file write). Use this to inspect UI state before clicks or scenario actions.",
+    "parameters": {
+      "additionalProperties": false,
+      "properties": {
+        "crop_height": {
+          "default": 0,
+          "description": "Crop height; 0 disables cropping in Y.",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "crop_width": {
+          "default": 0,
+          "description": "Crop width; 0 disables cropping in X.",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "crop_x": {
+          "default": 0,
+          "description": "Crop origin x in logical coordinates.",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "crop_y": {
+          "default": 0,
+          "description": "Crop origin y in logical coordinates.",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "crosshair_x": {
+          "default": -1,
+          "description": "Crosshair x coordinate; both x/y must be set together.",
+          "minimum": -1,
+          "type": "integer"
+        },
+        "crosshair_y": {
+          "default": -1,
+          "description": "Crosshair y coordinate; both x/y must be set together.",
+          "minimum": -1,
+          "type": "integer"
+        },
+        "grid": {
+          "default": 0,
+          "description": "Guide overlay grid spacing in pixels.",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "height": {
+          "default": 0,
+          "description": "Target capture height. Set one axis and keep aspect ratio via runtime logic.",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "project_path": {
+          "description": "Project root with active live session.",
+          "type": "string"
+        },
+        "rulers": {
+          "default": false,
+          "description": "Draw rulers along frame edges for measurement.",
+          "type": "boolean"
+        },
+        "scale": {
+          "default": 1.0,
+          "description": "Scale factor applied after crop/resize.",
+          "maximum": 16.0,
+          "minimum": 0.1,
+          "type": "number"
+        },
+        "width": {
+          "default": 0,
+          "description": "Target capture width. Set one axis and keep aspect ratio via runtime logic.",
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "project_path"
+      ],
+      "type": "object"
+    }
+  },
+  "renforge_search_docs": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": true,
+      "readOnlyHint": false
+    },
+    "description": "Search local Ren'Py documentation snippets by keyword before opening results. Use this to identify canonical topic IDs before `renforge_get_doc`. This may download and cache the SDK when docs are not already available.",
+    "parameters": {
+      "additionalProperties": false,
+      "properties": {
+        "query": {
+          "description": "Search query for Ren'Py documentation corpus.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "query"
+      ],
+      "type": "object"
+    }
+  },
+  "renforge_select_choice": {
+    "annotations": {
+      "destructiveHint": true,
+      "idempotentHint": false,
+      "openWorldHint": true,
+      "readOnlyHint": false
+    },
+    "description": "Select a menu choice by case-insensitive text or zero-based index. Text matching prefers an exact match, then uses the shortest case-insensitive substring match. Use list output first to avoid ambiguous partial text.",
+    "parameters": {
+      "additionalProperties": false,
+      "oneOf": [
+        {
+          "properties": {
+            "index": {
+              "anyOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "const": -1
+                }
+              ]
+            },
+            "text": {
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          "required": [
+            "text"
+          ]
+        },
+        {
+          "properties": {
+            "index": {
+              "minimum": 0,
+              "type": "integer"
+            },
+            "text": {
+              "anyOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "const": ""
+                }
+              ]
+            }
+          },
+          "required": [
+            "index"
+          ]
+        }
+      ],
+      "properties": {
+        "index": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Zero-based choice index fallback when text is omitted."
+        },
+        "project_path": {
+          "description": "Project root of the running live session.",
+          "type": "string"
+        },
+        "text": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Visible text to match; preferred over index."
+        }
+      },
+      "required": [
+        "project_path"
+      ],
+      "type": "object"
+    }
+  },
+  "renforge_send_input": {
+    "annotations": {
+      "destructiveHint": true,
+      "idempotentHint": false,
+      "openWorldHint": true,
+      "readOnlyHint": false
+    },
+    "description": "Send exactly one input command path (text, key, or scroll object) into the live game. Keep calls scoped and single-purpose; for deterministic workflows prefer one action per invocation.",
+    "parameters": {
+      "additionalProperties": false,
+      "oneOf": [
+        {
+          "properties": {
+            "key": {
+              "type": "null"
+            },
+            "scroll": {
+              "type": "null"
+            },
+            "text": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "text"
+          ]
+        },
+        {
+          "properties": {
+            "key": {
+              "minLength": 1,
+              "type": "string"
+            },
+            "scroll": {
+              "type": "null"
+            },
+            "submit": {
+              "const": false
+            },
+            "text": {
+              "type": "null"
+            }
+          },
+          "required": [
+            "key"
+          ]
+        },
+        {
+          "properties": {
+            "key": {
+              "type": "null"
+            },
+            "scroll": {
+              "additionalProperties": false,
+              "properties": {
+                "amount": {
+                  "minimum": 1,
+                  "type": "integer"
+                },
+                "direction": {
+                  "enum": [
+                    "up",
+                    "down"
+                  ],
+                  "type": "string"
+                },
+                "x": {
+                  "type": "number"
+                },
+                "y": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "x",
+                "y",
+                "direction"
+              ],
+              "type": "object"
+            },
+            "submit": {
+              "const": false
+            },
+            "text": {
+              "type": "null"
+            }
+          },
+          "required": [
+            "scroll"
+          ]
+        }
+      ],
+      "properties": {
+        "key": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Readable named key such as `enter`, `esc`, an arrow, `pageup`, `pagedown`, `backspace`, `delete`, `home`, `end`, `space`, `tab`, or a function key."
+        },
+        "project_path": {
+          "description": "Project root with active live session.",
+          "type": "string"
+        },
+        "scroll": {
+          "anyOf": [
+            {
+              "additionalProperties": false,
+              "properties": {
+                "amount": {
+                  "minimum": 1,
+                  "type": "integer"
+                },
+                "direction": {
+                  "enum": [
+                    "up",
+                    "down"
+                  ],
+                  "type": "string"
+                },
+                "x": {
+                  "type": "number"
+                },
+                "y": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "x",
+                "y",
+                "direction"
+              ],
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Logical-coordinate object `{\"x\": number, \"y\": number, \"direction\": \"up\"|\"down\", \"amount\": integer?}`."
+        },
+        "submit": {
+          "default": false,
+          "description": "Press Enter after injected text; only valid with text input, not key or scroll.",
+          "type": "boolean"
+        },
+        "text": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Text to inject as character-by-character text input."
+        }
+      },
+      "required": [
+        "project_path"
+      ],
+      "type": "object"
+    }
+  },
+  "renforge_set_var": {
+    "annotations": {
+      "destructiveHint": true,
+      "idempotentHint": false,
+      "openWorldHint": true,
+      "readOnlyHint": false
+    },
+    "description": "Write a game variable directly in the live store namespace. This mutates state immediately and should be used after validating the current state snapshot.",
+    "parameters": {
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "description": "Variable name to set.",
+          "type": "string"
+        },
+        "project_path": {
+          "description": "Project root with active live session.",
+          "type": "string"
+        },
+        "value": {
+          "description": "Value to write to the variable (JSON-compatible serializable object)."
+        }
+      },
+      "required": [
+        "project_path",
+        "name",
+        "value"
+      ],
+      "type": "object"
+    }
+  },
+  "renforge_stop": {
+    "annotations": {
+      "destructiveHint": true,
+      "idempotentHint": false,
+      "openWorldHint": false,
+      "readOnlyHint": false
+    },
+    "description": "Stop the live runtime and cleanup the launch/session state. Running games may be interrupted, and active quick-save/lock state should be considered volatile after stop.",
+    "parameters": {
+      "additionalProperties": false,
+      "properties": {
+        "project_path": {
+          "description": "Project root whose active launch should be stopped.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "project_path"
+      ],
+      "type": "object"
+    }
+  },
+  "renforge_translation_stats": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": true,
+      "readOnlyHint": false
+    },
+    "description": "Compute missing/covered translation stats for a language before generation. Run this first, then gate calls to translation generation. This may download and cache the required SDK before analysis.",
+    "parameters": {
+      "additionalProperties": false,
+      "properties": {
+        "language": {
+          "description": "Language code or name under `game/tl/`.",
+          "type": "string"
+        },
+        "project_path": {
+          "description": "Project root to analyze.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "project_path",
+        "language"
+      ],
+      "type": "object"
+    }
+  },
+  "renforge_wait_until": {
+    "annotations": {
+      "destructiveHint": true,
+      "idempotentHint": false,
+      "openWorldHint": true,
+      "readOnlyHint": false
+    },
+    "description": "Wait for one stable condition (`label`, `screen`, or `expr`). Prefer `label` or `screen` when possible; `expr` is arbitrary Python evaluated repeatedly in the store namespace and may mutate game state, access the filesystem, start processes, or use the network with the game process's permissions. Keep timeout bounded.",
+    "parameters": {
+      "additionalProperties": false,
+      "oneOf": [
+        {
+          "properties": {
+            "expr": {
+              "type": "null"
+            },
+            "label": {
+              "minLength": 1,
+              "type": "string"
+            },
+            "screen": {
+              "type": "null"
+            }
+          },
+          "required": [
+            "label"
+          ]
+        },
+        {
+          "properties": {
+            "expr": {
+              "type": "null"
+            },
+            "label": {
+              "type": "null"
+            },
+            "screen": {
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          "required": [
+            "screen"
+          ]
+        },
+        {
+          "properties": {
+            "expr": {
+              "minLength": 1,
+              "type": "string"
+            },
+            "label": {
+              "type": "null"
+            },
+            "screen": {
+              "type": "null"
+            }
+          },
+          "required": [
+            "expr"
+          ]
+        }
+      ],
+      "properties": {
+        "expr": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Expression condition to evaluate and await success. Evaluated repeatedly during waiting."
+        },
+        "include": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Optional fields to include in compact state output."
+        },
+        "interval": {
+          "default": 0.5,
+          "description": "Polling interval in seconds.",
+          "minimum": 0,
+          "type": "number"
+        },
+        "label": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Target label to wait for; provide either label, screen, or expression."
+        },
+        "max_depth": {
+          "default": 3,
+          "description": "Maximum object nesting depth in compact state, from 0 through 20.",
+          "maximum": 20,
+          "minimum": 0,
+          "type": "integer"
+        },
+        "max_items": {
+          "default": 50,
+          "description": "Maximum list/map items in compact state, from 1 through 10000.",
+          "maximum": 10000,
+          "minimum": 1,
+          "type": "integer"
+        },
+        "max_output_bytes": {
+          "default": 8192,
+          "description": "Payload cap for the result, from 64 through 2000000 bytes.",
+          "maximum": 2000000,
+          "minimum": 64,
+          "type": "integer"
+        },
+        "project_path": {
+          "description": "Project root with active live session.",
+          "type": "string"
+        },
+        "screen": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Target screen name to wait for."
+        },
+        "state_profile": {
+          "default": "interaction",
+          "description": "Returned state shape: `minimal`, `interaction`, `debug`, or `full`.",
+          "enum": [
+            "minimal",
+            "interaction",
+            "debug",
+            "full"
+          ],
+          "type": "string"
+        },
+        "timeout": {
+          "default": 30.0,
+          "description": "Maximum wait time, a finite value between 0 and 120 seconds.",
+          "maximum": 120,
+          "minimum": 0,
+          "type": "number"
+        }
+      },
+      "required": [
+        "project_path"
+      ],
+      "type": "object"
+    }
+  },
+  "renforge_web_build": {
+    "annotations": {
+      "destructiveHint": true,
+      "idempotentHint": false,
+      "openWorldHint": true,
+      "readOnlyHint": false
+    },
+    "description": "Run the Ren'Py web build pipeline and write browser assets. It may download/cache the Ren'Py SDK, but requires the separately installed Web DLC and does not download external toolchains or the Web DLC. Destination controls output.",
+    "parameters": {
+      "additionalProperties": false,
+      "properties": {
+        "destination": {
+          "default": "",
+          "description": "Optional output directory override.",
+          "type": "string"
+        },
+        "project_path": {
+          "description": "Project root for build output.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "project_path"
+      ],
+      "type": "object"
+    }
+  }
+}

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -94,6 +94,8 @@ EXPECTED_TOOLS = {
     "renforge_diff_screenshots",
     "renforge_scene_tree",
     "renforge_measure",
+    "renforge_hit_test",
+    "renforge_run_scenario",
     "renforge_autopilot",
     # assets / translation / build / docs
     "renforge_assets",
@@ -230,13 +232,16 @@ def test_game_state_compact_prefix_selection_enforces_all_output_limits(
 
 
 def test_create_app_registers_expected_tools() -> None:
+    from renforge.tool_definitions import TOOL_DEFINITIONS
+
     app = create_app()
     if isinstance(app, _FallbackServer):
         pytest.skip("MCP backend (mcp/fastmcp) not installed")
 
     tools = asyncio.run(app.list_tools())
-    names = {tool.name for tool in tools}
-    assert EXPECTED_TOOLS <= names
+    names = {tool.name for tool in tools if tool.name.startswith("renforge_")}
+    assert len(EXPECTED_TOOLS) == 54
+    assert EXPECTED_TOOLS == set(TOOL_DEFINITIONS) == names
     instructions = getattr(app, "instructions", "") or ""
     assert "renforge_info" in instructions or not hasattr(app, "instructions")
     for tool in ("renforge_control", "renforge_wait_until", "renforge_get_errors"):

--- a/tests/test_tool_registration.py
+++ b/tests/test_tool_registration.py
@@ -1,13 +1,17 @@
 import asyncio
-import hashlib
 import inspect
 import json
+from pathlib import Path
 
 from renforge.server import create_app
 from renforge.tool_definitions import TOOL_DEFINITIONS
 from renforge.tool_registration import DOMAIN_MODULES
 from renforge.tool_registration.registry import ToolRegistrar
 from renforge.tool_registration.wrappers import build_tool_wrappers
+
+CONTRACT_SNAPSHOT = (
+    Path(__file__).resolve().parent / "snapshots" / "mcp_public_tool_contract.json"
+)
 
 
 class _MetadataToolRegistry:
@@ -79,13 +83,8 @@ def test_server_bootstrap_no_longer_owns_tool_wrapper_bodies() -> None:
 
 def test_public_tool_contract_matches_agent_safe_baseline() -> None:
     contract = _public_contract()
-    payload = json.dumps(
-        contract,
-        sort_keys=True,
-        separators=(",", ":"),
-    ).encode("utf-8")
+    snapshot = json.loads(CONTRACT_SNAPSHOT.read_text(encoding="utf-8"))
 
     assert len(contract) == 54
-    assert hashlib.sha256(payload).hexdigest() == (
-        "0fe4c481efd5f410ef2b5d6d934862349aef730e4439e10741e8737432b029cc"
-    )
+    assert set(contract) == set(TOOL_DEFINITIONS)
+    assert contract == snapshot


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The MCP tool-registration refactor requested in #87 already landed on `main` through #93 stacked into #85. GitHub did not auto-close #87 because #93 merged into the `#85` feature branch rather than the default branch.

This follow-up, prepared in a separate worktree, documents that layout and makes the public-API freeze reviewable:

- document `tool_registration/` in `docs/ARCHITECTURE.md` and `CONTRIBUTING.md`
- record the refactor in `CHANGELOG.md` (public 54-tool API unchanged)
- require all 54 tool names in `EXPECTED_TOOLS` (`renforge_hit_test`, `renforge_run_scenario` were missing)
- replace the opaque SHA-256 contract digest with `tests/snapshots/mcp_public_tool_contract.json`

## Motivation and related issue

Fixes #87

## Changes

- Architecture and contributing docs now describe domain modules, `ToolRegistrar` cloning, and fail-closed drift checks.
- Contract test compares the live FastMCP catalog to a committed schema snapshot so accidental API changes show up in the diff.
- Server registration test asserts the 54 `renforge_*` names match `TOOL_DEFINITIONS`.

## Validation

- `python -m compileall src tests`: passed
- `python -m pytest -q tests/test_tool_definitions.py tests/test_tool_registration.py tests/test_server.py`: **73 passed**
- `python -m pytest -q -m "not live"`: 872 passed, 48 skipped; 38 failures are pre-existing on `main` in this environment (editor CAS across filesystems, i18n scanner, and a `/tmp/` path assertion when the repo lives under a worktree)
- `npm --prefix ui run build`: Not applicable (no UI change)
- Manual verification: confirmed `register_all_tools` already splits 54 wrappers across seven domain modules and `server.py` no longer owns wrapper bodies

## User-facing changes

None. Registration internals and tests only; MCP tool names, schemas, and behavior are unchanged.

## Internationalization

- [x] New user-visible copy uses i18n keys, or this PR adds no user-visible copy.
- [x] `npm --prefix ui run i18n:check` passes, or i18n is not applicable.

## Breaking changes

None

## Documentation

- `docs/ARCHITECTURE.md`: code layout + MCP tool registration section
- `CONTRIBUTING.md`: steps for adding or changing an MCP tool
- `CHANGELOG.md`: Unreleased / Changed

## Reviewer notes

#93 already implemented the acceptance criteria (domain modules, `ToolRegistrar`, fail-closed drift, non-mutation of wrapper annotations, FastMCP fallback tests). This PR closes the issue and replaces the hash-only freeze with a snapshot, which is what the issue asked for.

## Final checklist

- [x] The PR is focused on one coherent change.
- [x] Tests were added or updated for behavior changes.
- [x] Generated `src/renforge/ui/static/` assets remain untracked; CI and release builds produce them.
- [x] No credentials, tokens, personal paths, or other secrets are included.
- [x] I understand the submitted code and can explain how it works.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f92757e2-497c-4b5d-b749-5fe23d9f17bc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f92757e2-497c-4b5d-b749-5fe23d9f17bc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Résumé par Sourcery

Documenter l’architecture d’enregistrement des outils MCP et faire respecter le contrat public figé de 54 outils via des tests et un snapshot JSON.

Documentation :
- Ajouter une documentation d’architecture pour la disposition et les responsabilités de l’enregistrement des outils MCP.
- Mettre à jour les directives de contribution avec les étapes pour ajouter ou modifier des outils MCP et maintenir la cohérence du contrat.
- Consigner le refactoring de l’enregistrement des outils MCP et l’état du contrat dans le changelog sans modifier l’API publique.

Tests :
- Remplacer la vérification du contrat public des outils MCP basée sur un hash par une comparaison avec un snapshot JSON couvrant les 54 outils.
- Rendre les tests d’enregistrement du serveur plus stricts afin que les 54 noms d’outils `renforge_*` attendus doivent correspondre au catalogue canonique `TOOL_DEFINITIONS`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documenter l’architecture d’enregistrement des outils MCP et faire respecter le contrat public figé de 54 outils via des tests basés sur des snapshots et des vérifications d’enregistrement serveur plus strictes.

Documentation :
- Décrire la structure d’enregistrement des outils MCP, les modules de domaine et le comportement de `ToolRegistrar` dans `ARCHITECTURE.md`.
- Ajouter dans `CONTRIBUTING.md` des indications pour les contributeurs sur l’ajout ou la modification d’outils MCP, y compris le contrat, les wrappers et les tests.
- Consigner dans `CHANGELOG.md` le remaniement de l’enregistrement des outils MCP et l’API inchangée des 54 outils.

Tests :
- Remplacer la vérification du contrat public des outils MCP basée sur un hash par une comparaison de snapshot JSON couvrant les 54 outils.
- Rendre les tests d’enregistrement du serveur plus stricts afin que les 54 noms d’outils `renforge_*` correspondent à `TOOL_DEFINITIONS` et au catalogue FastMCP en production.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Document MCP tool registration architecture and enforce the frozen 54-tool public contract via snapshot-based tests and stricter server registration checks.

Documentation:
- Describe MCP tool registration layout, domain modules, and ToolRegistrar behavior in ARCHITECTURE.md.
- Add contributor guidance for adding or changing MCP tools, including contract, wrappers, and tests, in CONTRIBUTING.md.
- Record the MCP tool registration refactor and unchanged 54-tool API in CHANGELOG.md.

Tests:
- Replace hash-based public MCP tool contract verification with a JSON snapshot comparison covering all 54 tools.
- Tighten server registration tests so the 54 renforge_* tool names must match TOOL_DEFINITIONS and the live FastMCP catalog.

</details>

</details>