### PR TITLE
refactor: stop rewriting Ren'Py SDK source during graph inspection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,15 @@ versioning.
   blocks destructive and open-world operations unless `authorize=true` or an
   allowlist permits them. See [docs/POLICY.md](docs/POLICY.md).
 
+### Changed
+
+- Graph inspection no longer rewrites `renpy/dump.py` inside a discovered or
+  cached Ren'Py SDK. `compile --json-dump` injects an isolated `.rpe.py`
+  adapter via `RENPY_SEARCHPATH` so Node-keyed `script.namemap` labels on
+  Ren'Py 8.5 are emitted without mutating shared or read-only SDK files.
+  String-keyed dumps stay unchanged. See
+  [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md).
+
 ## [0.7.0] - 2026-08-11
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,10 @@ versioning.
 
 - Graph inspection no longer rewrites `renpy/dump.py` inside a discovered or
   cached Ren'Py SDK. `compile --json-dump` injects an isolated `.rpe.py`
-  adapter via `RENPY_SEARCHPATH` so Node-keyed `script.namemap` labels on
-  Ren'Py 8.5 are emitted without mutating shared or read-only SDK files.
-  String-keyed dumps stay unchanged. See
+  adapter via `RENPY_SEARCHPATH` so Node-keyed `script.namemap` labels
+  (Ren'Py 8.4.1+ / 8.5.x) are emitted without mutating shared or read-only
+  SDK files. The adapter still normalizes Node keys when upstream `dump.py`
+  already unwraps them; string-keyed namemaps stay unchanged. See
   [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md).
 - MCP tool registration is split into domain modules under
   `src/renforge/tool_registration/`. `server.py` only bootstraps the app;

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -60,7 +60,30 @@ its launcher and version are compatible. It then checks the explicit
 `RENPY_SDK_HOME` override before falling back to the managed
 `~/.cache/renforge/sdks/` cache. Missing or invalid cached SDKs are installed
 under an inter-process lock and published atomically. Override the stable
-version with `RENPY_SDK_STABLE_VERSION`.
+version with `RENPY_SDK_STABLE_VERSION`. Discovery and graph inspection never
+rewrite files under an existing or shared SDK root, including read-only
+installations.
+
+## Graph inspection and `--json-dump`
+
+Story Map uses Ren'Py's `compile --json-dump` for authoritative label
+locations. The pinned default SDK is **8.5.3**. Ren'Py 8.5 keys
+`Script.namemap` by `Node`, while 8.5.3 `renpy/dump.py` still filters with
+`isinstance(name, str)`, which drops every label. Upstream master unwraps
+`Node` keys before that check.
+
+RenForge follows that upstream fix without waiting on a new SDK release and
+without patching installed `dump.py`. Each dump subprocess loads a temporary
+`.rpe.py` adapter from `RENPY_SEARCHPATH` that wraps `renpy.dump.dump` and,
+only when keys are not already strings, presents a string-keyed namemap for
+the duration of the dump. Concurrent inspections use separate adapter
+directories and cannot race on SDK source contents.
+
+Supported dump shapes:
+
+- Ren'Py **8.5.x** Node-keyed `namemap` (including the default 8.5.3 SDK)
+- Older string-keyed dumps (Ren'Py 8.4 and earlier)
+- Future SDKs that already unwrap `Node` keys, where the adapter is a no-op
 
 ## Packaging
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -94,23 +94,30 @@ installations.
 ## Graph inspection and `--json-dump`
 
 Story Map uses Ren'Py's `compile --json-dump` for authoritative label
-locations. The pinned default SDK is **8.5.3**. Ren'Py 8.5 keys
-`Script.namemap` by `Node`, while 8.5.3 `renpy/dump.py` still filters with
-`isinstance(name, str)`, which drops every label. Upstream master unwraps
-`Node` keys before that check.
+locations. The pinned default SDK is **8.5.3**. From at least Ren'Py **8.4.1**
+through **8.5.x** and upstream master, `Script.namemap` is keyed by `Node`
+(`self.namemap[node] = node`; `Node.__hash__` / `__eq__` use `.name`).
+Released 8.5.3 `renpy/dump.py` still filters with `isinstance(name, str)`,
+which drops every label. Upstream master `dump.py` unwraps `Node` keys
+before that check; the namemap itself stays Node-keyed.
 
-RenForge follows that upstream fix without waiting on a new SDK release and
+RenForge follows that dump unwrap without waiting on a new SDK release and
 without patching installed `dump.py`. Each dump subprocess loads a temporary
 `.rpe.py` adapter from `RENPY_SEARCHPATH` that wraps `renpy.dump.dump` and,
 only when keys are not already strings, presents a string-keyed namemap for
-the duration of the dump. Concurrent inspections use separate adapter
-directories and cannot race on SDK source contents.
+the duration of the dump. Because namemap keys remain `Node` objects even
+after upstream `dump.py` is fixed, the adapter still normalizes the map on
+those SDKs. It is a no-op only when keys are already strings. Concurrent
+inspections use separate adapter directories and cannot race on SDK source
+contents.
 
 Supported dump shapes:
 
-- Ren'Py **8.5.x** Node-keyed `namemap` (including the default 8.5.3 SDK)
-- Older string-keyed dumps (Ren'Py 8.4 and earlier)
-- Future SDKs that already unwrap `Node` keys, where the adapter is a no-op
+- Node-keyed `namemap` on Ren'Py **8.4.1+** and **8.5.x** (including the
+  default 8.5.3 SDK): the adapter presents a string-keyed copy for the dump
+- String-keyed namemaps, if present: the adapter leaves the map unchanged
+- Future SDKs whose `dump.py` already unwraps `Node` keys: namemap stays
+  Node-keyed, so the adapter still normalizes it
 
 ## Packaging
 

--- a/src/renforge/dump.py
+++ b/src/renforge/dump.py
@@ -7,12 +7,23 @@ and similar attributes that are only wired up during a full display+audio init,
 which raises ``AttributeError`` before our command runs.
 
 Ren'Py's built-in ``compile --json-dump`` instead introspects the *parsed*
-script without executing init code, so it works in any headless environment. It
-yields exact ``file:line`` locations for labels, defines, screens, transforms
-and callables. The narrative *flow* graph (jumps / menus / says) comes from the
-fast regex scanner (see :mod:`renforge.scanner`); exact AST-level flow is a
-runtime concern handled later through the in-game bridge, where every
-``renpy.*`` module is fully loaded.
+script without executing a full display+audio init, so it works in any
+headless environment. It yields exact ``file:line`` locations for labels,
+defines, screens, transforms and callables. The narrative *flow* graph
+(jumps / menus / says) comes from the fast regex scanner (see
+:mod:`renforge.scanner`); exact AST-level flow is a runtime concern handled
+later through the in-game bridge, where every ``renpy.*`` module is fully
+loaded.
+
+Ren'Py 8.5 keyed ``Script.namemap`` by ``Node`` (``Node.__hash__`` /
+``__eq__`` use ``.name``) while 8.5.3 ``dump.py`` still filters with
+``isinstance(name, str)``, which drops every label. Upstream master unwraps
+``Node`` keys before that check. RenForge follows that fix in the dump
+subprocess instead of rewriting installed or cached SDK files: each
+``compile --json-dump`` injects a temporary ``.rpe.py`` adapter via
+``RENPY_SEARCHPATH``. String-keyed namemaps (Ren'Py 8.4 and earlier, and
+SDKs that already unwrap) are left unchanged. The pinned default SDK is
+8.5.3; compatible 8.5.x installs and older string-keyed SDKs are supported.
 """
 
 from __future__ import annotations
@@ -29,6 +40,60 @@ from .util.subprocess import run_command
 
 _DEFINITION_CATEGORIES = ("label", "define", "screen", "transform", "callable")
 
+JSON_DUMP_ADAPTER_FILENAME = "renforge_json_dump.rpe.py"
+
+# Executed inside the Ren'Py dump subprocess (bundled Python, no renforge
+# import). Keep this self-contained and compatible with Ren'Py 8.4+.
+JSON_DUMP_ADAPTER_SOURCE = '''# renforge json-dump adapter — unwrap Node-keyed namemap without editing SDK files
+import renpy.dump as _renforge_dump_mod
+
+if not getattr(_renforge_dump_mod.dump, "_renforge_json_dump_adapter", False):
+    _renforge_original_dump = _renforge_dump_mod.dump
+
+    def _renforge_unwrap_namemap_key(name):
+        if isinstance(name, str):
+            return name
+        return getattr(name, "name", name)
+
+    def _renforge_adapted_dump(error):
+        import renpy
+
+        script = getattr(renpy.game, "script", None)
+        namemap = getattr(script, "namemap", None) if script is not None else None
+        if not namemap:
+            return _renforge_original_dump(error)
+
+        unwrapped = {}
+        needs_unwrap = False
+        for name, node in namemap.items():
+            key = _renforge_unwrap_namemap_key(name)
+            if key is not name:
+                needs_unwrap = True
+            if isinstance(key, str):
+                unwrapped[key] = node
+
+        if not needs_unwrap:
+            return _renforge_original_dump(error)
+
+        original = script.namemap
+        script.namemap = unwrapped
+        try:
+            return _renforge_original_dump(error)
+        finally:
+            script.namemap = original
+
+    _renforge_adapted_dump._renforge_json_dump_adapter = True
+    _renforge_dump_mod.dump = _renforge_adapted_dump
+'''
+
+
+def _json_dump_searchpath_env(adapter_dir: Path) -> dict[str, str]:
+    adapter = str(adapter_dir)
+    existing = os.environ.get("RENPY_SEARCHPATH", "")
+    if existing:
+        return {"RENPY_SEARCHPATH": f"{adapter}::{existing}"}
+    return {"RENPY_SEARCHPATH": adapter}
+
 
 def run_native_dump(sdk: RenpySdk, project: RenpyProject, *, timeout: int = 180) -> dict[str, Any]:
     """Return Ren'Py's native JSON dump for ``project``.
@@ -36,25 +101,38 @@ def run_native_dump(sdk: RenpySdk, project: RenpyProject, *, timeout: int = 180)
     This compiles the project (writing ``.rpyc`` next to sources, as Ren'Py
     normally does) and introspects the parsed script. Raises ``RuntimeError``
     if Ren'Py produced no dump file.
+
+    The dump subprocess receives an isolated ``.rpe.py`` adapter on
+    ``RENPY_SEARCHPATH``. SDK files under ``sdk.root`` are never modified.
     """
-    out_fd, out_name = tempfile.mkstemp(prefix="renforge-jsondump-", suffix=".json")
-    os.close(out_fd)
-    out_path = Path(out_name)
-    out_path.unlink(missing_ok=True)  # Ren'Py writes <file>.new then renames into place.
+    with tempfile.TemporaryDirectory(prefix="renforge-dump-adapter-") as adapter_home:
+        adapter_dir = Path(adapter_home)
+        (adapter_dir / JSON_DUMP_ADAPTER_FILENAME).write_text(
+            JSON_DUMP_ADAPTER_SOURCE,
+            encoding="utf-8",
+        )
+        out_fd, out_name = tempfile.mkstemp(prefix="renforge-jsondump-", suffix=".json")
+        os.close(out_fd)
+        out_path = Path(out_name)
+        out_path.unlink(missing_ok=True)  # Ren'Py writes <file>.new then renames into place.
 
-    try:
-        command = project.renpy_command(sdk, ("compile", "--json-dump", str(out_path)))
-        result = run_command(command, timeout=timeout)
-
-        if not out_path.exists() or out_path.stat().st_size == 0:
-            raise RuntimeError(
-                "Ren'Py produced no JSON dump "
-                f"(returncode={result.returncode}, timed_out={result.timed_out}).\n"
-                f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        try:
+            command = project.renpy_command(sdk, ("compile", "--json-dump", str(out_path)))
+            result = run_command(
+                command,
+                timeout=timeout,
+                env=_json_dump_searchpath_env(adapter_dir),
             )
-        return json.loads(out_path.read_text(encoding="utf-8"))
-    finally:
-        out_path.unlink(missing_ok=True)
+
+            if not out_path.exists() or out_path.stat().st_size == 0:
+                raise RuntimeError(
+                    "Ren'Py produced no JSON dump "
+                    f"(returncode={result.returncode}, timed_out={result.timed_out}).\n"
+                    f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+                )
+            return json.loads(out_path.read_text(encoding="utf-8"))
+        finally:
+            out_path.unlink(missing_ok=True)
 
 
 def normalize_definitions(raw_dump: dict[str, Any]) -> list[dict[str, Any]]:
@@ -77,4 +155,9 @@ def normalize_definitions(raw_dump: dict[str, Any]) -> list[dict[str, Any]]:
     return definitions
 
 
-__all__ = ["run_native_dump", "normalize_definitions"]
+__all__ = [
+    "JSON_DUMP_ADAPTER_FILENAME",
+    "JSON_DUMP_ADAPTER_SOURCE",
+    "run_native_dump",
+    "normalize_definitions",
+]

--- a/src/renforge/dump.py
+++ b/src/renforge/dump.py
@@ -15,15 +15,18 @@ defines, screens, transforms and callables. The narrative *flow* graph
 later through the in-game bridge, where every ``renpy.*`` module is fully
 loaded.
 
-Ren'Py 8.5 keyed ``Script.namemap`` by ``Node`` (``Node.__hash__`` /
-``__eq__`` use ``.name``) while 8.5.3 ``dump.py`` still filters with
-``isinstance(name, str)``, which drops every label. Upstream master unwraps
-``Node`` keys before that check. RenForge follows that fix in the dump
-subprocess instead of rewriting installed or cached SDK files: each
+From at least Ren'Py 8.4.1, ``Script.namemap`` is keyed by ``Node``
+(``self.namemap[node] = node``; ``Node.__hash__`` / ``__eq__`` use
+``.name``) while 8.5.3 ``dump.py`` still filters with
+``isinstance(name, str)``, which drops every label. Upstream master
+``dump.py`` unwraps ``Node`` keys before that check; the namemap itself
+stays Node-keyed. RenForge follows that dump unwrap in the dump subprocess
+instead of rewriting installed or cached SDK files: each
 ``compile --json-dump`` injects a temporary ``.rpe.py`` adapter via
-``RENPY_SEARCHPATH``. String-keyed namemaps (Ren'Py 8.4 and earlier, and
-SDKs that already unwrap) are left unchanged. The pinned default SDK is
-8.5.3; compatible 8.5.x installs and older string-keyed SDKs are supported.
+``RENPY_SEARCHPATH``. The adapter still normalizes Node-keyed namemaps
+even when ``dump.py`` already unwraps; it is a no-op only when keys are
+already strings. The pinned default SDK is 8.5.3; compatible 8.4.1+ and
+8.5.x installs are supported.
 """
 
 from __future__ import annotations

--- a/src/renforge/sdk.py
+++ b/src/renforge/sdk.py
@@ -27,54 +27,6 @@ _VERSION_IDENTIFIER_RE: Final = re.compile(
     r"\d+\.\d+\.\d+(?:[._+-][A-Za-z0-9]+)*\Z"
 )
 
-# Ren'Py 8.5 keyed Script.namemap by Node (Node.__hash__/__eq__ use .name) but
-# left dump.py filtering with ``isinstance(name, str)``, which drops every
-# label from --json-dump. Unwrap Node keys before the type check.
-_DUMP_NAMEMAP_LOOP = (
-    "    for name, n in renpy.game.script.namemap.items():\n"
-    "        filename = n.filename\n"
-    "        line = n.linenumber\n"
-    "\n"
-    "        if not isinstance(name, str):\n"
-    "            continue\n"
-)
-_DUMP_NAMEMAP_LOOP_FIXED = (
-    "    for name, n in renpy.game.script.namemap.items():\n"
-    "        # renforge: unwrap Node-keyed namemap (Ren'Py 8.5+)\n"
-    "        if not isinstance(name, str):\n"
-    "            name = getattr(name, \"name\", name)\n"
-    "        filename = n.filename\n"
-    "        line = n.linenumber\n"
-    "\n"
-    "        if not isinstance(name, str):\n"
-    "            continue\n"
-)
-
-
-def _patch_sdk_json_dump(root: Path) -> bool:
-    """Repair label emission in a cached/downloaded Ren'Py SDK dump.py.
-
-    Returns True when the file was modified.
-    """
-    dump_path = root / "renpy" / "dump.py"
-    if not dump_path.is_file():
-        return False
-    try:
-        text = dump_path.read_text(encoding="utf-8")
-    except OSError:
-        return False
-    if "renforge: unwrap Node-keyed namemap" in text:
-        return False
-    if _DUMP_NAMEMAP_LOOP not in text:
-        return False
-    try:
-        dump_path.write_text(
-            text.replace(_DUMP_NAMEMAP_LOOP, _DUMP_NAMEMAP_LOOP_FIXED, 1),
-            encoding="utf-8",
-        )
-    except OSError:
-        return False
-    return True
 
 def _resolve_version(version: str) -> str:
     if version == "stable" or not version:
@@ -464,10 +416,13 @@ def get_or_install_sdk(
     version: str = "stable",
     *,
     project_root: Path | None = None,
-    patch_json_dump: bool = False,
 ) -> RenpySdk:
     """
     Discover or prepare a Ren'Py SDK directory.
+
+    Discovery never rewrites files under the chosen SDK root. Graph inspection
+    injects an isolated dump adapter into the ``compile --json-dump``
+    subprocess instead of patching ``renpy/dump.py``.
     """
     resolved_version = _validate_version_identifier(_resolve_version(version))
     if project_root is not None:
@@ -476,8 +431,6 @@ def get_or_install_sdk(
             resolved_version,
         )
         if local_root is not None:
-            if patch_json_dump:
-                _patch_sdk_json_dump(local_root)
             return RenpySdk(version=resolved_version, root=local_root)
 
     explicit_root = _first_valid_sdk(
@@ -485,21 +438,15 @@ def get_or_install_sdk(
         resolved_version,
     )
     if explicit_root is not None:
-        if patch_json_dump:
-            _patch_sdk_json_dump(explicit_root)
         return RenpySdk(version=resolved_version, root=explicit_root)
 
     cached_root = _first_valid_sdk(_cache_candidates(resolved_version), resolved_version)
     if cached_root is not None:
-        if patch_json_dump:
-            _patch_sdk_json_dump(cached_root)
         return RenpySdk(version=resolved_version, root=cached_root)
 
     with _sdk_install_lock(resolved_version):
         cached_root = _first_valid_sdk(_cache_candidates(resolved_version), resolved_version)
         if cached_root is not None:
-            if patch_json_dump:
-                _patch_sdk_json_dump(cached_root)
             return RenpySdk(version=resolved_version, root=cached_root)
 
         cache_root = _managed_cache_child(_cache_version_dir(resolved_version))
@@ -518,8 +465,6 @@ def get_or_install_sdk(
                 raise ValueError(
                     f"Downloaded Ren'Py SDK is invalid or incompatible with {resolved_version}."
                 )
-            if patch_json_dump:
-                _patch_sdk_json_dump(discovered_root)
 
             quarantine = _managed_cache_child(
                 cache_root.with_name(

--- a/src/renforge/ui/graph.py
+++ b/src/renforge/ui/graph.py
@@ -139,7 +139,7 @@ def build_story_map(project_root: str) -> dict:
     native_locations: dict[str, dict] = {}
     try:
         project = RenpyProject(root)
-        sdk = get_or_install_sdk(project_root=project.abs_root, patch_json_dump=True)
+        sdk = get_or_install_sdk(project_root=project.abs_root)
         raw_dump = run_native_dump(sdk, project)
         for definition in normalize_definitions(raw_dump):
             if definition.get("kind") == "label" and definition.get("name"):

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -78,3 +78,19 @@ def test_public_god_mode_tools_and_workflow_are_documented() -> None:
     assert 'include=["metrics", "audio"]' in docs
     assert "docs/MCP.md" in readme
     assert "full tool catalogue" in readme.lower()
+
+
+def test_json_dump_compatibility_strategy_is_documented() -> None:
+    root = Path(__file__).parents[1]
+    architecture = (root / "docs" / "ARCHITECTURE.md").read_text(encoding="utf-8")
+    changelog = (root / "CHANGELOG.md").read_text(encoding="utf-8")
+
+    assert "compile --json-dump" in architecture
+    assert "RENPY_SEARCHPATH" in architecture
+    assert ".rpe.py" in architecture
+    assert "8.5.3" in architecture
+    assert "Node" in architecture
+    assert "read-only" in architecture
+    assert "dump.py" in architecture
+    assert "RENPY_SEARCHPATH" in changelog
+    assert "dump.py" in changelog

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -84,13 +84,22 @@ def test_json_dump_compatibility_strategy_is_documented() -> None:
     root = Path(__file__).parents[1]
     architecture = (root / "docs" / "ARCHITECTURE.md").read_text(encoding="utf-8")
     changelog = (root / "CHANGELOG.md").read_text(encoding="utf-8")
+    dump_docs = (root / "src" / "renforge" / "dump.py").read_text(encoding="utf-8")
 
     assert "compile --json-dump" in architecture
     assert "RENPY_SEARCHPATH" in architecture
     assert ".rpe.py" in architecture
     assert "8.5.3" in architecture
+    assert "8.4.1" in architecture
     assert "Node" in architecture
     assert "read-only" in architecture
     assert "dump.py" in architecture
+    assert "namemap itself stays Node-keyed" in architecture
+    assert "adapter still normalizes" in architecture
+    assert "Older string-keyed dumps (Ren'Py 8.4 and earlier)" not in architecture
+    assert "where the adapter is a no-op" not in architecture
+    assert "8.4.1" in dump_docs
+    assert "namemap itself" in dump_docs and "stays Node-keyed" in dump_docs
+    assert "String-keyed namemaps (Ren'Py 8.4 and earlier" not in dump_docs
     assert "RENPY_SEARCHPATH" in changelog
     assert "dump.py" in changelog

--- a/tests/test_dump.py
+++ b/tests/test_dump.py
@@ -1,0 +1,222 @@
+from __future__ import annotations
+
+import json
+import stat
+import sys
+import types
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from renforge import dump as dump_mod
+
+
+class _FakeNode:
+    def __init__(self, name: object, filename: str, linenumber: int) -> None:
+        self.name = name
+        self.filename = filename
+        self.linenumber = linenumber
+
+    def __hash__(self) -> int:
+        return hash(self.name)
+
+    def __eq__(self, other: object) -> bool:
+        return self.name == getattr(other, "name", other)
+
+
+def _install_fake_renpy(namemap: dict[object, _FakeNode]) -> dict[str, object]:
+    captured: dict[str, object] = {}
+    renpy = types.ModuleType("renpy")
+    dump_module = types.ModuleType("renpy.dump")
+    renpy.game = SimpleNamespace(script=SimpleNamespace(namemap=namemap))
+
+    def dump_fn(error: object) -> None:
+        labels: dict[str, list[object]] = {}
+        for name, node in renpy.game.script.namemap.items():
+            if not isinstance(name, str):
+                continue
+            labels[name] = [node.filename, node.linenumber]
+        captured["labels"] = labels
+        captured["error"] = error
+        captured["namemap_during_dump"] = renpy.game.script.namemap
+
+    dump_module.dump = dump_fn
+    sys.modules["renpy"] = renpy
+    sys.modules["renpy.dump"] = dump_module
+    captured["renpy"] = renpy
+    return captured
+
+
+def _exec_adapter() -> None:
+    exec(dump_mod.JSON_DUMP_ADAPTER_SOURCE, {"__file__": dump_mod.JSON_DUMP_ADAPTER_FILENAME})
+
+
+@pytest.fixture
+def restore_renpy_modules():
+    previous = {name: sys.modules.get(name) for name in ("renpy", "renpy.dump")}
+    try:
+        yield
+    finally:
+        for name, module in previous.items():
+            if module is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = module
+
+
+def test_adapter_unwraps_node_keyed_namemap(restore_renpy_modules) -> None:
+    start = _FakeNode("start", "game/script.rpy", 10)
+    jump = _FakeNode(("game/script.rpy", 1, 2), "game/script.rpy", 20)
+    namemap = {start: start, jump: jump}
+    captured = _install_fake_renpy(namemap)
+
+    _exec_adapter()
+    sys.modules["renpy.dump"].dump(False)
+
+    assert captured["labels"] == {"start": ["game/script.rpy", 10]}
+    assert captured["error"] is False
+    assert sys.modules["renpy"].game.script.namemap is namemap
+
+
+def test_adapter_leaves_string_keyed_namemap_unchanged(restore_renpy_modules) -> None:
+    start = _FakeNode("start", "game/script.rpy", 10)
+    namemap = {"start": start}
+    captured = _install_fake_renpy(namemap)
+
+    _exec_adapter()
+    sys.modules["renpy.dump"].dump(False)
+
+    assert captured["labels"] == {"start": ["game/script.rpy", 10]}
+    assert captured["namemap_during_dump"] is namemap
+    assert sys.modules["renpy"].game.script.namemap is namemap
+
+
+def test_adapter_follows_upstream_node_attribute_unwrap(restore_renpy_modules) -> None:
+    """Match upstream dump.py: `if isinstance(name, Node): name = name.name`."""
+    village = _FakeNode("village_gate", "game/script.rpy", 42)
+    captured = _install_fake_renpy({village: village})
+
+    _exec_adapter()
+    sys.modules["renpy.dump"].dump(True)
+
+    assert captured["labels"] == {"village_gate": ["game/script.rpy", 42]}
+    assert captured["error"] is True
+
+
+def test_adapter_install_is_idempotent(restore_renpy_modules) -> None:
+    start = _FakeNode("start", "game/script.rpy", 1)
+    captured = _install_fake_renpy({start: start})
+
+    _exec_adapter()
+    first = sys.modules["renpy.dump"].dump
+    _exec_adapter()
+    second = sys.modules["renpy.dump"].dump
+
+    assert first is second
+    second(False)
+    assert captured["labels"] == {"start": ["game/script.rpy", 1]}
+
+
+def _fake_project() -> SimpleNamespace:
+    return SimpleNamespace(
+        renpy_command=lambda _sdk, args: ["renpy", "/tmp/project", *args],
+    )
+
+
+def test_run_native_dump_injects_adapter_without_touching_sdk(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    sdk_root = tmp_path / "sdk"
+    dump_path = sdk_root / "renpy" / "dump.py"
+    dump_path.parent.mkdir(parents=True)
+    original = "original dump.py\n"
+    dump_path.write_text(original, encoding="utf-8")
+    dump_path.chmod(stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH)
+    sdk = SimpleNamespace(root=sdk_root)
+    seen: dict[str, object] = {}
+
+    def fake_run(command, **kwargs):
+        env = kwargs["env"]
+        searchpath = env["RENPY_SEARCHPATH"]
+        adapter_dir = Path(searchpath.split("::", 1)[0])
+        adapter = adapter_dir / dump_mod.JSON_DUMP_ADAPTER_FILENAME
+        seen["adapter"] = adapter
+        seen["adapter_dir"] = adapter_dir
+        seen["searchpath"] = searchpath
+        assert adapter.is_file()
+        text = adapter.read_text(encoding="utf-8")
+        assert "renforge json-dump adapter" in text
+        assert "unwrap" in text
+        out_path = Path(command[command.index("--json-dump") + 1])
+        payload = {"location": {"label": {"start": ["game/script.rpy", 1]}}}
+        out_path.write_text(json.dumps(payload), encoding="utf-8")
+        return SimpleNamespace(returncode=0, timed_out=False, stdout="", stderr="")
+
+    monkeypatch.setattr(dump_mod, "run_command", fake_run)
+
+    raw = dump_mod.run_native_dump(sdk, _fake_project())
+
+    assert raw["location"]["label"]["start"] == ["game/script.rpy", 1]
+    assert dump_path.read_text(encoding="utf-8") == original
+    assert not seen["adapter_dir"].exists()
+
+
+def test_run_native_dump_prepends_adapter_to_existing_searchpath(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("RENPY_SEARCHPATH", "/already/there")
+    seen: dict[str, str] = {}
+
+    def fake_run(command, **kwargs):
+        searchpath = kwargs["env"]["RENPY_SEARCHPATH"]
+        first, rest = searchpath.split("::", 1)
+        seen["first"] = first
+        seen["rest"] = rest
+        assert (Path(first) / dump_mod.JSON_DUMP_ADAPTER_FILENAME).is_file()
+        out_path = Path(command[command.index("--json-dump") + 1])
+        out_path.write_text("{}", encoding="utf-8")
+        return SimpleNamespace(returncode=0, timed_out=False, stdout="", stderr="")
+
+    monkeypatch.setattr(dump_mod, "run_command", fake_run)
+
+    dump_mod.run_native_dump(SimpleNamespace(), _fake_project())
+
+    assert seen["rest"] == "/already/there"
+    assert "renforge-dump-adapter-" in Path(seen["first"]).name
+
+
+def test_run_native_dump_is_isolated_across_concurrent_calls(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter_dirs: list[Path] = []
+
+    def fake_run(command, **kwargs):
+        adapter_dir = Path(kwargs["env"]["RENPY_SEARCHPATH"].split("::", 1)[0])
+        adapter_dirs.append(adapter_dir)
+        out_path = Path(command[command.index("--json-dump") + 1])
+        out_path.write_text("{}", encoding="utf-8")
+        return SimpleNamespace(returncode=0, timed_out=False, stdout="", stderr="")
+
+    monkeypatch.setattr(dump_mod, "run_command", fake_run)
+    dump_mod.run_native_dump(SimpleNamespace(), _fake_project())
+    dump_mod.run_native_dump(SimpleNamespace(), _fake_project())
+
+    assert len(adapter_dirs) == 2
+    assert adapter_dirs[0] != adapter_dirs[1]
+
+
+def test_normalize_definitions_flattens_label_locations() -> None:
+    definitions = dump_mod.normalize_definitions(
+        {
+            "location": {
+                "label": {"start": ["game/script.rpy", 12]},
+                "screen": {"hud": ["game/screens.rpy", 4]},
+            }
+        }
+    )
+    assert definitions == [
+        {"name": "start", "kind": "label", "file": "game/script.rpy", "line": 12},
+        {"name": "hud", "kind": "screen", "file": "game/screens.rpy", "line": 4},
+    ]

--- a/tests/test_dump.py
+++ b/tests/test_dump.py
@@ -92,6 +92,38 @@ def test_adapter_leaves_string_keyed_namemap_unchanged(restore_renpy_modules) ->
     assert sys.modules["renpy"].game.script.namemap is namemap
 
 
+def test_adapter_still_normalizes_when_dump_already_unwraps(restore_renpy_modules) -> None:
+    """Upstream dump.py may unwrap Node keys; namemap itself stays Node-keyed."""
+    start = _FakeNode("start", "game/script.rpy", 10)
+    namemap = {start: start}
+    captured: dict[str, object] = {}
+    renpy = types.ModuleType("renpy")
+    dump_module = types.ModuleType("renpy.dump")
+    renpy.game = SimpleNamespace(script=SimpleNamespace(namemap=namemap))
+
+    def dump_fn(error: object) -> None:
+        labels: dict[str, list[object]] = {}
+        for name, node in renpy.game.script.namemap.items():
+            if not isinstance(name, str):
+                name = getattr(name, "name", name)
+            if isinstance(name, str):
+                labels[name] = [node.filename, node.linenumber]
+        captured["labels"] = labels
+        captured["namemap_during_dump"] = renpy.game.script.namemap
+        captured["error"] = error
+
+    dump_module.dump = dump_fn
+    sys.modules["renpy"] = renpy
+    sys.modules["renpy.dump"] = dump_module
+
+    _exec_adapter()
+    sys.modules["renpy.dump"].dump(False)
+
+    assert captured["labels"] == {"start": ["game/script.rpy", 10]}
+    assert captured["namemap_during_dump"] is not namemap
+    assert sys.modules["renpy"].game.script.namemap is namemap
+
+
 def test_adapter_follows_upstream_node_attribute_unwrap(restore_renpy_modules) -> None:
     """Match upstream dump.py: `if isinstance(name, Node): name = name.name`."""
     village = _FakeNode("village_gate", "game/script.rpy", 42)

--- a/tests/test_sdk.py
+++ b/tests/test_sdk.py
@@ -1,3 +1,4 @@
+import inspect
 import io
 import os
 import tarfile
@@ -112,53 +113,46 @@ def test_project_local_compatible_sdk_has_priority_without_download(
     assert discovered.root == local_sdk
 
 
-def test_project_local_sdk_is_not_patched(
+def test_project_local_sdk_dump_py_is_never_rewritten(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
     project = tmp_path / "project"
     local_sdk = _write_fake_sdk(project / "renpy-sdk", "8.5.3")
     dump = local_sdk / "renpy" / "dump.py"
-    dump.write_text(sdk._DUMP_NAMEMAP_LOOP)
+    original = "unpatched dump.py\n"
+    dump.write_text(original)
+    dump.chmod(0o444)
     monkeypatch.setenv(sdk.RENPY_SDK_CACHE_ENV, str(tmp_path / "cache"))
     monkeypatch.delenv(sdk.RENPY_SDK_ENV, raising=False)
 
     discovered = sdk.get_or_install_sdk("8.5.3", project_root=project)
 
     assert discovered.root == local_sdk
-    assert "renforge: unwrap Node-keyed namemap" not in dump.read_text()
+    assert dump.read_text() == original
 
 
-def test_explicit_sdk_is_not_patched_during_plain_discovery(
+def test_explicit_sdk_dump_py_is_never_rewritten(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
     explicit_sdk = _write_fake_sdk(tmp_path / "explicit-sdk", "8.5.3")
     dump = explicit_sdk / "renpy" / "dump.py"
-    dump.write_text(sdk._DUMP_NAMEMAP_LOOP)
+    original = "unpatched dump.py\n"
+    dump.write_text(original)
+    dump.chmod(0o444)
     monkeypatch.setenv(sdk.RENPY_SDK_ENV, str(explicit_sdk))
     monkeypatch.setenv(sdk.RENPY_SDK_CACHE_ENV, str(tmp_path / "cache"))
 
     discovered = sdk.get_or_install_sdk("8.5.3")
 
     assert discovered.root == explicit_sdk
-    assert "renforge: unwrap Node-keyed namemap" not in dump.read_text()
+    assert dump.read_text() == original
 
 
-def test_explicit_sdk_dump_patch_requires_explicit_opt_in(
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
-) -> None:
-    explicit_sdk = _write_fake_sdk(tmp_path / "explicit-sdk", "8.5.3")
-    dump = explicit_sdk / "renpy" / "dump.py"
-    dump.write_text(sdk._DUMP_NAMEMAP_LOOP)
-    monkeypatch.setenv(sdk.RENPY_SDK_ENV, str(explicit_sdk))
-    monkeypatch.setenv(sdk.RENPY_SDK_CACHE_ENV, str(tmp_path / "cache"))
-
-    discovered = sdk.get_or_install_sdk("8.5.3", patch_json_dump=True)
-
-    assert discovered.root == explicit_sdk
-    assert "renforge: unwrap Node-keyed namemap" in dump.read_text()
+def test_get_or_install_sdk_has_no_sdk_source_patch_flag() -> None:
+    assert "patch_json_dump" not in inspect.signature(sdk.get_or_install_sdk).parameters
+    assert not hasattr(sdk, "_patch_sdk_json_dump")
 
 
 def test_incompatible_project_sdk_falls_back_to_compatible_cache(
@@ -341,32 +335,6 @@ def test_sdk_install_rechecks_cache_after_acquiring_lock(
     discovered = sdk.get_or_install_sdk(version)
 
     assert discovered.root == cache_dir / version
-
-
-def test_patch_sdk_json_dump_unwraps_node_keyed_namemap(tmp_path: Path) -> None:
-    dump = tmp_path / "renpy" / "dump.py"
-    dump.parent.mkdir(parents=True)
-    dump.write_text(
-        "def dump(error):\n"
-        "    label = location[\"label\"] = {}\n"
-        "\n"
-        "    for name, n in renpy.game.script.namemap.items():\n"
-        "        filename = n.filename\n"
-        "        line = n.linenumber\n"
-        "\n"
-        "        if not isinstance(name, str):\n"
-        "            continue\n"
-        "\n"
-        "        label[name] = [filename, line]\n",
-        encoding="utf-8",
-    )
-
-    assert sdk._patch_sdk_json_dump(tmp_path) is True
-    patched = dump.read_text(encoding="utf-8")
-    assert "renforge: unwrap Node-keyed namemap" in patched
-    assert "name = getattr(name, \"name\", name)" in patched
-    # Idempotent.
-    assert sdk._patch_sdk_json_dump(tmp_path) is False
 
 
 def test_default_renpy_version_tracks_current_stable() -> None:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Graph inspection no longer rewrites `renpy/dump.py` inside a discovered or cached Ren'Py SDK.

`compile --json-dump` now injects an isolated `.rpe.py` adapter via `RENPY_SEARCHPATH`. The adapter wraps `renpy.dump.dump` and, only when `Script.namemap` keys are not already strings, presents a string-keyed namemap for the duration of the dump. Shared, read-only, and concurrent SDK installs are left untouched.

## Motivation and related issue

Ren'Py 8.4.1+ keys `Script.namemap` by `Node` while 8.5.3 `dump.py` still filters with `isinstance(name, str)`, which drops every label. #85 made the previous SDK source patch explicit and opt-in. This change removes that mutation entirely by following the upstream unwrap in an isolated subprocess adapter.

Fixes #88

## Changes

- Removed `_patch_sdk_json_dump` and the `patch_json_dump` flag from SDK discovery.
- Inject a temporary Ren'Py extension (`.rpe.py`) for each native dump subprocess.
- Document the compatibility strategy and supported dump shapes (8.4.1+/8.5.x Node-keyed namemap, string-keyed no-op, and future SDKs whose `dump.py` already unwraps — namemap stays Node-keyed, so the adapter still normalizes it).
- Cover both dump shapes, read-only SDK files, adapter isolation, dump.py-already-unwraps, and the documented strategy with tests.

## Validation

- `python -m compileall src tests`: passed
- `python -m pytest -q tests/test_dump.py tests/test_sdk.py tests/test_docs.py tests/test_ui_backend.py::test_story_map_caches_after_first_build`: **30 passed**
- Follow-up docs/spec tests: `python3 -m pytest -q tests/test_dump.py tests/test_docs.py::test_json_dump_compatibility_strategy_is_documented`: **10 passed**
- `python -m pytest -q -m "not live"`: 880 passed; remaining failures are pre-existing in this environment (editor CAS/i18n scanner/`/tmp` worktree path assertion) and reproduce on `main`
- `npm --prefix ui run build`: Not applicable (no frontend changes)
- Manual verification: live `compile --json-dump` against cached Ren'Py 8.5.3 demo recovered all 16 labels; `renpy/dump.py` mtime and contents were unchanged, including when the file was mode `0444`
- Merge with `main` (`#94`): simple `CHANGELOG.md` conflict only; both Unreleased Changed bullets kept. `docs/ARCHITECTURE.md` auto-merged.

## User-facing changes

Story Map / graph inspection still reports authoritative label locations on Ren'Py 8.4.1+ / 8.5. SDK directories are no longer modified as a side effect.

## Internationalization

- [x] New user-visible copy uses i18n keys, or this PR adds no user-visible copy.
- [x] `npm --prefix ui run i18n:check` passes, or i18n is not applicable.

## Breaking changes

`get_or_install_sdk(..., patch_json_dump=True)` is removed. The flag was only used internally for graph inspection.

## Documentation

- `docs/ARCHITECTURE.md` — SDK resolution and `--json-dump` compatibility strategy
- `CHANGELOG.md` — Unreleased change entry
- `src/renforge/dump.py` — module docstring

## Reviewer notes

The adapter cannot import `renforge`; it is a self-contained snippet executed by Ren'Py's `load_rpe_py`. Bundled Ren'Py Python ignores `PYTHONPATH` / `sitecustomize`, so `RENPY_SEARCHPATH` is the injection path that actually loads in the dump subprocess.

Upstream `renpy/dump.py` on master already unwraps `Node` keys. `Script.namemap` remains Node-keyed (`self.namemap[node] = node`) from at least 8.4.1 through master, so this adapter still normalizes the map on those SDKs. It is a no-op only when keys are already strings.

Work was done in a separate git worktree (`/tmp/renforge-issue-88`) on `cursor/stop-sdk-rewrite-eae1`.

## Final checklist

- [x] The PR is focused on one coherent change.
- [x] Tests were added or updated for behavior changes.
- [x] Generated `src/renforge/ui/static/` assets remain untracked; CI and release builds produce them.
- [x] No credentials, tokens, personal paths, or other secrets are included.
- [x] I understand the submitted code and can explain how it works.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4e205161-cb31-4344-b329-6d712819eae1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4e205161-cb31-4344-b329-6d712819eae1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

Arrêter de modifier les fichiers source du SDK Ren'Py pour l’inspection du graphe de la Story Map en injectant à l’exécution un adaptateur temporaire de json-dump et en mettant à jour la documentation et les tests pour refléter la nouvelle stratégie de compatibilité.

Nouvelles fonctionnalités :
- Prendre en charge les deux formes de `Script.namemap` indexées par Node et par chaîne de caractères pendant `compile --json-dump` via un adaptateur `.rpe.py` injecté, afin que les emplacements de labels soient émis de manière cohérente entre les différentes versions de Ren'Py.

Corrections de bugs :
- Rétablir les emplacements de labels manquants dans l’inspection du graphe de la Story Map lors de l’utilisation des SDK Ren'Py 8.5 qui indexent `Script.namemap` par `Node`.

Améliorations :
- Garantir que la découverte et l’utilisation du SDK fonctionnent avec des installations de SDK partagées et en lecture seule en évitant toute réécriture sous la racine du SDK.
- Exposer des constantes pour le nom de fichier et la source de l’adaptateur de json-dump afin de rendre l’intégration du dump explicite et vérifiable dans les tests.

Documentation :
- Documenter la stratégie de compatibilité du json-dump, les formes de dump prises en charge et la découverte non mutante du SDK dans `ARCHITECTURE.md`, et mentionner le nouveau comportement basé sur l’adaptateur dans `CHANGELOG.md`.

Tests :
- Ajouter des tests couvrant le comportement de l’adaptateur pour les namemaps indexées par Node et par chaîne de caractères, l’installation idempotente, l’injection du chemin de recherche, l’isolation en concurrence, et la suppression du flag `patch_json_dump` de la découverte du SDK.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Stop mutating Ren'Py SDK source files for Story Map graph inspection by injecting a temporary json-dump adapter at runtime and updating docs and tests to reflect the new compatibility strategy.

New Features:
- Support both Node-keyed and string-keyed `Script.namemap` shapes during `compile --json-dump` via an injected `.rpe.py` adapter so label locations are emitted consistently across Ren'Py versions.

Bug Fixes:
- Restore missing label locations in Story Map graph inspection when using Ren'Py 8.5 SDKs that key `Script.namemap` by `Node`.

Enhancements:
- Ensure SDK discovery and usage work with shared and read-only SDK installations by avoiding any rewrites under the SDK root.
- Expose constants for the json-dump adapter filename and source to make dump integration explicit and verifiable in tests.

Documentation:
- Document the json-dump compatibility strategy, supported dump shapes, and non-mutating SDK discovery in `ARCHITECTURE.md` and note the new adapter-based behavior in `CHANGELOG.md`.

Tests:
- Add tests covering the adapter behavior for Node-keyed and string-keyed namemaps, idempotent installation, search path injection, concurrent isolation, and the removal of the `patch_json_dump` flag from SDK discovery.

</details>

Nouvelles fonctionnalités :
- Prise en charge des formes de `Script.namemap` indexées par Node et par chaîne de caractères lors des dumps JSON via un adaptateur injecté, garantissant que les emplacements de labels sont émis de manière cohérente entre les différentes versions de Ren'Py.

Corrections de bugs :
- Correction des labels manquants lors de l’inspection du graphe Story Map avec les SDK Ren'Py 8.5 qui indexent `Script.namemap` par Node.

Améliorations :
- Garantir que la découverte et l’utilisation du SDK fonctionnent avec des installations de SDK en lecture seule ou partagées en évitant toute réécriture de fichier sous la racine du SDK.
- Exposer des constantes pour le nom de fichier et la source de l’adaptateur de json-dump afin de rendre l’intégration du dump explicite et testable.
- Clarifier le comportement du dump et la compatibilité du SDK dans les docstrings de `renforge.dump` et la documentation d’architecture.

Documentation :
- Documenter la stratégie de compatibilité du json-dump, les formes de dump prises en charge, et la découverte non mutante du SDK dans `ARCHITECTURE.md`.
- Consigner le nouveau comportement d’inspection de graphe et l’approche basée sur l’adaptateur dans `CHANGELOG.md`.

Tests :
- Ajouter des tests unitaires pour le comportement de l’adaptateur de json-dump sur les namemaps indexées par Node et par chaîne, l’installation idempotente, et le dépliage de clés compatible avec l’amont.
- Ajouter des tests vérifiant que `run_native_dump` injecte l’adaptateur via `RENPY_SEARCHPATH`, respecte les chemins de recherche existants, isole les appels concurrents et laisse les fichiers du SDK intacts.
- Ajouter des tests garantissant que `get_or_install_sdk` n’expose ni n’utilise plus de drapeau `patch_json_dump` et que la documentation décrit la stratégie de json-dump et ses contraintes.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Arrêter de modifier les fichiers source du SDK Ren'Py pour l’inspection du graphe de la Story Map en injectant à l’exécution un adaptateur temporaire de json-dump et en mettant à jour la documentation et les tests pour refléter la nouvelle stratégie de compatibilité.

Nouvelles fonctionnalités :
- Prendre en charge les deux formes de `Script.namemap` indexées par Node et par chaîne de caractères pendant `compile --json-dump` via un adaptateur `.rpe.py` injecté, afin que les emplacements de labels soient émis de manière cohérente entre les différentes versions de Ren'Py.

Corrections de bugs :
- Rétablir les emplacements de labels manquants dans l’inspection du graphe de la Story Map lors de l’utilisation des SDK Ren'Py 8.5 qui indexent `Script.namemap` par `Node`.

Améliorations :
- Garantir que la découverte et l’utilisation du SDK fonctionnent avec des installations de SDK partagées et en lecture seule en évitant toute réécriture sous la racine du SDK.
- Exposer des constantes pour le nom de fichier et la source de l’adaptateur de json-dump afin de rendre l’intégration du dump explicite et vérifiable dans les tests.

Documentation :
- Documenter la stratégie de compatibilité du json-dump, les formes de dump prises en charge et la découverte non mutante du SDK dans `ARCHITECTURE.md`, et mentionner le nouveau comportement basé sur l’adaptateur dans `CHANGELOG.md`.

Tests :
- Ajouter des tests couvrant le comportement de l’adaptateur pour les namemaps indexées par Node et par chaîne de caractères, l’installation idempotente, l’injection du chemin de recherche, l’isolation en concurrence, et la suppression du flag `patch_json_dump` de la découverte du SDK.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Stop mutating Ren'Py SDK source files for Story Map graph inspection by injecting a temporary json-dump adapter at runtime and updating docs and tests to reflect the new compatibility strategy.

New Features:
- Support both Node-keyed and string-keyed `Script.namemap` shapes during `compile --json-dump` via an injected `.rpe.py` adapter so label locations are emitted consistently across Ren'Py versions.

Bug Fixes:
- Restore missing label locations in Story Map graph inspection when using Ren'Py 8.5 SDKs that key `Script.namemap` by `Node`.

Enhancements:
- Ensure SDK discovery and usage work with shared and read-only SDK installations by avoiding any rewrites under the SDK root.
- Expose constants for the json-dump adapter filename and source to make dump integration explicit and verifiable in tests.

Documentation:
- Document the json-dump compatibility strategy, supported dump shapes, and non-mutating SDK discovery in `ARCHITECTURE.md` and note the new adapter-based behavior in `CHANGELOG.md`.

Tests:
- Add tests covering the adapter behavior for Node-keyed and string-keyed namemaps, idempotent installation, search path injection, concurrent isolation, and the removal of the `patch_json_dump` flag from SDK discovery.

</details>

</details>