### PR TITLE
Release v0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ versioning.
 
 ### Added
 
+### Changed
+
+### Fixed
+
+## [0.7.1] - 2026-08-17
+
+### Added
+
 - Operation-level runtime policy for `renforge_control`, `renforge_saves`,
   `renforge_eval`, and `renforge_run_scenario`. Default remains
   `RENFORGE_POLICY=off` (classify and record, never deny). `enforce` mode
@@ -26,6 +34,12 @@ versioning.
   `src/renforge/tool_registration/`. `server.py` only bootstraps the app;
   wrappers, contract metadata, and fail-closed registration live next to each
   other by domain. The public 54-tool MCP API is unchanged.
+
+### Fixed
+
+- Dismiss `say` / `nvl` / `bubble` / `choice` immediately on editor jump so a
+  pending hide transition cannot raise `TypeError: missing a required
+  argument: 'who'`.
 
 ## [0.7.0] - 2026-08-11
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "renforge"
-version = "0.7.0"
+version = "0.7.1"
 description = "MCP server, CLI, and web dashboard for Ren'Py visual-novel development"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/server.json
+++ b/server.json
@@ -6,13 +6,13 @@
     "url": "https://github.com/alex-jordan547/renforge-mcp",
     "source": "github"
   },
-  "version": "0.7.0",
+  "version": "0.7.1",
   "websiteUrl": "https://pypi.org/project/renforge/",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "renforge",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/src/renforge/__init__.py
+++ b/src/renforge/__init__.py
@@ -1,4 +1,4 @@
 """RenForge package."""
 
-__version__ = "0.7.0"
+__version__ = "0.7.1"
 __all__ = ["__version__"]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Bump version to 0.7.1 for patch release shipping fixes and improvements from current main.

## Motivation and related issue

Jordan requested a patch release to ship recent improvements ahead of v0.7.0.

## Changes

- Bump version from 0.7.0 to 0.7.1 in `pyproject.toml`, `server.json`, and `src/renforge/__init__.py`
- Add `[0.7.1] - 2026-08-17` section to `CHANGELOG.md` with:
  - **Added:** operation-level runtime policy for `renforge_control`, `renforge_saves`, `renforge_eval`, `renforge_run_scenario` (default `RENFORGE_POLICY=off`; `enforce` needs authorize/allowlist) - #92
  - **Changed:** graph inspection no longer rewrites `renpy/dump.py`; isolated `.rpe.py` via `RENPY_SEARCHPATH` - #95
  - **Changed:** MCP tool registration split into domain modules; public 54-tool API unchanged - #85, #94
  - **Fixed:** dismiss `say` / `nvl` / `bubble` / `choice` immediately on editor jump so a pending hide transition cannot raise `TypeError: missing a required argument: 'who'` - #90
- Keep fresh empty `## Unreleased` section

## Validation

- Manual verification: CHANGELOG properly formatted, version numbers consistent across all files

## User-facing changes

None (version number only visible in package metadata and release artifacts)

## Internationalization

- [x] New user-visible copy uses i18n keys, or this PR adds no user-visible copy.
- [x] `npm --prefix ui run i18n:check` passes, or i18n is not applicable.

## Breaking changes

None

## Documentation

CHANGELOG updated with release notes for v0.7.1.

## Reviewer notes

This is a standard patch release. Once merged, tag `v0.7.1` on the merge commit to trigger the release workflow (PyPI, MCP registry, GitHub Release).

## Final checklist

- [x] The PR is focused on one coherent change.
- [x] Tests were added or updated for behavior changes.
- [x] Generated `src/renforge/ui/static/` assets remain untracked; CI and release builds produce them.
- [x] No credentials, tokens, personal paths, or other secrets are included.
- [x] I understand the submitted code and can explain how it works.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f537b0f0-8bf0-4198-8c71-ffb70f3dc508?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f537b0f0-8bf0-4198-8c71-ffb70f3dc508&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

Préparer la version correctrice 0.7.1 avec une mise à jour de la gestion de versions et des notes de publication.

Nouvelles fonctionnalités :
- Documenter les nouveaux contrôles de stratégie d’exécution au niveau des opérations pour les opérations clés de RenForge.

Corrections de bugs :
- Documenter la correction des transitions de saut de l’éditeur qui pouvaient provoquer une erreur de type TypeError « who » manquant lors de la dissimulation de dialogues.

Améliorations :
- Mettre à jour le changelog avec des détails sur les valeurs par défaut des stratégies d’exécution, le comportement d’inspection du graphe Ren’Py et la modularisation de l’outil MCP.

Build :
- Augmenter la version du projet de 0.7.0 à 0.7.1 dans les métadonnées du package et la configuration du serveur.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Prepare the 0.7.1 patch release with updated versioning and release notes.

New Features:
- Document newly added operation-level runtime policy controls for key RenForge operations.

Bug Fixes:
- Document fix for editor jump transitions that could raise a missing 'who' TypeError in dialogue hides.

Enhancements:
- Update changelog with details on runtime policy defaults, Ren'Py graph inspection behavior, and MCP tool modularization.

Build:
- Bump project version from 0.7.0 to 0.7.1 across package metadata and server configuration.

</details>