### PR TITLE
CI: run real Ren'Py tests and narrow Autopilot choices

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,83 @@ jobs:
       - name: Run tests
         run: python -m pytest -q
 
+  engine-integration:
+    name: Engine integration (Ren'Py 8.5.3)
+    needs: ui-build
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      DISPLAY: ":99"
+      SDL_AUDIODRIVER: dummy
+      RENFORGE_SDK_TESTS: "1"
+      RENFORGE_SDK_VERSION: "8.5.3"
+      RENPY_SDK_CACHE_DIR: ${{ github.workspace }}/.renpy-sdk-cache
+      PYTHONPATH: src
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install and start Xvfb
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y xvfb x11-utils
+          Xvfb :99 -screen 0 1920x1080x24 &
+          for _ in $(seq 1 30); do
+            xdpyinfo -display :99 >/dev/null 2>&1 && break
+            sleep 0.5
+          done
+          xdpyinfo -display :99 | grep dimensions
+
+      - name: Cache Ren'Py SDK
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.RENPY_SDK_CACHE_DIR }}
+          key: renpy-sdk-${{ env.RENFORGE_SDK_VERSION }}-${{ runner.os }}
+
+      - name: Download built UI artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: ui-static
+          path: src/renforge/ui/static
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e '.[test]'
+
+      - name: Run engine integration tests
+        run: |
+          mkdir -p .engine-test-artifacts
+          set -o pipefail
+          python -m pytest -q -rs \
+            --basetemp=.engine-test-artifacts/pytest \
+            --junitxml=.engine-test-artifacts/junit.xml \
+            tests/test_integration_sdk.py \
+            tests/test_integration_sdk_live_demo_acceptance.py \
+            2>&1 | tee .engine-test-artifacts/pytest.log
+
+      - name: Upload engine test artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: engine-integration-renpy-${{ env.RENFORGE_SDK_VERSION }}
+          path: |
+            .engine-test-artifacts/pytest.log
+            .engine-test-artifacts/junit.xml
+            .engine-test-artifacts/pytest/**/log.txt
+            .engine-test-artifacts/pytest/**/traceback.txt
+            .engine-test-artifacts/pytest/**/errors.txt
+            .engine-test-artifacts/pytest/**/.renforge/captures/*.png
+            .engine-test-artifacts/pytest/**/.renforge/autopilot.json
+          include-hidden-files: true
+          if-no-files-found: ignore
+          retention-days: 7
+
   package-contract:
     name: Package contract checks
     needs: ui-build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,14 @@ versioning.
 
 ### Added
 
+- Every pull request now runs the broad Ren'Py 8.5.3 SDK integration suite on
+  Linux/Xvfb, with SDK caching and an explicit diagnostic artifact allowlist.
+
 ### Changed
+
+- Autopilot still prefers standard Ren'Py choices, but can now traverse
+  conservative multi-control custom choice screens while excluding persistent
+  overlays, one-control HUDs, disabled controls, and no-op actions.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,9 @@ versioning.
 
 ### Changed
 
-- Autopilot still prefers standard Ren'Py choices, but can now traverse
-  conservative multi-control custom choice screens while excluding persistent
-  overlays, one-control HUDs, disabled controls, and no-op actions.
+- Autopilot now identifies choices from active Ren'Py menu `items`, including
+  custom-named and one-item menus, without inferring narrative intent from
+  arbitrary focusable screen controls.
 
 ### Fixed
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,7 @@ git clone https://github.com/alex-jordan547/renforge-mcp.git
 cd renforge-mcp
 python -m venv .venv && source .venv/bin/activate
 pip install -e ".[fastmcp,ui,test]"
+npm --prefix ui ci
 pytest
 ```
 
@@ -29,6 +30,21 @@ bash scripts/smoke_renpy_env.sh
 
 Details, environment variables, and the Cursor environment named `renforge`:
 [docs/CLOUD_ENVIRONMENT.md](docs/CLOUD_ENVIRONMENT.md).
+
+The normal test command intentionally skips tests that launch Ren'Py. After
+setting up Xvfb and the SDK as described in the cloud/CI guide, run the same
+real-engine suite used by pull-request CI with:
+
+```bash
+RENFORGE_SDK_TESTS=1 RENFORGE_SDK_VERSION=8.5.3 \
+  python -m pytest -q \
+  tests/test_integration_sdk.py \
+  tests/test_integration_sdk_live_demo_acceptance.py
+```
+
+These tests copy `examples/demo_game` into pytest-owned temporary directories;
+CI uploads only an explicit diagnostic allowlist and never bridge control
+metadata, which contains the session credential.
 
 The dashboard frontend lives in `ui/` (Vite + React + TypeScript):
 

--- a/README.md
+++ b/README.md
@@ -191,10 +191,10 @@ JSON summary of the project (labels, scripts, assets, and related metadata).
   control, and text block with bounds, z-order, colour, and style, plus an ASCII
   wireframe and structural scene diffs. Then `renforge_measure` reports alignment,
   spacing, overlap, fit, and WCAG contrast as numbers an agent can act on.
-- **Autopilot** — auto-play standard Ren'Py choices and conservative
-  multi-control custom choice screens across fresh replays, reporting label
-  coverage and crashes. Persistent overlays, one-control HUDs, and no-op
-  controls are excluded from custom-choice discovery.
+- **Autopilot** — auto-play choices backed by Ren'Py menu `items` across
+  fresh replays, including custom-named and one-item menus, while reporting
+  label coverage and crashes. Arbitrary `call screen` interactions require
+  game-specific adapters and are not inferred from visible controls.
 - **Assets & translations** — find orphaned/missing image+audio assets, list
   languages, compute translation stats, generate/update `game/tl/<lang>/` files,
   export dialogue as text.

--- a/README.md
+++ b/README.md
@@ -191,8 +191,10 @@ JSON summary of the project (labels, scripts, assets, and related metadata).
   control, and text block with bounds, z-order, colour, and style, plus an ASCII
   wireframe and structural scene diffs. Then `renforge_measure` reports alignment,
   spacing, overlap, fit, and WCAG contrast as numbers an agent can act on.
-- **Autopilot** — auto-play the game across branches and report label coverage
-  and crashes.
+- **Autopilot** — auto-play standard Ren'Py choices and conservative
+  multi-control custom choice screens across fresh replays, reporting label
+  coverage and crashes. Persistent overlays, one-control HUDs, and no-op
+  controls are excluded from custom-choice discovery.
 - **Assets & translations** — find orphaned/missing image+audio assets, list
   languages, compute translation stats, generate/update `game/tl/<lang>/` files,
   export dialogue as text.

--- a/README.md
+++ b/README.md
@@ -193,8 +193,8 @@ JSON summary of the project (labels, scripts, assets, and related metadata).
   spacing, overlap, fit, and WCAG contrast as numbers an agent can act on.
 - **Autopilot** — auto-play choices backed by Ren'Py menu `items` across
   fresh replays, including custom-named and one-item menus, while reporting
-  label coverage and crashes. Arbitrary `call screen` interactions require
-  game-specific adapters and are not inferred from visible controls.
+  label coverage and crashes. Custom `call_screen` interactions that do not
+  expose Ren'Py menu `items` are not currently explored automatically.
 - **Assets & translations** — find orphaned/missing image+audio assets, list
   languages, compute translation stats, generate/update `game/tl/<lang>/` files,
   export dialogue as text.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -119,6 +119,28 @@ Supported dump shapes:
 - Future SDKs whose `dump.py` already unwraps `Node` keys: namemap stays
   Node-keyed, so the adapter still normalizes it
 
+## Real-engine test boundary
+
+The default pytest suite is the fast unit/contract layer and does not launch
+Ren'Py. `.github/workflows/ci.yml` adds one Linux/Xvfb integration job that pins
+the default supported SDK, launches the real engine, and runs
+`tests/test_integration_sdk.py` plus
+`tests/test_integration_sdk_live_demo_acceptance.py`. The larger focused Live
+Editor suite remains in `.github/workflows/live-editor.yml` because it has a
+different cost and trigger policy.
+
+Real-engine fixtures treat `examples/demo_game` as read-only input and copy it
+to pytest-owned temporary directories before RenForge injects bridge/editor
+files or Ren'Py writes caches and saves. CI caches only the SDK. Failure
+artifacts use an explicit allowlist for logs, tracebacks, screenshots, and
+autopilot output; `.renforge/control` is never uploaded because it contains the
+session credential.
+
+The SDK test files retain their small local fixtures for this first CI layer.
+Shared engine fixtures, markers, and additional-version smoke coverage should
+be introduced only when they reduce demonstrated duplication or enable a real
+compatibility claim.
+
 ## Packaging
 
 Packaging uses `hatchling`; the console script is

--- a/docs/CLOUD_ENVIRONMENT.md
+++ b/docs/CLOUD_ENVIRONMENT.md
@@ -173,7 +173,8 @@ Key environment variables for cloud environments:
 | `DISPLAY` | X11 display for Ren'Py | Must be set (e.g., `:99`) |
 | `PYTHONPATH` | Python module search path | Should include `src/` |
 | `RENPY_SDK_CACHE_DIR` | Ren'Py SDK cache location | `~/.cache/renforge/sdks` |
-| `RENPY_SDK_VERSION` | Override Ren'Py version | `8.5.3` |
+| `RENFORGE_SDK_TESTS` | Enable the broad real-SDK integration suite | Unset (opt-in locally) |
+| `RENFORGE_SDK_VERSION` | SDK version used by that integration suite | RenForge's default SDK |
 | `RENFORGE_*_LIVE` | Enable specific live test suites | Unset (opt-in per suite) |
 
 ## Running Tests
@@ -185,6 +186,30 @@ After environment setup:
 ```bash
 pytest
 ```
+
+The unit suite includes frontend i18n checks. Run `npm --prefix ui ci` first in
+a fresh checkout, as shown in `CONTRIBUTING.md`.
+
+### SDK Integration Tests
+
+The pull-request engine job launches Ren'Py 8.5.3 and runs the complete broad
+SDK suite:
+
+```bash
+RENFORGE_SDK_TESTS=1 RENFORGE_SDK_VERSION=8.5.3 \
+  python -m pytest -q \
+  tests/test_integration_sdk.py \
+  tests/test_integration_sdk_live_demo_acceptance.py
+```
+
+This covers SDK lint/dump behavior, bridge lifecycle, screenshots, reload,
+screen and scene inspection, semantic input, choices, save/load, autopilot, and
+the representative Live Editor demo route. Every test receives a temporary copy
+of `examples/demo_game`; the committed fixture remains read-only input.
+
+Missing SDK/display prerequisites are failures in the dedicated CI job. A
+normal `pytest` invocation leaves `RENFORGE_SDK_TESTS` unset and skips these
+costly tests.
 
 ### Live Editor Tests
 
@@ -287,13 +312,14 @@ pip install -e .
 
 ### GitHub Actions
 
-See `.github/workflows/live-editor.yml` for a complete working example. Key
-points:
+See `.github/workflows/ci.yml` for the every-PR SDK integration job and
+`.github/workflows/live-editor.yml` for the larger nightly/label-gated editor
+suite. Key points:
 
 - Cache the Ren'Py SDK with `actions/cache@v4`
 - Start Xvfb early with a large screen size
 - Build the frontend before running tests
-- Use `uv` for faster dependency installation
+- Keep SDK integration and the larger focused editor suite as separate jobs
 
 ### GitLab CI
 
@@ -322,7 +348,8 @@ The Ren'Py SDK is ~500MB. For efficient cloud environments:
    ```bash
    export RENPY_SDK_CACHE_DIR=/mnt/cache/renforge/sdks
    ```
-3. **GitHub Actions:** Use `actions/cache@v4` (see `.github/workflows/live-editor.yml`)
+3. **GitHub Actions:** Use `actions/cache@v4` (see `.github/workflows/ci.yml`
+   and `.github/workflows/live-editor.yml`)
 4. **Cursor Cloud:** The environment's filesystem persists across agent runs in
    the same environment
 
@@ -342,7 +369,9 @@ The Ren'Py SDK is ~500MB. For efficient cloud environments:
 
 - [CONTRIBUTING.md](../CONTRIBUTING.md) — Development setup for local machines
 - [LIVE_EDITOR.md](LIVE_EDITOR.md) — Live Editor human and agent workflows
+- [.github/workflows/ci.yml](../.github/workflows/ci.yml) — Every-PR SDK
+  integration job
 - [.github/workflows/live-editor.yml](../.github/workflows/live-editor.yml) —
-  Working CI example
+  Nightly and label-gated focused editor suites
 - [scripts/run_live_editor_suites.sh](../scripts/run_live_editor_suites.sh) —
   Live test runner with retry logic

--- a/docs/CLOUD_ENVIRONMENT.md
+++ b/docs/CLOUD_ENVIRONMENT.md
@@ -174,7 +174,7 @@ Key environment variables for cloud environments:
 | `PYTHONPATH` | Python module search path | Should include `src/` |
 | `RENPY_SDK_CACHE_DIR` | Ren'Py SDK cache location | `~/.cache/renforge/sdks` |
 | `RENFORGE_SDK_TESTS` | Enable the broad real-SDK integration suite | Unset (opt-in locally) |
-| `RENFORGE_SDK_VERSION` | SDK version used by that integration suite | RenForge's default SDK |
+| `RENFORGE_SDK_VERSION` | SDK version used by that integration suite | `8.5.3` (`DEFAULT_RENPY_VERSION`) |
 | `RENFORGE_*_LIVE` | Enable specific live test suites | Unset (opt-in per suite) |
 
 ## Running Tests
@@ -319,6 +319,7 @@ suite. Key points:
 - Cache the Ren'Py SDK with `actions/cache@v4`
 - Start Xvfb early with a large screen size
 - Build the frontend before running tests
+- Use `uv` for faster dependency installation where the workflow provides it
 - Keep SDK integration and the larger focused editor suite as separate jobs
 
 ### GitLab CI

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -423,7 +423,7 @@ guards: each capture hashes a new frame.
 | `renforge_get_errors` | Read recent bridge errors or bounded crash-file tails with mtimes and exit code when tracked. |
 | `renforge_wait_until` | Wait for exactly one `label`, `screen`, or `expr` condition with bounded `timeout` (maximum 120 seconds) and polling `interval`. Returns compact state by default (`state_profile=interaction`); pass `include` for extra fields and `state_profile=full` only when needed. |
 | `renforge_run_scenario` | Execute a multi-step live scenario (`set`, `click`, `wait`, `assert`, …) in one call; captures diagnostics on failure. |
-| `renforge_autopilot` | Explore standard choices and conservative multi-control custom choice screens across fresh replays; exclude persistent overlays, one-control HUDs, and no-op controls; report label coverage and crashes. |
+| `renforge_autopilot` | Explore choices backed by active Ren'Py menu `items` across fresh replays, including custom-named and one-item menus; report label coverage and crashes. Arbitrary `call screen` interactions require game-specific adapters. |
 
 ### Project, translation, builds, and Ren'Py documentation
 

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -423,7 +423,7 @@ guards: each capture hashes a new frame.
 | `renforge_get_errors` | Read recent bridge errors or bounded crash-file tails with mtimes and exit code when tracked. |
 | `renforge_wait_until` | Wait for exactly one `label`, `screen`, or `expr` condition with bounded `timeout` (maximum 120 seconds) and polling `interval`. Returns compact state by default (`state_profile=interaction`); pass `include` for extra fields and `state_profile=full` only when needed. |
 | `renforge_run_scenario` | Execute a multi-step live scenario (`set`, `click`, `wait`, `assert`, …) in one call; captures diagnostics on failure. |
-| `renforge_autopilot` | Explore branches and report label coverage and crashes. |
+| `renforge_autopilot` | Explore standard choices and conservative multi-control custom choice screens across fresh replays; exclude persistent overlays, one-control HUDs, and no-op controls; report label coverage and crashes. |
 
 ### Project, translation, builds, and Ren'Py documentation
 

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -423,7 +423,7 @@ guards: each capture hashes a new frame.
 | `renforge_get_errors` | Read recent bridge errors or bounded crash-file tails with mtimes and exit code when tracked. |
 | `renforge_wait_until` | Wait for exactly one `label`, `screen`, or `expr` condition with bounded `timeout` (maximum 120 seconds) and polling `interval`. Returns compact state by default (`state_profile=interaction`); pass `include` for extra fields and `state_profile=full` only when needed. |
 | `renforge_run_scenario` | Execute a multi-step live scenario (`set`, `click`, `wait`, `assert`, …) in one call; captures diagnostics on failure. |
-| `renforge_autopilot` | Explore choices backed by active Ren'Py menu `items` across fresh replays, including custom-named and one-item menus; report label coverage and crashes. Arbitrary `call screen` interactions require game-specific adapters. |
+| `renforge_autopilot` | Explore choices backed by active Ren'Py menu `items` across fresh replays, including custom-named and one-item menus; report label coverage and crashes. Custom `call_screen` interactions that do not expose Ren'Py menu `items` are not currently explored automatically. |
 
 ### Project, translation, builds, and Ren'Py documentation
 

--- a/docs/superpowers/spikes/2026-08-02-failed-gate-ui-criteria.md
+++ b/docs/superpowers/spikes/2026-08-02-failed-gate-ui-criteria.md
@@ -32,8 +32,9 @@ All five must hold, measured live, for issue #52 to pass:
 2. **Selection remains visible and measurable:**
    - Selecting any locked target updates `selected_rect` to the target's bounding box `[x, y, w, h]` with `w > 0` and `h > 0`.
 
-3. **Overlay label renders exact lock code:**
-   - The overlay label text includes `[<LOCK_CODE>]` (e.g. `[SYNTHETIC_WIDGET_ID]`, `[TRANSFORM_CROP_COMPOSITE_UNSUPPORTED]`, `[MULTI_INSTANCE_UNSUPPORTED]`).
+3. **Overlay label renders a localized, human-readable refusal:**
+   - The canvas label explains that the target cannot be edited without exposing `<LOCK_CODE>` or other internal protocol identifiers.
+   - The corresponding runtime/API response retains the lock code for diagnostics.
 
 4. **Drag and write actions stay disabled:**
    - Drag attempts fail with `ok=False` and report the lock code.
@@ -45,7 +46,7 @@ All five must hold, measured live, for issue #52 to pass:
 
 ## Blocked conditions
 
-- Any gate family fails to render its lock code in the overlay.
+- Any gate family renders an internal lock/protocol code in the canvas label, or fails to present a localized, human-readable refusal.
 - Drag or write modifies source files when targeting a locked element.
 - Bounding box is cleared or hidden instead of highlighting the selected locked target.
 

--- a/docs/superpowers/spikes/2026-08-02-failed-gate-ui-criteria.md
+++ b/docs/superpowers/spikes/2026-08-02-failed-gate-ui-criteria.md
@@ -4,6 +4,14 @@ Written **before** claiming completion of issue #52. PR #25 proved the locked-st
 
 **SDK under test:** Ren'Py **8.5.3**.
 
+> **Historical status:** The August 11, 2026 Live Editor remediation
+> ([#80](https://github.com/alex-jordan547/renforge-mcp/pull/80)) superseded
+> pass condition 3 below. The current UI presents a localized, human-readable
+> refusal and deliberately keeps internal protocol lock codes out of the canvas
+> label. Runtime/API responses still carry the code for diagnostics. See
+> `test_editor_lock_ui_never_exposes_internal_codes_or_expands_canvas_label`
+> for the enforced current contract.
+
 ## What the editor needs to be true
 
 When a user clicks or selects a locked visual-editor target:

--- a/src/renforge/autopilot.py
+++ b/src/renforge/autopilot.py
@@ -8,11 +8,10 @@ that work reliably (launch / advance / list_choices / select_choice /
 poll_events) — no in-game save/load, which cannot be driven from the bridge's
 main-thread callback.
 
-Standard Ren'Py ``choice`` screens are preferred. When a game blocks on a
-custom screen instead, a conservative fallback accepts the first non-internal
-screen with at least two actionable textual controls. This excludes persistent
-one-button story controls, disabled/no-op controls, and known overlays such as
-the quick menu.
+Menus are discovered from the active screen's Ren'Py ``items`` data rather
+than inferred from arbitrary focusable controls. This includes standard,
+custom-named, NVL, and one-item Ren'Py menus while leaving unrelated HUD and
+overlay buttons alone.
 """
 
 from __future__ import annotations
@@ -35,58 +34,18 @@ def _story_labels(project_path: str | Path) -> set[str]:
     return {label["name"] for label in index.get("labels", []) if not label["name"].startswith("_")}
 
 
-_NON_NARRATIVE_SCREENS = {"quick_menu", "say", "notify"}
-
-
 def _menu_choices(client) -> list[dict]:
-    """Return one active narrative choice group, preferring Ren'Py's standard screen."""
-    raw_choices = [
+    """Return controls proven to be backed by an active Ren'Py menu item."""
+    # TODO: Add an opt-in game-specific adapter hook for custom call_screen
+    # interactions that do not expose Ren'Py menu items. Do not infer narrative
+    # intent from control count or screen names.
+    return [
         choice
         for choice in client.list_choices()
-        if isinstance(choice, dict) and choice.get("text")
+        if isinstance(choice, dict)
+        and choice.get("menu_item") is True
+        and choice.get("text")
     ]
-
-    standard = [choice for choice in raw_choices if choice.get("screen") == "choice"]
-    if standard:
-        return standard
-
-    groups: dict[str, list[dict]] = {}
-    for choice in raw_choices:
-        screen = choice.get("screen")
-        if (
-            not isinstance(screen, str)
-            or not screen
-            or screen.startswith("_")
-            or screen in _NON_NARRATIVE_SCREENS
-        ):
-            continue
-        groups.setdefault(screen, []).append(choice)
-
-    if not groups:
-        return []
-
-    elements = client.list_ui_elements()
-    actionable = {
-        (element.get("screen"), element.get("text"))
-        for element in elements
-        if isinstance(element, dict)
-        and element.get("enabled") is not False
-        and element.get("clickable") is not False
-        and element.get("action") != "NullAction"
-    }
-
-    # A lone text control is commonly an always-on HUD or story fixture. Requiring
-    # a group avoids repeatedly clicking it while still supporting call_screen
-    # menus such as the demo's village gate.
-    for choices in groups.values():
-        selectable = [
-            choice
-            for choice in choices
-            if (choice.get("screen"), choice.get("text")) in actionable
-        ]
-        if len(selectable) >= 2:
-            return selectable
-    return []
 
 
 def autopilot(

--- a/src/renforge/autopilot.py
+++ b/src/renforge/autopilot.py
@@ -1,17 +1,18 @@
-"""Autopilot: explore a Ren'Py visual novel and report label coverage + crashes.
+"""Autopilot: replay a Ren'Py story to explore menus and report outcomes.
 
-Strategy — systematic branch exploration by replay. Each run launches the game
-fresh, replays a fixed prefix of menu choices, then at the first *new* menu it
-takes choice 0 and queues the remaining choices as future runs. Repeating until
-the frontier is empty covers every branch combination, using only primitives
-that work reliably (launch / advance / list_choices / select_choice /
-poll_events) — no in-game save/load, which cannot be driven from the bridge's
-main-thread callback.
+Each run launches the game fresh and replays a fixed prefix of earlier menu
+selections. At the next new menu, Autopilot selects the first choice and queues
+the remaining choices as prefixes for later runs. It collects label and dialogue
+events after every interaction, records bridge exceptions as crashes, and stops
+a run when a story label repeats or the step limit is reached.
 
-Menus are discovered from the active screen's Ren'Py ``items`` data rather
-than inferred from arbitrary focusable controls. This includes standard,
-custom-named, NVL, and one-item Ren'Py menus while leaving unrelated HUD and
-overlay buttons alone.
+The bridge derives the current story choices from the active menu screen's
+``items`` scope and maps actionable item captions to visible controls. This is
+the data Ren'Py supplies to standard, custom-named, NVL, and one-item menu
+screens. Other ``call_screen`` interactions that do not expose menu ``items``
+are not currently explored automatically.
+
+Ren'Py menu screens: https://www.renpy.org/doc/html/menus.html#menu-arguments
 """
 
 from __future__ import annotations
@@ -35,16 +36,14 @@ def _story_labels(project_path: str | Path) -> set[str]:
 
 
 def _menu_choices(client) -> list[dict]:
-    """Return controls proven to be backed by an active Ren'Py menu item."""
+    """Return the active story-menu controls in bridge display order."""
     # TODO: Add an opt-in game-specific adapter hook for custom call_screen
     # interactions that do not expose Ren'Py menu items. Do not infer narrative
     # intent from control count or screen names.
     return [
         choice
-        for choice in client.list_choices()
-        if isinstance(choice, dict)
-        and choice.get("menu_item") is True
-        and choice.get("text")
+        for choice in client.list_menu_choices()
+        if isinstance(choice, dict) and choice.get("text")
     ]
 
 

--- a/src/renforge/autopilot.py
+++ b/src/renforge/autopilot.py
@@ -8,9 +8,11 @@ that work reliably (launch / advance / list_choices / select_choice /
 poll_events) — no in-game save/load, which cannot be driven from the bridge's
 main-thread callback.
 
-Menus are detected by ``list_choices`` returning options. (A game with an
-always-on quick menu could surface non-choice buttons here; refining detection
-to the active ``choice`` screen is a future improvement.)
+Standard Ren'Py ``choice`` screens are preferred. When a game blocks on a
+custom screen instead, a conservative fallback accepts the first non-internal
+screen with at least two actionable textual controls. This excludes persistent
+one-button story controls, disabled/no-op controls, and known overlays such as
+the quick menu.
 """
 
 from __future__ import annotations
@@ -33,9 +35,58 @@ def _story_labels(project_path: str | Path) -> set[str]:
     return {label["name"] for label in index.get("labels", []) if not label["name"].startswith("_")}
 
 
+_NON_NARRATIVE_SCREENS = {"quick_menu", "say", "notify"}
+
+
 def _menu_choices(client) -> list[dict]:
-    """Choices that belong to the active ``choice`` screen (ignores quick menu)."""
-    return [c for c in client.list_choices() if c.get("screen") == "choice"]
+    """Return one active narrative choice group, preferring Ren'Py's standard screen."""
+    raw_choices = [
+        choice
+        for choice in client.list_choices()
+        if isinstance(choice, dict) and choice.get("text")
+    ]
+
+    standard = [choice for choice in raw_choices if choice.get("screen") == "choice"]
+    if standard:
+        return standard
+
+    groups: dict[str, list[dict]] = {}
+    for choice in raw_choices:
+        screen = choice.get("screen")
+        if (
+            not isinstance(screen, str)
+            or not screen
+            or screen.startswith("_")
+            or screen in _NON_NARRATIVE_SCREENS
+        ):
+            continue
+        groups.setdefault(screen, []).append(choice)
+
+    if not groups:
+        return []
+
+    elements = client.list_ui_elements()
+    actionable = {
+        (element.get("screen"), element.get("text"))
+        for element in elements
+        if isinstance(element, dict)
+        and element.get("enabled") is not False
+        and element.get("clickable") is not False
+        and element.get("action") != "NullAction"
+    }
+
+    # A lone text control is commonly an always-on HUD or story fixture. Requiring
+    # a group avoids repeatedly clicking it while still supporting call_screen
+    # menus such as the demo's village gate.
+    for choices in groups.values():
+        selectable = [
+            choice
+            for choice in choices
+            if (choice.get("screen"), choice.get("text")) in actionable
+        ]
+        if len(selectable) >= 2:
+            return selectable
+    return []
 
 
 def autopilot(

--- a/src/renforge/bridge/bridge.rpy
+++ b/src/renforge/bridge/bridge.rpy
@@ -1598,9 +1598,47 @@ init python:
                 choices.append((focus, text, element.get("screen")))
         return choices
 
+    def _renforge_active_menu_captions(screen_name):
+        """Captions backed by an active Ren'Py menu screen's items data."""
+        if not screen_name:
+            return set()
+        try:
+            screen = renpy.get_screen(screen_name)
+            scope = getattr(screen, "scope", None) or {}
+            items = scope.get("items")
+        except Exception:
+            return set()
+        if not isinstance(items, (builtins.list, tuple)):
+            return set()
+
+        captions = set()
+        for item in items:
+            # A menu caption can have action=None; it is not selectable.
+            if getattr(item, "action", None) is None:
+                continue
+            caption = getattr(item, "caption", None)
+            if caption is None:
+                continue
+            try:
+                caption = str(caption).strip()
+            except Exception:
+                continue
+            if caption:
+                captions.add(caption)
+        return captions
+
     def _renforge_h_list_choices(payload):
         choices = _renforge_focusable_choices()
-        return {"choices": [{"index": i, "text": t, "screen": s} for i, (_f, t, s) in enumerate(choices)]}
+        menu_captions = {}
+        result = []
+        for index, (_focus, text, screen) in enumerate(choices):
+            item = {"index": index, "text": text, "screen": screen}
+            if screen not in menu_captions:
+                menu_captions[screen] = _renforge_active_menu_captions(screen)
+            if text in menu_captions[screen]:
+                item["menu_item"] = True
+            result.append(item)
+        return {"choices": result}
 
     def _renforge_h_list_ui_elements(payload):
         payload = payload or {}

--- a/src/renforge/bridge/bridge.rpy
+++ b/src/renforge/bridge/bridge.rpy
@@ -1628,16 +1628,26 @@ init python:
         return captions
 
     def _renforge_h_list_choices(payload):
-        choices = _renforge_focusable_choices()
-        menu_captions = {}
+        return {
+            "choices": [
+                {"index": index, "text": text, "screen": screen}
+                for index, (_focus, text, screen) in enumerate(_renforge_focusable_choices())
+            ]
+        }
+
+
+    def _renforge_h_list_menu_choices(payload):
+        """Visible controls backed by actionable items on their active menu screen."""
+        captions_by_screen = {}
         result = []
-        for index, (_focus, text, screen) in enumerate(choices):
-            item = {"index": index, "text": text, "screen": screen}
-            if screen not in menu_captions:
-                menu_captions[screen] = _renforge_active_menu_captions(screen)
-            if text in menu_captions[screen]:
-                item["menu_item"] = True
-            result.append(item)
+        for index, (_focus, text, screen) in enumerate(_renforge_focusable_choices()):
+            if screen not in captions_by_screen:
+                captions_by_screen[screen] = _renforge_active_menu_captions(screen)
+            if text not in captions_by_screen[screen]:
+                continue
+            # Preserve the broad focus-list index so select_choice(index=...) keeps
+            # referring to the same control as list_choices().
+            result.append({"index": index, "text": text, "screen": screen})
         return {"choices": result}
 
     def _renforge_h_list_ui_elements(payload):
@@ -3105,6 +3115,7 @@ init python:
         "list_slots": _renforge_h_list_slots,
         "poll_events": _renforge_h_poll_events,
         "list_choices": _renforge_h_list_choices,
+        "list_menu_choices": _renforge_h_list_menu_choices,
         "select_choice": _renforge_h_select_choice,
         "list_ui_elements": _renforge_h_list_ui_elements,
         "click_element": _renforge_h_click_element,

--- a/src/renforge/bridge/client.py
+++ b/src/renforge/bridge/client.py
@@ -292,8 +292,12 @@ class BridgeClient:
         return self._checked("poll_events", {"since": since})
 
     def list_choices(self) -> list[dict[str, Any]]:
-        """Return textual focusables; menu-backed entries include ``menu_item=True``."""
+        """Return textual focusables as ``index``, ``text``, and ``screen``."""
         return self._checked("list_choices")["choices"]
+
+    def list_menu_choices(self) -> list[dict[str, Any]]:
+        """Return visible controls backed by the active Ren'Py menu's ``items``."""
+        return self._checked("list_menu_choices")["choices"]
 
     def select_choice(self, text: str | None = None, index: int | None = None) -> dict:
         """Select a menu option by visible text (preferred) or by index."""

--- a/src/renforge/bridge/client.py
+++ b/src/renforge/bridge/client.py
@@ -292,7 +292,7 @@ class BridgeClient:
         return self._checked("poll_events", {"since": since})
 
     def list_choices(self) -> list[dict[str, Any]]:
-        """Return the on-screen focusable choices as ``[{"index", "text"}, ...]``."""
+        """Return textual focusables; menu-backed entries include ``menu_item=True``."""
         return self._checked("list_choices")["choices"]
 
     def select_choice(self, text: str | None = None, index: int | None = None) -> dict:

--- a/src/renforge/bridge/editor.rpy
+++ b/src/renforge/bridge/editor.rpy
@@ -3667,6 +3667,9 @@ init 1100 python:
             )
         else:
             state.label_text = "id=%s" % selected
+        lock_code = _renforge_editor_lock_code(state.selected_lock_reason)
+        if lock_code:
+            state.label_text += " [%s]" % lock_code
         state.label_rect = [x, y, label_w, label_h]
         state.label_alpha = alpha
 

--- a/src/renforge/bridge/editor.rpy
+++ b/src/renforge/bridge/editor.rpy
@@ -3667,9 +3667,6 @@ init 1100 python:
             )
         else:
             state.label_text = "id=%s" % selected
-        lock_code = _renforge_editor_lock_code(state.selected_lock_reason)
-        if lock_code:
-            state.label_text += " [%s]" % lock_code
         state.label_rect = [x, y, label_w, label_h]
         state.label_alpha = alpha
 

--- a/src/renforge/editor_demo_runner.py
+++ b/src/renforge/editor_demo_runner.py
@@ -623,19 +623,18 @@ def run_demo_v1_scenario(client: Any) -> dict[str, Any]:
         "str(_renforge_editor_label_snapshot()['text']) "
         "if _renforge_editor_label_snapshot() is not None else ''"
     )
-    lock_code_token = f"[{locked_reason}]"
     lock_code_in_label = (
         isinstance(lock_label_text, str)
         and bool(lock_label_text.strip())
-        and lock_code_token in lock_label_text
+        and str(locked_reason) in lock_label_text
     )
     if not isinstance(lock_label_text, str) or not lock_label_text.strip():
         raise AssertionError(
             f"locked target label missing: reason={locked_reason!r}, label={lock_label_text!r}"
         )
-    if not lock_code_in_label:
+    if lock_code_in_label:
         raise AssertionError(
-            f"exact lock code missing from rendered editor label: token={lock_code_token!r}, "
+            f"internal lock code leaked into rendered editor label: reason={locked_reason!r}, "
             f"label={lock_label_text!r}"
         )
     locked_observation = locked_selection.get("observation")
@@ -777,7 +776,6 @@ def run_demo_v1_scenario(client: Any) -> dict[str, Any]:
             "observation_rect": locked_observation_rect,
             "observation": locked_observation,
             "lock_label_text": lock_label_text,
-            "lock_code_token": lock_code_token,
             "lock_code_in_label": lock_code_in_label,
         },
         "multi": {

--- a/src/renforge/editor_demo_runner.py
+++ b/src/renforge/editor_demo_runner.py
@@ -352,20 +352,51 @@ def run_demo_v1_scenario(client: Any) -> dict[str, Any]:
             )
         )
 
+    # The real input drag above has already moved the preview. Start this second
+    # drag from the same grab point on the widget's observed position rather than
+    # the now-stale original position.
+    grab_offset = [bx - baseline[0], by - baseline[1]]
+    move_start = [
+        real_preview[0] + grab_offset[0],
+        real_preview[1] + grab_offset[1],
+    ]
     move_points = [
-        [baseline[0], baseline[1]],
-        [baseline[0] + 30, baseline[1]],
-        [baseline[0] + 60, baseline[1]],
+        move_start,
+        [move_start[0] + 30, move_start[1]],
+        [move_start[0] + 60, move_start[1]],
     ]
     drag_move = _ed_require_ok(
         client.request("editor_task0_drag", {"points": move_points, "shift": False}),
         "move drag",
     )
     moved = _ed_wait_preview(client)
-    drag_delta = [moved[0] - baseline[0], moved[1] - baseline[1]]
+    drag_delta = [moved[0] - real_preview[0], moved[1] - real_preview[1]]
     if abs(drag_delta[0]) < 20 or abs(drag_delta[1]) > 1:
         raise AssertionError(f"move drag did not move horizontally: {drag_delta!r}")
 
+    # Exercise Shift while the moved target is still unobscured. Once snapped
+    # onto the neighbouring button below, coordinate selection correctly resolves
+    # to that topmost neighbour instead.
+    _ed_select(client, _TAKE_ID)
+    _ed_wait_analysis(client, locked=False)
+    shift_start = _ed_wait_preview(client)
+    shift_points = [
+        shift_start,
+        [shift_start[0] + 30, shift_start[1]],
+    ]
+    shift_drag = _ed_require_ok(
+        client.request("editor_task0_drag", {"points": shift_points, "shift": True}),
+        "shift drag",
+    )
+    shift_samples = shift_drag.get("samples") or []
+    if any(
+        sample.get("guide_x") is not None or sample.get("guide_y") is not None
+        for sample in shift_samples
+    ):
+        raise AssertionError(f"shift drag unexpectedly snapped: {shift_drag!r}")
+
+    _ed_select(client, _TAKE_ID)
+    _ed_wait_analysis(client, locked=False)
     cur = _ed_wait_preview(client)
     snap_points = [[cur[0], cur[1]], [cur[0], decline_top]]
     snap = _ed_require_ok(
@@ -463,16 +494,8 @@ def run_demo_v1_scenario(client: Any) -> dict[str, Any]:
         )
     _ed_require_ok(client.eval_expr("_renforge_editor_end_drag()"), "visual snap end")
 
-    shift_drag = _ed_require_ok(
-        client.request("editor_task0_drag", {"points": snap_points, "shift": True}),
-        "shift drag",
-    )
-    shift_samples = shift_drag.get("samples") or []
-    if any(
-        sample.get("guide_x") is not None or sample.get("guide_y") is not None
-        for sample in shift_samples
-    ):
-        raise AssertionError(f"shift drag unexpectedly snapped: {shift_drag!r}")
+    _ed_require_ok(client.request("editor_task0_reset", {}), "reset after snap proof")
+    _ed_wait_preview(client, expect=baseline)
 
     _ed_require_ok(_ed_select(client, _TAKE_ID), "take reselect for shift nudge")
     _ed_wait_analysis(client, locked=False)
@@ -583,9 +606,13 @@ def run_demo_v1_scenario(client: Any) -> dict[str, Any]:
         and bool(lock_label_text.strip())
         and str(locked_reason) in lock_label_text
     )
-    if not lock_code_in_label:
+    if not isinstance(lock_label_text, str) or not lock_label_text.strip():
         raise AssertionError(
-            f"locked code missing from rendered editor label: reason={locked_reason!r}, "
+            f"locked target label missing: reason={locked_reason!r}, label={lock_label_text!r}"
+        )
+    if lock_code_in_label:
+        raise AssertionError(
+            f"internal lock code leaked into rendered editor label: reason={locked_reason!r}, "
             f"label={lock_label_text!r}"
         )
     locked_observation = locked_selection.get("observation")

--- a/src/renforge/editor_demo_runner.py
+++ b/src/renforge/editor_demo_runner.py
@@ -374,31 +374,17 @@ def run_demo_v1_scenario(client: Any) -> dict[str, Any]:
     if abs(drag_delta[0]) < 20 or abs(drag_delta[1]) > 1:
         raise AssertionError(f"move drag did not move horizontally: {drag_delta!r}")
 
-    # Exercise Shift while the moved target is still unobscured. Once snapped
-    # onto the neighbouring button below, coordinate selection correctly resolves
-    # to that topmost neighbour instead.
-    _ed_select(client, _TAKE_ID)
-    _ed_wait_analysis(client, locked=False)
-    shift_start = _ed_wait_preview(client)
-    shift_points = [
-        shift_start,
-        [shift_start[0] + 30, shift_start[1]],
-    ]
-    shift_drag = _ed_require_ok(
-        client.request("editor_task0_drag", {"points": shift_points, "shift": True}),
-        "shift drag",
-    )
-    shift_samples = shift_drag.get("samples") or []
-    if any(
-        sample.get("guide_x") is not None or sample.get("guide_y") is not None
-        for sample in shift_samples
-    ):
-        raise AssertionError(f"shift drag unexpectedly snapped: {shift_drag!r}")
-
-    _ed_select(client, _TAKE_ID)
+    # Isolate the snap proof from the preceding movement checks. Both halves
+    # of the A/B test below start at the same baseline and use the same pointer
+    # path ending just inside the six-pixel snap-acquire threshold.
+    _ed_require_ok(client.request("editor_task0_reset", {}), "reset before snap proof")
+    _ed_wait_preview(client, expect=baseline)
+    _ed_require_ok(_ed_select(client, _TAKE_ID), "take reselect for snap proof")
     _ed_wait_analysis(client, locked=False)
     cur = _ed_wait_preview(client)
-    snap_points = [[cur[0], cur[1]], [cur[0], decline_top]]
+    snap_offset = 4
+    snap_pointer_y = decline_top + snap_offset
+    snap_points = [[cur[0], cur[1]], [cur[0], snap_pointer_y]]
     snap = _ed_require_ok(
         client.request("editor_task0_drag", {"points": snap_points, "shift": False}),
         "snap drag",
@@ -494,7 +480,43 @@ def run_demo_v1_scenario(client: Any) -> dict[str, Any]:
         )
     _ed_require_ok(client.eval_expr("_renforge_editor_end_drag()"), "visual snap end")
 
-    _ed_require_ok(client.request("editor_task0_reset", {}), "reset after snap proof")
+    # Repeat the exact same near-anchor pointer path with Shift held. It must
+    # preserve the raw four-pixel offset and must not expose either snap guide.
+    _ed_require_ok(client.request("editor_task0_reset", {}), "reset before shift snap proof")
+    _ed_wait_preview(client, expect=baseline)
+    _ed_require_ok(_ed_select(client, _TAKE_ID), "take reselect for shift snap proof")
+    _ed_wait_analysis(client, locked=False)
+    shift_start = _ed_wait_preview(client)
+    if shift_start != cur:
+        raise AssertionError(
+            f"snap A/B did not start from the same position: normal={cur!r}, shift={shift_start!r}"
+        )
+    shift_points = [list(point) for point in snap_points]
+    shift_drag = _ed_require_ok(
+        client.request("editor_task0_drag", {"points": shift_points, "shift": True}),
+        "shift snap drag",
+    )
+    shift_samples = shift_drag.get("samples")
+    if not isinstance(shift_samples, list) or not shift_samples:
+        raise AssertionError(f"shift snap samples missing: {shift_drag!r}")
+    if any(
+        sample.get("guide_x") is not None or sample.get("guide_y") is not None
+        for sample in shift_samples
+    ):
+        raise AssertionError(f"shift drag unexpectedly snapped: {shift_drag!r}")
+    shift_preview = shift_samples[-1].get("preview_position")
+    expected_shift_preview = [cur[0], snap_pointer_y]
+    if shift_preview != expected_shift_preview:
+        raise AssertionError(
+            "shift drag did not preserve the unsnapped pointer offset: "
+            f"expected={expected_shift_preview!r}, actual={shift_preview!r}, reply={shift_drag!r}"
+        )
+    if shift_preview == preview:
+        raise AssertionError(
+            f"snap A/B produced identical previews: normal={preview!r}, shift={shift_preview!r}"
+        )
+
+    _ed_require_ok(client.request("editor_task0_reset", {}), "reset after snap A/B proof")
     _ed_wait_preview(client, expect=baseline)
 
     _ed_require_ok(_ed_select(client, _TAKE_ID), "take reselect for shift nudge")
@@ -601,18 +623,19 @@ def run_demo_v1_scenario(client: Any) -> dict[str, Any]:
         "str(_renforge_editor_label_snapshot()['text']) "
         "if _renforge_editor_label_snapshot() is not None else ''"
     )
+    lock_code_token = f"[{locked_reason}]"
     lock_code_in_label = (
         isinstance(lock_label_text, str)
         and bool(lock_label_text.strip())
-        and str(locked_reason) in lock_label_text
+        and lock_code_token in lock_label_text
     )
     if not isinstance(lock_label_text, str) or not lock_label_text.strip():
         raise AssertionError(
             f"locked target label missing: reason={locked_reason!r}, label={lock_label_text!r}"
         )
-    if lock_code_in_label:
+    if not lock_code_in_label:
         raise AssertionError(
-            f"internal lock code leaked into rendered editor label: reason={locked_reason!r}, "
+            f"exact lock code missing from rendered editor label: token={lock_code_token!r}, "
             f"label={lock_label_text!r}"
         )
     locked_observation = locked_selection.get("observation")
@@ -704,6 +727,9 @@ def run_demo_v1_scenario(client: Any) -> dict[str, Any]:
         "drag_delta": drag_delta,
         "snap": {
             "reply": snap,
+            "points": snap_points,
+            "requested_y": snap_pointer_y,
+            "offset": snap_offset,
             "guide_y": guide_y,
             "preview": preview,
             "preview_on_anchor": abs(int(preview[1]) - decline_top) <= 1,
@@ -717,6 +743,8 @@ def run_demo_v1_scenario(client: Any) -> dict[str, Any]:
             "high_png_bytes": len(high_png),
         },
         "shift_drag": shift_drag,
+        "shift_points": shift_points,
+        "shift_preview": shift_preview,
         "shift_nudge": {
             "before": pre_shift_nudge,
             "after": post_shift_nudge,
@@ -749,6 +777,7 @@ def run_demo_v1_scenario(client: Any) -> dict[str, Any]:
             "observation_rect": locked_observation_rect,
             "observation": locked_observation,
             "lock_label_text": lock_label_text,
+            "lock_code_token": lock_code_token,
             "lock_code_in_label": lock_code_in_label,
         },
         "multi": {

--- a/tests/test_autopilot.py
+++ b/tests/test_autopilot.py
@@ -12,94 +12,42 @@ def test_story_labels_excludes_internal_labels() -> None:
 
 
 class _ChoiceClient:
-    def __init__(self, choices: list[dict], elements: list[dict] | None = None) -> None:
+    def __init__(self, choices: list[dict]) -> None:
         self.choices = choices
-        self.elements = (
-            elements
-            if elements is not None
-            else [
-                {
-                    **choice,
-                    "action": "Return",
-                    "enabled": True,
-                    "clickable": True,
-                }
-                for choice in choices
-            ]
-        )
 
     def list_choices(self) -> list[dict]:
         return self.choices
 
-    def list_ui_elements(self) -> list[dict]:
-        return self.elements
+
+def test_menu_choices_accepts_one_proven_menu_item() -> None:
+    menu_item = {
+        "text": "Continue",
+        "screen": "kinetic_continue",
+        "menu_item": True,
+    }
+
+    assert _menu_choices(_ChoiceClient([menu_item])) == [menu_item]
 
 
-def test_menu_choices_prefers_standard_choice_screen() -> None:
-    standard = {"text": "Take the ridge", "screen": "choice"}
-    choices = _menu_choices(
-        _ChoiceClient(
-            [
-                {"text": "Custom A", "screen": "story_choices"},
-                {"text": "Custom B", "screen": "story_choices"},
-                standard,
-            ]
-        )
-    )
-
-    assert choices == [standard]
-
-
-def test_menu_choices_accepts_multi_control_custom_screen() -> None:
-    custom = [
-        {"text": "Take the lantern", "screen": "village_gate_choices"},
-        {"text": "Stay home", "screen": "village_gate_choices"},
-        {"text": "Locked demo", "screen": "village_gate_choices"},
-        {"text": "Disabled demo", "screen": "village_gate_choices"},
+def test_menu_choices_returns_only_proven_menu_items() -> None:
+    menu_items = [
+        {"text": "Take the ridge", "screen": "story_menu", "menu_item": True},
+        {"text": "Stay home", "screen": "story_menu", "menu_item": True},
+    ]
+    controls = [
+        {"text": "Save", "screen": "quick_menu"},
+        *menu_items,
+        {"text": "Inventory", "screen": "hud"},
+        {"text": "Map", "screen": "hud"},
     ]
 
-    choices = _menu_choices(
-        _ChoiceClient(
-            [
-                {"text": "Save", "screen": "quick_menu"},
-                *custom,
-            ],
-            elements=[
-                {**custom[0], "action": "Return", "enabled": True, "clickable": True},
-                {**custom[1], "action": "Return", "enabled": True, "clickable": True},
-                {**custom[2], "action": "NullAction", "enabled": True, "clickable": True},
-                {**custom[3], "action": "Return", "enabled": False, "clickable": False},
-            ],
-        )
-    )
-
-    assert choices == custom[:2]
+    assert _menu_choices(_ChoiceClient(controls)) == menu_items
 
 
-def test_menu_choices_ignores_overlays_and_single_story_controls() -> None:
-    choices = _menu_choices(
-        _ChoiceClient(
-            [
-                {"text": "Save", "screen": "quick_menu"},
-                {"text": "Preferences", "screen": "quick_menu"},
-                {"text": "RF", "screen": "_renforge_editor_launcher"},
-                {"text": "Touch shrine", "screen": "shrine_controls"},
-            ]
-        )
-    )
+def test_menu_choices_does_not_infer_custom_choices_from_control_count() -> None:
+    controls = [
+        {"text": "Custom A", "screen": "custom_screen"},
+        {"text": "Custom B", "screen": "custom_screen"},
+    ]
 
-    assert choices == []
-
-
-def test_menu_choices_does_not_inventory_ui_without_a_candidate_group() -> None:
-    class _OverlayOnlyClient:
-        def list_choices(self) -> list[dict]:
-            return [
-                {"text": "Save", "screen": "quick_menu"},
-                {"text": "Preferences", "screen": "quick_menu"},
-            ]
-
-        def list_ui_elements(self) -> list[dict]:
-            raise AssertionError("UI inventory should not be requested")
-
-    assert _menu_choices(_OverlayOnlyClient()) == []
+    assert _menu_choices(_ChoiceClient(controls)) == []

--- a/tests/test_autopilot.py
+++ b/tests/test_autopilot.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from renforge.autopilot import _story_labels
+from renforge.autopilot import _menu_choices, _story_labels
 
 _DEMO = Path(__file__).resolve().parents[1] / "examples" / "demo_game"
 
@@ -9,3 +9,97 @@ def test_story_labels_excludes_internal_labels() -> None:
     labels = _story_labels(_DEMO)
     assert {"start", "village_gate", "crossroads", "ending_light", "main_menu"} <= labels
     assert not any(name.startswith("_") for name in labels)
+
+
+class _ChoiceClient:
+    def __init__(self, choices: list[dict], elements: list[dict] | None = None) -> None:
+        self.choices = choices
+        self.elements = (
+            elements
+            if elements is not None
+            else [
+                {
+                    **choice,
+                    "action": "Return",
+                    "enabled": True,
+                    "clickable": True,
+                }
+                for choice in choices
+            ]
+        )
+
+    def list_choices(self) -> list[dict]:
+        return self.choices
+
+    def list_ui_elements(self) -> list[dict]:
+        return self.elements
+
+
+def test_menu_choices_prefers_standard_choice_screen() -> None:
+    standard = {"text": "Take the ridge", "screen": "choice"}
+    choices = _menu_choices(
+        _ChoiceClient(
+            [
+                {"text": "Custom A", "screen": "story_choices"},
+                {"text": "Custom B", "screen": "story_choices"},
+                standard,
+            ]
+        )
+    )
+
+    assert choices == [standard]
+
+
+def test_menu_choices_accepts_multi_control_custom_screen() -> None:
+    custom = [
+        {"text": "Take the lantern", "screen": "village_gate_choices"},
+        {"text": "Stay home", "screen": "village_gate_choices"},
+        {"text": "Locked demo", "screen": "village_gate_choices"},
+        {"text": "Disabled demo", "screen": "village_gate_choices"},
+    ]
+
+    choices = _menu_choices(
+        _ChoiceClient(
+            [
+                {"text": "Save", "screen": "quick_menu"},
+                *custom,
+            ],
+            elements=[
+                {**custom[0], "action": "Return", "enabled": True, "clickable": True},
+                {**custom[1], "action": "Return", "enabled": True, "clickable": True},
+                {**custom[2], "action": "NullAction", "enabled": True, "clickable": True},
+                {**custom[3], "action": "Return", "enabled": False, "clickable": False},
+            ],
+        )
+    )
+
+    assert choices == custom[:2]
+
+
+def test_menu_choices_ignores_overlays_and_single_story_controls() -> None:
+    choices = _menu_choices(
+        _ChoiceClient(
+            [
+                {"text": "Save", "screen": "quick_menu"},
+                {"text": "Preferences", "screen": "quick_menu"},
+                {"text": "RF", "screen": "_renforge_editor_launcher"},
+                {"text": "Touch shrine", "screen": "shrine_controls"},
+            ]
+        )
+    )
+
+    assert choices == []
+
+
+def test_menu_choices_does_not_inventory_ui_without_a_candidate_group() -> None:
+    class _OverlayOnlyClient:
+        def list_choices(self) -> list[dict]:
+            return [
+                {"text": "Save", "screen": "quick_menu"},
+                {"text": "Preferences", "screen": "quick_menu"},
+            ]
+
+        def list_ui_elements(self) -> list[dict]:
+            raise AssertionError("UI inventory should not be requested")
+
+    assert _menu_choices(_OverlayOnlyClient()) == []

--- a/tests/test_autopilot.py
+++ b/tests/test_autopilot.py
@@ -12,42 +12,34 @@ def test_story_labels_excludes_internal_labels() -> None:
 
 
 class _ChoiceClient:
-    def __init__(self, choices: list[dict]) -> None:
-        self.choices = choices
+    def __init__(self, menu_choices: list[dict]) -> None:
+        self.menu_choices = menu_choices
+
+    def list_menu_choices(self) -> list[dict]:
+        return self.menu_choices
 
     def list_choices(self) -> list[dict]:
-        return self.choices
+        raise AssertionError("Autopilot must not depend on the broad list_choices schema")
 
 
 def test_menu_choices_accepts_one_proven_menu_item() -> None:
-    menu_item = {
+    menu_choice = {
+        "index": 2,
         "text": "Continue",
         "screen": "kinetic_continue",
-        "menu_item": True,
     }
 
-    assert _menu_choices(_ChoiceClient([menu_item])) == [menu_item]
+    assert _menu_choices(_ChoiceClient([menu_choice])) == [menu_choice]
 
 
-def test_menu_choices_returns_only_proven_menu_items() -> None:
-    menu_items = [
-        {"text": "Take the ridge", "screen": "story_menu", "menu_item": True},
-        {"text": "Stay home", "screen": "story_menu", "menu_item": True},
-    ]
-    controls = [
-        {"text": "Save", "screen": "quick_menu"},
-        *menu_items,
-        {"text": "Inventory", "screen": "hud"},
-        {"text": "Map", "screen": "hud"},
+def test_menu_choices_returns_only_bridge_proven_menu_items() -> None:
+    menu_choices = [
+        {"index": 1, "text": "Take the ridge", "screen": "story_menu"},
+        {"index": 2, "text": "Stay home", "screen": "story_menu"},
     ]
 
-    assert _menu_choices(_ChoiceClient(controls)) == menu_items
+    assert _menu_choices(_ChoiceClient(menu_choices)) == menu_choices
 
 
 def test_menu_choices_does_not_infer_custom_choices_from_control_count() -> None:
-    controls = [
-        {"text": "Custom A", "screen": "custom_screen"},
-        {"text": "Custom B", "screen": "custom_screen"},
-    ]
-
-    assert _menu_choices(_ChoiceClient(controls)) == []
+    assert _menu_choices(_ChoiceClient([])) == []

--- a/tests/test_bridge_runtime.py
+++ b/tests/test_bridge_runtime.py
@@ -1003,6 +1003,7 @@ def test_list_menu_choices_returns_only_items_from_their_active_screen(running_b
     focus_list[1].screen_name = "story_menu"
     focus_list[2].screen_name = "story_menu"
     focus_list[3].screen_name = "hud"
+    focus_list[3].widget._text = "Alpha choice"
 
     menu_items = [
         types.SimpleNamespace(caption="Alpha choice", action=object()),
@@ -1011,11 +1012,9 @@ def test_list_menu_choices_returns_only_items_from_their_active_screen(running_b
     ]
     screens = {
         "story_menu": types.SimpleNamespace(scope={"items": menu_items}),
-        # Repeating a story caption on a non-menu screen must not create a
-        # false match, which is why captions are kept as a set per screen.
-        "hud": types.SimpleNamespace(
-            scope={"items": [types.SimpleNamespace(caption="Load icon", action=None)]}
-        ),
+        # The HUD visibly repeats a story caption but has no menu items.
+        # A single unioned caption set would falsely classify that HUD control.
+        "hud": types.SimpleNamespace(scope={}),
     }
     running_bridge.renpy.get_screen = screens.get
 

--- a/tests/test_bridge_runtime.py
+++ b/tests/test_bridge_runtime.py
@@ -978,6 +978,32 @@ def test_list_choices_enumerates_focusable_text(running_bridge):
     assert texts == ["Alpha choice", "Beta choice", "Load icon"]  # the default focus is skipped
 
 
+def test_list_choices_marks_only_active_menu_items(running_bridge):
+    focus_list = running_bridge.renpy.display.focus.focus_list
+    focus_list[1].screen_name = "story_menu"
+    focus_list[2].screen_name = "story_menu"
+    focus_list[3].screen_name = "hud"
+
+    menu_items = [
+        types.SimpleNamespace(caption="Alpha choice", action=object()),
+        types.SimpleNamespace(caption="Beta choice", action=object()),
+        types.SimpleNamespace(caption="Narrator caption", action=None),
+    ]
+    screens = {
+        "story_menu": types.SimpleNamespace(scope={"items": menu_items}),
+        "hud": types.SimpleNamespace(scope={}),
+    }
+    running_bridge.renpy.get_screen = screens.get
+
+    choices = running_bridge.client.list_choices()
+
+    assert [choice["text"] for choice in choices if choice.get("menu_item")] == [
+        "Alpha choice",
+        "Beta choice",
+    ]
+    assert next(choice for choice in choices if choice["text"] == "Load icon").get("menu_item") is None
+
+
 def test_select_choice_by_text_clicks_focus_center(running_bridge):
     reply = running_bridge.client.select_choice(text="Beta")
     assert reply["ok"] is True

--- a/tests/test_bridge_runtime.py
+++ b/tests/test_bridge_runtime.py
@@ -994,7 +994,7 @@ def test_list_choices_schema_is_unchanged_when_menu_items_are_active(running_bri
     assert running_bridge.client.list_choices() == [
         {"index": 0, "text": "Alpha choice", "screen": "story_menu"},
         {"index": 1, "text": "Beta choice", "screen": "story_menu"},
-        {"index": 2, "text": "Load icon", "screen": "quick_menu"},
+        {"index": 2, "text": "Load icon", "screen": None},
     ]
 
 

--- a/tests/test_bridge_runtime.py
+++ b/tests/test_bridge_runtime.py
@@ -978,7 +978,27 @@ def test_list_choices_enumerates_focusable_text(running_bridge):
     assert texts == ["Alpha choice", "Beta choice", "Load icon"]  # the default focus is skipped
 
 
-def test_list_choices_marks_only_active_menu_items(running_bridge):
+def test_list_choices_schema_is_unchanged_when_menu_items_are_active(running_bridge):
+    focus_list = running_bridge.renpy.display.focus.focus_list
+    focus_list[1].screen_name = "story_menu"
+    focus_list[2].screen_name = "story_menu"
+    running_bridge.renpy.get_screen = lambda _name: types.SimpleNamespace(
+        scope={
+            "items": [
+                types.SimpleNamespace(caption="Alpha choice", action=object()),
+                types.SimpleNamespace(caption="Beta choice", action=object()),
+            ]
+        }
+    )
+
+    assert running_bridge.client.list_choices() == [
+        {"index": 0, "text": "Alpha choice", "screen": "story_menu"},
+        {"index": 1, "text": "Beta choice", "screen": "story_menu"},
+        {"index": 2, "text": "Load icon", "screen": "quick_menu"},
+    ]
+
+
+def test_list_menu_choices_returns_only_items_from_their_active_screen(running_bridge):
     focus_list = running_bridge.renpy.display.focus.focus_list
     focus_list[1].screen_name = "story_menu"
     focus_list[2].screen_name = "story_menu"
@@ -991,17 +1011,18 @@ def test_list_choices_marks_only_active_menu_items(running_bridge):
     ]
     screens = {
         "story_menu": types.SimpleNamespace(scope={"items": menu_items}),
-        "hud": types.SimpleNamespace(scope={}),
+        # Repeating a story caption on a non-menu screen must not create a
+        # false match, which is why captions are kept as a set per screen.
+        "hud": types.SimpleNamespace(
+            scope={"items": [types.SimpleNamespace(caption="Load icon", action=None)]}
+        ),
     }
     running_bridge.renpy.get_screen = screens.get
 
-    choices = running_bridge.client.list_choices()
-
-    assert [choice["text"] for choice in choices if choice.get("menu_item")] == [
-        "Alpha choice",
-        "Beta choice",
+    assert running_bridge.client.list_menu_choices() == [
+        {"index": 0, "text": "Alpha choice", "screen": "story_menu"},
+        {"index": 1, "text": "Beta choice", "screen": "story_menu"},
     ]
-    assert next(choice for choice in choices if choice["text"] == "Load icon").get("menu_item") is None
 
 
 def test_select_choice_by_text_clicks_focus_center(running_bridge):

--- a/tests/test_integration_sdk.py
+++ b/tests/test_integration_sdk.py
@@ -606,18 +606,68 @@ def test_live_named_save_state_round_trip(sdk, demo_copy: Path) -> None:
         }
 
 
+@pytest.fixture
+def autopilot_menu_copy(demo_copy: Path) -> Path:
+    """A real-engine fixture containing only supported Ren'Py menu semantics."""
+    (demo_copy / "game" / "script.rpy").write_text(
+        """
+screen autopilot_choice(items):
+    vbox:
+        for item in items:
+            if item.action:
+                textbutton item.caption action item.action
+
+label start:
+    "Choose a path."
+    menu (screen="autopilot_choice"):
+        "Take the ridge.":
+            jump ridge
+        "Stay home.":
+            jump home
+
+label ridge:
+    "The ridge is clear."
+    menu (screen="autopilot_choice"):
+        "Continue.":
+            jump ridge_end
+
+label home:
+    "Home is warm."
+    menu (screen="autopilot_choice"):
+        "Continue.":
+            jump home_end
+
+label ridge_end:
+    "Ridge ending."
+    return
+
+label home_end:
+    "Home ending."
+    return
+""".lstrip(),
+        encoding="utf-8",
+    )
+    return demo_copy
+
+
 @pytest.mark.skipif(not os.environ.get("DISPLAY"), reason="autopilot needs a display (set DISPLAY, or run under xvfb)")
-def test_autopilot_covers_all_labels(sdk, demo_copy: Path) -> None:
+def test_autopilot_covers_supported_menu_items(sdk, autopilot_menu_copy: Path) -> None:
     from renforge.autopilot import autopilot
     from renforge.project import RenpyProject
 
-    report = autopilot(sdk, RenpyProject(demo_copy), max_runs=8, max_steps=30, settle=0.5)
+    report = autopilot(
+        sdk,
+        RenpyProject(autopilot_menu_copy),
+        max_runs=4,
+        max_steps=20,
+        settle=0.5,
+    )
 
     assert report["ok"] is True
     assert report["coverage"] == 1.0
     assert report["labels_unreached"] == []
     assert report["crashes"] == []
-    assert report["choices_explored"] >= 2  # both branches taken
+    assert report["choices_explored"] >= 4
 
 
 @pytest.mark.skipif(not os.environ.get("DISPLAY"), reason="live bridge needs a display (set DISPLAY, or run under xvfb)")

--- a/tests/test_integration_sdk.py
+++ b/tests/test_integration_sdk.py
@@ -2,7 +2,9 @@
 
 Opt-in: these download/use a real Ren'Py SDK and invoke it. Enable with::
 
-    RENFORGE_SDK_TESTS=1 pytest tests/test_integration_sdk.py
+    RENFORGE_SDK_TESTS=1 pytest \
+        tests/test_integration_sdk.py \
+        tests/test_integration_sdk_live_demo_acceptance.py
 
 Optionally pin the version with ``RENFORGE_SDK_VERSION`` (default: the
 ``DEFAULT_RENPY_VERSION`` RenForge ships with).
@@ -30,13 +32,14 @@ _DEMO = Path(__file__).resolve().parents[1] / "examples" / "demo_game"
 @pytest.fixture(scope="module")
 def sdk():
     from renforge.sdk import DEFAULT_RENPY_VERSION, get_or_install_sdk
-    from renforge.editor_live_common import DEMO_COPY_IGNORE
 
     return get_or_install_sdk(os.environ.get("RENFORGE_SDK_VERSION", DEFAULT_RENPY_VERSION))
 
 
 @pytest.fixture
 def demo_copy(tmp_path: Path) -> Path:
+    from renforge.editor_live_common import DEMO_COPY_IGNORE
+
     destination = tmp_path / "demo"
     # Never inherit Ren'Py bytecode/cache from a previous local run: stale
     # compiled scripts can make ``--warp`` skip a fixture label entirely.

--- a/tests/test_integration_sdk.py
+++ b/tests/test_integration_sdk.py
@@ -611,6 +611,8 @@ def autopilot_menu_copy(demo_copy: Path) -> Path:
     """A real-engine fixture containing only supported Ren'Py menu semantics."""
     (demo_copy / "game" / "script.rpy").write_text(
         """
+define config.main_menu = False
+
 screen autopilot_choice(items):
     vbox:
         for item in items:

--- a/tests/test_integration_sdk.py
+++ b/tests/test_integration_sdk.py
@@ -611,7 +611,8 @@ def autopilot_menu_copy(demo_copy: Path) -> Path:
     """A real-engine fixture containing only supported Ren'Py menu semantics."""
     (demo_copy / "game" / "script.rpy").write_text(
         """
-define config.main_menu = False
+label main_menu:
+    return
 
 screen autopilot_choice(items):
     vbox:

--- a/tests/test_integration_sdk_live_demo_acceptance.py
+++ b/tests/test_integration_sdk_live_demo_acceptance.py
@@ -108,9 +108,8 @@ def test_live_demo_editor_v1_acceptance(sdk, demo_copy: Path) -> None:
     assert locked["save_enabled"] is False
     assert len(locked["observation_rect"]) == 4
     assert locked["lock_label_text"]
-    assert locked["lock_code_token"] == f"[{locked['selected_lock_reason']}]"
-    assert locked["lock_code_token"] in locked["lock_label_text"]
-    assert locked["lock_code_in_label"] is True
+    assert locked["selected_lock_reason"] not in locked["lock_label_text"]
+    assert locked["lock_code_in_label"] is False
     assert report["reset_after_save_error"] == "RESET_UNAVAILABLE"
 
     assert report["multi"]["dirty_before_undo"] >= 2

--- a/tests/test_integration_sdk_live_demo_acceptance.py
+++ b/tests/test_integration_sdk_live_demo_acceptance.py
@@ -19,13 +19,14 @@ _DEMO = Path(__file__).resolve().parents[1] / "examples" / "demo_game"
 @pytest.fixture(scope="module")
 def sdk():
     from renforge.sdk import DEFAULT_RENPY_VERSION, get_or_install_sdk
-    from renforge.editor_live_common import DEMO_COPY_IGNORE
 
     return get_or_install_sdk(os.environ.get("RENFORGE_SDK_VERSION", DEFAULT_RENPY_VERSION))
 
 
 @pytest.fixture
 def demo_copy(tmp_path: Path) -> Path:
+    from renforge.editor_live_common import DEMO_COPY_IGNORE
+
     destination = tmp_path / "demo"
     shutil.copytree(_DEMO, destination, ignore=DEMO_COPY_IGNORE)
     return destination
@@ -95,7 +96,7 @@ def test_live_demo_editor_v1_acceptance(sdk, demo_copy: Path) -> None:
     assert locked["save_enabled"] is False
     assert len(locked["observation_rect"]) == 4
     assert locked["lock_label_text"]
-    assert locked["lock_code_in_label"] is True
+    assert locked["lock_code_in_label"] is False
     assert report["reset_after_save_error"] == "RESET_UNAVAILABLE"
 
     assert report["multi"]["dirty_before_undo"] >= 2

--- a/tests/test_integration_sdk_live_demo_acceptance.py
+++ b/tests/test_integration_sdk_live_demo_acceptance.py
@@ -67,8 +67,20 @@ def test_live_demo_editor_v1_acceptance(sdk, demo_copy: Path) -> None:
     assert snap["guide_over_neighbour"] > 2.0
     assert snap["guide_opacity_delta"] > 0.0
 
+    assert snap["offset"] == 4
+    assert snap["requested_y"] == snap["guide_y"] + snap["offset"]
+    assert report["shift_points"] == snap["points"]
     assert report["shift_drag"]["guide_x"] is None
     assert report["shift_drag"]["guide_y"] is None
+    assert all(
+        sample["guide_x"] is None and sample["guide_y"] is None
+        for sample in report["shift_drag"]["samples"]
+    )
+    assert report["shift_preview"] == [
+        snap["points"][0][0],
+        snap["requested_y"],
+    ]
+    assert report["shift_preview"] != snap["preview"]
     assert report["shift_nudge"]["delta"] == [10, 0]
 
     history = report["history"]
@@ -96,7 +108,9 @@ def test_live_demo_editor_v1_acceptance(sdk, demo_copy: Path) -> None:
     assert locked["save_enabled"] is False
     assert len(locked["observation_rect"]) == 4
     assert locked["lock_label_text"]
-    assert locked["lock_code_in_label"] is False
+    assert locked["lock_code_token"] == f"[{locked['selected_lock_reason']}]"
+    assert locked["lock_code_token"] in locked["lock_label_text"]
+    assert locked["lock_code_in_label"] is True
     assert report["reset_after_save_error"] == "RESET_UNAVAILABLE"
 
     assert report["multi"]["dirty_before_undo"] >= 2


### PR DESCRIPTION
## Summary

- add a broad Ren'Py 8.5.3 integration job to pull-request CI, retaining logs, JUnit output, screenshots, and Autopilot reports as artifacts
- narrow Autopilot to visible controls backed by the active Ren'Py menu `items` data
- support custom-named, NVL-style, and one-item Ren'Py menus without screen-name or control-count heuristics
- preserve the existing `list_choices()` response exactly as `{index, text, screen}`; use a dedicated internal `list_menu_choices()` bridge call for Autopilot provenance
- document the current boundary: custom `call_screen` interactions without Ren'Py menu items are not explored automatically
- preserve the editor runner's stale-coordinate correction and restore a same-path snap/Shift-no-snap A/B proof
- restore the documented 8.5.3 SDK default and existing `uv` guidance

## Compatibility and regression coverage

- audited all `list_choices()` consumers; public MCP, UI, scenario diagnostics, and existing tests retain the unchanged API
- captions remain scoped per screen so HUD/overlay text cannot be mistaken for a story choice
- regression tests cover the exact legacy schema, screen-scoped menu discovery, custom-named and one-item menus, and the editor Shift-drag behavior

## Validation

Validated in the fork's full CI matrix:

- UI build and package contract checks
- Python 3.11 on Ubuntu; Python 3.12 on Ubuntu, macOS, and Windows
- real-engine integration: **21 passed** against Ren'Py 8.5.3

Fork validation run: https://github.com/Aaron-Fine/renforge-mcp/actions/runs/33450456860

## Résumé par Sourcery

Exécutez de véritables tests d’intégration Ren’Py dans la CI des pull requests et faites en sorte qu’Autopilot repose uniquement sur des contrôles actionnables associés à des données de menu actives.

Nouvelles fonctionnalités :
- Ajout d’un job d’intégration Ren’Py 8.5.3 exécuté à chaque pull request, avec configuration du SDK mise en cache et conservation des artefacts de diagnostic.
- Activation de l’exploration par Autopilot des choix actionnables issus des données de menu Ren’Py actives, y compris les menus aux noms personnalisés, de style NVL et à un seul élément.

Corrections de bugs :
- Empêcher Autopilot de considérer des contrôles ou légendes visibles sans rapport comme des choix de l’histoire.
- Préserver la correction des coordonnées obsolètes et vérifier le comportement distinct du glissement de l’éditeur avec accrochage et sans accrochage via Shift.
- Garantir que les libellés de l’éditeur verrouillé restent compréhensibles sans exposer les codes de verrouillage internes.

Améliorations :
- Conserver la réponse publique de `list_choices` inchangée tout en ajoutant une API distincte de liaison des choix de menu pour la provenance d’Autopilot.
- Documenter les limites prises en charge par Autopilot, le workflow de test avec le moteur réel, l’isolation des fixtures et la politique relative aux artefacts de diagnostic.

CI :
- Exécuter la vaste suite d’intégration du SDK avec le moteur réel dans la CI des pull requests sous Linux/Xvfb.

Documentation :
- Mettre à jour la documentation destinée aux contributeurs, l’architecture, l’environnement cloud, MCP, le README et le changelog afin de couvrir la nouvelle couverture d’intégration et le comportement d’Autopilot.

Tests :
- Étendre la couverture de régression du bridge et d’Autopilot pour la compatibilité des schémas, la découverte des menus limitée à l’écran, les menus personnalisés, les menus à un seul élément et le comportement de glissement de l’éditeur.
- Étendre la couverture d’intégration Ren’Py réelle afin de valider l’exploration des menus pris en charge et le flux d’acceptation de l’éditeur.

<details>
<summary>Original summary in English</summary>

## Résumé par Sourcery

Exécuter de vrais tests d’intégration Ren’Py dans la CI des pull requests et limiter l’exploration d’Autopilot aux contrôles exploitables associés à des éléments de menu actifs.

Nouvelles fonctionnalités :
- Exécuter la vaste suite d’intégration Ren’Py 8.5.3 sur chaque pull request et conserver des artefacts de diagnostic ciblés.
- Faire en sorte qu’Autopilot explore les choix exploitables issus des données de menu Ren’Py actives, y compris les menus aux noms personnalisés, de style NVL et à élément unique.

Corrections de bugs :
- Empêcher Autopilot de prendre des contrôles ou des légendes visibles sans rapport pour des choix de scénario.
- Préserver la gestion par l’éditeur des coordonnées obsolètes et vérifier le comportement distinct des déplacements par glisser-déposer avec accrochage et sans accrochage via Maj.
- Conserver des libellés d’éditeur verrouillé lisibles par les utilisateurs sans exposer les identifiants internes de verrouillage.

Améliorations :
- Préserver le schéma public de `list_choices()` tout en ajoutant une API distincte de passerelle de provenance des menus pour Autopilot.
- Isoler les fixtures du moteur réel et documenter les limites prises en charge par Autopilot ainsi que le workflow des tests d’intégration.

CI :
- Ajouter à la CI des pull requests un job d’intégration Ren’Py 8.5.3 sous Linux/Xvfb avec mise en cache, incluant les journaux, la sortie JUnit, les captures d’écran et les rapports Autopilot.

Documentation :
- Mettre à jour la documentation destinée aux contributeurs, l’architecture, l’environnement cloud, MCP, le README et le changelog concernant la CI avec moteur réel et le comportement d’Autopilot basé sur les menus.

Tests :
- Étendre la couverture de non-régression de la passerelle, d’Autopilot et du moteur réel pour la découverte des menus, la compatibilité des schémas, les variantes de menus prises en charge et le comportement de déplacement par glisser-déposer de l’éditeur.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Run real Ren’Py integration tests in pull-request CI and restrict Autopilot exploration to actionable controls backed by active menu items.

New Features:
- Run the broad Ren’Py 8.5.3 integration suite on every pull request and retain focused diagnostic artifacts.
- Make Autopilot explore actionable choices from active Ren’Py menu data, including custom-named, NVL-style, and one-item menus.

Bug Fixes:
- Prevent Autopilot from mistaking unrelated visible controls or captions for story choices.
- Preserve editor stale-coordinate handling and verify distinct snapped and Shift-unsnapped drag behavior.
- Keep locked-editor labels human-readable without exposing internal lock identifiers.

Enhancements:
- Preserve the public `list_choices()` schema while adding a separate menu-provenance bridge API for Autopilot.
- Isolate real-engine fixtures and document the supported Autopilot boundary and integration-test workflow.

CI:
- Add a cached Linux/Xvfb Ren’Py 8.5.3 integration job to pull-request CI with logs, JUnit output, screenshots, and Autopilot reports.

Documentation:
- Update contributor, architecture, cloud-environment, MCP, README, and changelog documentation for real-engine CI and menu-backed Autopilot behavior.

Tests:
- Expand bridge, Autopilot, and real-engine regression coverage for menu discovery, schema compatibility, supported menu variants, and editor drag behavior.

</details>

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Autopilot now recognizes choices from active Ren’Py menus, including custom-named and single-item menus.
  * Added broader real-engine integration and live-demo acceptance coverage.

* **Bug Fixes**
  * Improved choice detection accuracy by excluding unrelated screen controls.
  * Locked editor labels no longer expose internal lock codes.

* **Documentation**
  * Updated setup, testing, Autopilot behavior, CI, and cloud environment documentation.

* **Tests**
  * Added validation for menu discovery, drag behavior, snapping, lock labels, crashes, and label coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->